### PR TITLE
refactor: extract runtime config to releases.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Listens to changes in a PostgreSQL Database and broadcasts them over websockets.
 
 <p align="center"><kbd><img src="./examples/next-js/demo.gif" alt="Demo"/></kbd></p>
 
-
 **Contents**
+
 - [Status](#status)
 - [Example](#example)
 - [Introduction](#introduction)
-    - [What is this?](#what-is-this)
-    - [Cool, but why not just use Postgres' `NOTIFY`?](#cool-but-why-not-just-use-postgres-notify)
-    - [What are the benefits?](#what-are-the-benefits)
-    - [What can I build with this?](#what-can-i-build-with-this)
+  - [What is this?](#what-is-this)
+  - [Cool, but why not just use Postgres' `NOTIFY`?](#cool-but-why-not-just-use-postgres-notify)
+  - [What are the benefits?](#what-are-the-benefits)
+  - [What can I build with this?](#what-can-i-build-with-this)
 - [Quick start](#quick-start)
 - [Getting Started](#getting-started)
   - [Client](#client)
@@ -32,7 +32,6 @@ Listens to changes in a PostgreSQL Database and broadcasts them over websockets.
 This repo is still under heavy development and the documentation is evolving. You're welcome to try it, but expect some breaking changes. Watch "releases" of this repo to receive a notifification when we are ready for Beta. And give us a star if you like it!
 
 ![Watch this repo](https://gitcdn.xyz/repo/supabase/monorepo/master/web/static/watch-repo.gif "Watch this repo")
-
 
 ## Example
 
@@ -69,8 +68,8 @@ It works like this:
 
 1. the Phoenix server listens to PostgreSQL's replication functionality (using Postgres' logical decoding)
 2. it converts the byte stream into JSON
-3. it then broadcasts over websockets. 
-  
+3. it then broadcasts over websockets.
+
 #### Cool, but why not just use Postgres' `NOTIFY`?
 
 A few reasons:
@@ -81,7 +80,7 @@ A few reasons:
 
 #### What are the benefits?
 
-1. The beauty of listening to the replication functionality is that you can make changes to your database from anywhere - your API, directly in the DB, via a console etc - and you will still receive the changes via websockets. 
+1. The beauty of listening to the replication functionality is that you can make changes to your database from anywhere - your API, directly in the DB, via a console etc - and you will still receive the changes via websockets.
 2. Decoupling. For example, if you want to send a new slack message every time someone makes a new purchase you might build that funcitonality directly into your API. This allows you to decouple your async functionality from your API.
 3. This is built with Phoenix, an [extremely scalable Elixir framework](https://www.phoenixframework.org/blog/the-road-to-2-million-websocket-connections)
 
@@ -95,7 +94,7 @@ A few reasons:
 
 ## Quick start
 
-If you just want to start it up and see it in action: 
+If you just want to start it up and see it in action:
 
 1. Run `docker-compose up`
 2. Visit `http://localhost:3000` (be patient, node_modules will need to install)
@@ -116,7 +115,7 @@ Set up the socket
 import { Socket } = '@supabase/realtime-js'
 
 const REALTIME_URL = process.env.REALTIME_URL || 'http://localhost:4000'
-var socket = new Socket(REALTIME_URL) 
+var socket = new Socket(REALTIME_URL)
 socket.connect()
 ```
 
@@ -124,36 +123,44 @@ You can listen to these events on each table:
 
 ```js
 const EVENTS = {
-  EVERYTHING: '*',
-  INSERT: 'INSERT',
-  UPDATE: 'UPDATE',
-  DELETE: 'DELETE'
-}
+  EVERYTHING: "*",
+  INSERT: "INSERT",
+  UPDATE: "UPDATE",
+  DELETE: "DELETE",
+};
 ```
 
 Example 1: Listen to all INSERTS, on your `users` table
 
 ```js
-var allChanges = this.socket.channel('realtime:public:users')
+var allChanges = this.socket
+  .channel("realtime:public:users")
   .join()
-  .on(EVENTS.INSERT, payload => { console.log('Record inserted!', payload) })
+  .on(EVENTS.INSERT, (payload) => {
+    console.log("Record inserted!", payload);
+  });
 ```
 
 Example 2: Listen to all UPDATES in the `public` schema
 
 ```js
-var allChanges = this.socket.channel('realtime:public')
+var allChanges = this.socket
+  .channel("realtime:public")
   .join()
-  .on(EVENTS.UPDATE, payload => { console.log('Update received!', payload) })
-
+  .on(EVENTS.UPDATE, (payload) => {
+    console.log("Update received!", payload);
+  });
 ```
 
 Example 3: Listen to all INSERTS, UPDATES, and DELETES, in all schemas
 
 ```js
-let allChanges = this.socket.channel('realtime:*')
+let allChanges = this.socket
+  .channel("realtime:*")
   .join()
-  .on(EVENTS.EVERYTHING, payload => { console.log('Update received!', payload) })
+  .on(EVENTS.EVERYTHING, (payload) => {
+    console.log("Update received!", payload);
+  });
 ```
 
 ### Server
@@ -168,7 +175,6 @@ There are a some requirements for your database
    2. You must set `max_replication_slots` to at least 1: `ALTER SYSTEM SET max_replication_slots = 5;`
 3. Create a `PUBLICATION` for this server to listen to: `CREATE PUBLICATION supabase_realtime FOR ALL TABLES;`
 4. [OPTIONAL] If you want to recieve the old record (previous values) on UDPATE and DELETE, you can set the `REPLICA IDENTITY` to `FULL` like this: `ALTER TABLE your_table REPLICA IDENTITY FULL;`. This has to be set for each table unfortunately.
-
 
 ### Server set up
 
@@ -197,11 +203,19 @@ docker run \
 - Push your work back up to your fork
 - Submit a Pull request so that we can review your changes and merge
 
-## Releases
+## Releasing
 
-to trigger a release you must tag the commit, then push to origin
-```bash
+- Make a commit to bump the version in `mix.exs`
+- Tag the commit
+
+```sh
 git tag -a 7.x.x -m "some stuff about the release"
+```
+
+- Push the commit and the tag
+
+```sh
+git push
 git push origin 7.x.x
 ```
 
@@ -213,4 +227,4 @@ This repo is liscenced under Apache 2.0.
 
 - [https://github.com/phoenixframework/phoenix](https://github.com/phoenixframework/phoenix) - The server is built with the amazing elixir framework.
 - [https://github.com/cainophile/cainophile](https://github.com/cainophile/cainophile) - A lot of this implementation leveraged the work already done on Cainophile.
-- [https://github.com/mcampa/phoenix-channels](https://github.com/mcampa/phoenix-channels) - The client library is ported from this library. 
+- [https://github.com/mcampa/phoenix-channels](https://github.com/mcampa/phoenix-channels) - The client library is ported from this library.

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -1,28 +1,35 @@
 import Config
 
-app_port = System.get_env("PORT") || 4000
 app_hostname = System.get_env("HOSTNAME") || "localhost"
+app_port = System.get_env("PORT") || "4000"
+db_host = System.get_env("DB_HOST") || "localhost"
+db_port = System.get_env("DB_PORT") || "5432"
+db_name = System.get_env("DB_NAME") || "postgres"
 db_user = System.get_env("DB_USER") || "postgres"
 db_password = System.get_env("DB_PASSWORD") || "postgres"
-db_host = System.get_env("DB_HOST") || "localhost"
-db_port = System.get_env("DB_PORT") || 5432
-db_name = System.get_env("DB_NAME") || "postgres"
 db_ssl = System.get_env("DB_SSL") || true
+slot_name = System.get_env("SLOT_NAME") || :temporary
+configuration_file = System.get_env("CONFIGURATION_FILE")
+
+config :realtime,
+  app_hostname: app_hostname,
+  app_port: app_port,
+  db_host: db_host,
+  db_port: db_port,
+  db_name: db_name,
+  db_user: db_user,
+  db_password: db_password,
+  db_ssl: db_ssl,
+  slot_name: slot_name,
+  configuration_file: configuration_file
 
 secret_key_base =
   System.get_env("SECRET_KEY_BASE") ||
     raise """
     environment variable SECRET_KEY_BASE is missing.
-    You can generate one by calling:
-    export SECRET_KEY_BASE=`openssl rand -base64 48`
+    You can generate one by calling: mix phx.gen.secret
     """
 
 config :realtime, RealtimeWeb.Endpoint,
   http: [:inet6, port: String.to_integer(app_port)],
   secret_key_base: secret_key_base
-
-config :realtime,
-  app_port: app_port
-
-config :realtime,
-  app_hostname: app_hostname

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -1,14 +1,14 @@
 import Config
 
-app_hostname = System.get_env("HOSTNAME") || "localhost"
-app_port = System.get_env("PORT") || "4000"
-db_host = System.get_env("DB_HOST") || "localhost"
-db_port = System.get_env("DB_PORT") || "5432"
-db_name = System.get_env("DB_NAME") || "postgres"
-db_user = System.get_env("DB_USER") || "postgres"
-db_password = System.get_env("DB_PASSWORD") || "postgres"
-db_ssl = System.get_env("DB_SSL") || true
-slot_name = System.get_env("SLOT_NAME") || :temporary
+app_hostname = System.get_env("HOSTNAME")
+app_port = System.get_env("PORT")
+db_host = System.get_env("DB_HOST")
+db_port = System.get_env("DB_PORT")
+db_name = System.get_env("DB_NAME")
+db_user = System.get_env("DB_USER")
+db_password = System.get_env("DB_PASSWORD")
+db_ssl = System.get_env("DB_SSL")
+slot_name = System.get_env("SLOT_NAME")
 configuration_file = System.get_env("CONFIGURATION_FILE")
 
 config :realtime,

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -7,27 +7,27 @@ defmodule Realtime.Application do
   require Logger, warn: false
 
   def start(_type, _args) do
-
     # Hostname must be a char list for some reason
     # Use this var to convert to sigil at connection
-    host = System.get_env("DB_HOST") || 'localhost'
-    port = System.get_env("DB_PORT") || 5432
+    host = Application.fetch_env!(:realtime, :db_host)
+    port = Application.fetch_env!(:realtime, :db_port)
     # Use a named replication slot if you want realtime to pickup from where
     # it left after a restart because of, for example, a crash.
     # You can get a list of active replication slots with
     # `select * from pg_replication_slots`
-    slot_name = System.get_env("SLOT_NAME") || :temporary
+    slot_name = Application.fetch_env!(:realtime, :slot_name)
     {port_number, _} = :string.to_integer(to_charlist(port))
+
     epgsql_params = %{
       host: ~c(#{host}),
-      username: System.get_env("DB_USER") || "postgres",
-      database: System.get_env("DB_NAME") || "postgres",
-      password: System.get_env("DB_PASSWORD") || "postgres",
+      username: Application.fetch_env!(:realtime, :db_user),
+      database: Application.fetch_env!(:realtime, :db_name),
+      password: Application.fetch_env!(:realtime, :db_password),
       port: port_number,
-      ssl: System.get_env("DB_SSL") || true
+      ssl: Application.fetch_env!(:realtime, :db_ssl)
     }
 
-    configuration_file = System.get_env("CONFIGURATION_FILE")
+    configuration_file = Application.fetch_env!(:realtime, :configuration_file)
 
     # List all child processes to be supervised
     children = [
@@ -35,21 +35,22 @@ defmodule Realtime.Application do
       RealtimeWeb.Endpoint,
       {
         Realtime.Replication,
+        # You can provide a different WAL position if desired, or default to allowing Postgres to send you what it thinks you need
         epgsql: epgsql_params,
         slot: slot_name,
-        wal_position: {"0", "0"}, # You can provide a different WAL position if desired, or default to allowing Postgres to send you what it thinks you need
+        wal_position: {"0", "0"},
         publications: ["supabase_realtime"]
       },
       {
         Realtime.ConfigurationManager,
-        filename: configuration_file,
+        filename: configuration_file
       },
       Realtime.SubscribersNotification,
       {
         Realtime.Connectors,
-        config: nil,
+        config: nil
       },
-      Realtime.WebhookConnector,
+      Realtime.WebhookConnector
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -9,25 +9,25 @@ defmodule Realtime.Application do
   def start(_type, _args) do
     # Hostname must be a char list for some reason
     # Use this var to convert to sigil at connection
-    host = Application.fetch_env!(:realtime, :db_host)
-    port = Application.fetch_env!(:realtime, :db_port)
+    host = Application.get_env(:realtime, :db_host, "localhost")
+    port = Application.get_env(:realtime, :db_port, "5432")
     # Use a named replication slot if you want realtime to pickup from where
     # it left after a restart because of, for example, a crash.
     # You can get a list of active replication slots with
     # `select * from pg_replication_slots`
-    slot_name = Application.fetch_env!(:realtime, :slot_name)
+    slot_name = Application.get_env(:realtime, :slot_name, :temporary)
     {port_number, _} = :string.to_integer(to_charlist(port))
 
     epgsql_params = %{
       host: ~c(#{host}),
-      username: Application.fetch_env!(:realtime, :db_user),
-      database: Application.fetch_env!(:realtime, :db_name),
-      password: Application.fetch_env!(:realtime, :db_password),
+      username: Application.get_env(:realtime, :db_user, "postgres"),
+      database: Application.get_env(:realtime, :db_name, "postgres"),
+      password: Application.get_env(:realtime, :db_password, "postgres"),
       port: port_number,
-      ssl: Application.fetch_env!(:realtime, :db_ssl)
+      ssl: Application.get_env(:realtime, :db_ssl, true)
     }
 
-    configuration_file = Application.fetch_env!(:realtime, :configuration_file)
+    configuration_file = Application.get_env(:realtime, :configuration_file)
 
     # List all child processes to be supervised
     children = [


### PR DESCRIPTION
This will probably be affected by #48 in the future, but for now we should follow the recommended way to set runtime configs as explained [here](https://hexdocs.pm/mix/1.9.0/Mix.Tasks.Release.html#module-runtime-configuration).

Closes #31.