### PR TITLE
Move realtime subscribers notification to separate module

### DIFF
--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -33,6 +33,7 @@ defmodule Realtime.Application do
         wal_position: {"0", "0"}, # You can provide a different WAL position if desired, or default to allowing Postgres to send you what it thinks you need
         publications: ["supabase_realtime"]
       },
+      Realtime.SubscribersNotification,
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/server/lib/realtime/replication.ex
+++ b/server/lib/realtime/replication.ex
@@ -36,6 +36,8 @@ defmodule Realtime.Replication do
     Type
   }
 
+  alias Realtime.SubscribersNotification
+
   def start_link(config) do
     GenServer.start_link(__MODULE__, config)
   end
@@ -196,54 +198,7 @@ defmodule Realtime.Replication do
     Keyword.get(config, :postgres_adapter, Realtime.Adapters.Postgres.EpgsqlImplementation)
   end
 
-  @doc """
-  Send events via Phoenix Channels
-  """
   defp notify_subscribers(%State{transaction: {_current_txn_lsn, txn}}) do
-    # For every change in the txn.changes, we want to broadcast it specific listeners
-    # Example Change:
-    # %Realtime.Adapters.Changes.UpdatedRecord{
-    #   columns: [
-    #     %Realtime.Decoder.Messages.Relation.Column{ flags: [:key], name: "id", type: "int8", type_modifier: 4294967295 },
-    #     %Realtime.Decoder.Messages.Relation.Column{ flags: [], name: "name", type: "text", type_modifier: 4294967295 }
-    #   ],
-    #   commit_timestamp: nil,
-    #   old_record: %{},
-    #   record: %{"id" => "2", "name" => "Jane Doe2"},
-    #   schema: "public",
-    #   table: "users",
-    #   type: "UPDATE"
-    # }
-    for raw_change <- txn.changes do
-
-      change = Map.put(raw_change, :commit_timestamp, txn.commit_timestamp)
-      # Logger.info inspect(change, pretty: true)
-
-      # Shout to anyone listening on the open realtime channel - e.g. "realtime:*"
-      topic = "realtime"
-      RealtimeWeb.RealtimeChannel.handle_realtime_transaction(topic <> ":*", change)
-
-      # Shout to specific schema - e.g. "realtime:public"
-      schema_topic = topic <> ":" <> change.schema
-      Logger.info inspect(schema_topic)
-      RealtimeWeb.RealtimeChannel.handle_realtime_transaction(schema_topic, change)
-
-      # Shout to specific table - e.g. "realtime:public:users"
-      table_topic = schema_topic <> ":" <> change.table
-      Logger.info inspect(table_topic)
-      RealtimeWeb.RealtimeChannel.handle_realtime_transaction(table_topic, change)
-
-      # Shout to specific columns - e.g. "realtime:public:users.id=eq.2"
-      Enum.each change.record, fn {k, v} ->
-        if v != nil do
-          eq = table_topic <> ":" <> k <> "=eq." <> v
-          Logger.info inspect(eq)
-          RealtimeWeb.RealtimeChannel.handle_realtime_transaction(eq, change)
-        end
-      end
-    end
-
-    # Event handled
-    {:noreply, :event_received}
+    SubscribersNotification.notify(txn)
   end
 end

--- a/server/lib/realtime/subscribers_notification.ex
+++ b/server/lib/realtime/subscribers_notification.ex
@@ -1,0 +1,71 @@
+defmodule Realtime.SubscribersNotification do
+  use GenServer
+  require Logger
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @doc """
+  Send notification events via Phoenix Channels to subscribers
+  """
+  def notify(txn) do
+    GenServer.call(__MODULE__, {:notify, txn})
+  end
+
+
+  @impl true
+  def init(nil) do
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_call({:notify, txn}, _from, nil) do
+    notify_subscribers(txn)
+    {:reply, :ok, nil}
+  end
+
+  defp notify_subscribers(txn) do
+    # For every change in the txn.changes, we want to broadcast it specific listeners
+    # Example Change:
+    # %Realtime.Adapters.Changes.UpdatedRecord{
+    #   columns: [
+    #     %Realtime.Decoder.Messages.Relation.Column{ flags: [:key], name: "id", type: "int8", type_modifier: 4294967295 },
+    #     %Realtime.Decoder.Messages.Relation.Column{ flags: [], name: "name", type: "text", type_modifier: 4294967295 }
+    #   ],
+    #   commit_timestamp: nil,
+    #   old_record: %{},
+    #   record: %{"id" => "2", "name" => "Jane Doe2"},
+    #   schema: "public",
+    #   table: "users",
+    #   type: "UPDATE"
+    # }
+    for raw_change <- txn.changes do
+      change = Map.put(raw_change, :commit_timestamp, txn.commit_timestamp)
+      # Logger.info inspect(change, pretty: true)
+
+      # Shout to anyone listening on the open realtime channel - e.g. "realtime:*"
+      topic = "realtime"
+      RealtimeWeb.RealtimeChannel.handle_realtime_transaction(topic <> ":*", change)
+
+      # Shout to specific schema - e.g. "realtime:public"
+      schema_topic = topic <> ":" <> change.schema
+      Logger.info inspect(schema_topic)
+      RealtimeWeb.RealtimeChannel.handle_realtime_transaction(schema_topic, change)
+
+      # Shout to specific table - e.g. "realtime:public:users"
+      table_topic = schema_topic <> ":" <> change.table
+      Logger.info inspect(table_topic)
+      RealtimeWeb.RealtimeChannel.handle_realtime_transaction(table_topic, change)
+
+      # Shout to specific columns - e.g. "realtime:public:users.id=eq.2"
+      Enum.each change.record, fn {k, v} ->
+        if v != nil do
+          eq = table_topic <> ":" <> k <> "=eq." <> v
+          Logger.info inspect(eq)
+          RealtimeWeb.RealtimeChannel.handle_realtime_transaction(eq, change)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is related to #33.

I moved the notification logic to a separate genserver that is a sibling of the replication genserver.