### PR TITLE
fix: incorrect env config handling

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -5,7 +5,21 @@
 # is restricted to this project.
 
 # General application configuration
-use Mix.Config
+import Config
+
+# These configs mirror the defaults in releases.exs, remember not to change one
+# without changing the other.
+config :realtime,
+  app_hostname: "localhost",
+  app_port: 4000,
+  db_host: "localhost",
+  db_port: 5432,
+  db_name: "postgres",
+  db_user: "postgres",
+  db_password: "postgres",
+  db_ssl: true,
+  slot_name: :temporary,
+  configuration_file: nil
 
 # Configures the endpoint
 config :realtime, RealtimeWeb.Endpoint,

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -1,14 +1,17 @@
 import Config
 
-app_hostname = System.get_env("HOSTNAME")
-app_port = System.get_env("PORT")
-db_host = System.get_env("DB_HOST")
-db_port = System.get_env("DB_PORT")
-db_name = System.get_env("DB_NAME")
-db_user = System.get_env("DB_USER")
-db_password = System.get_env("DB_PASSWORD")
-db_ssl = System.get_env("DB_SSL")
-slot_name = System.get_env("SLOT_NAME")
+# These defaults mirror the ones in config.exs, remember not to change one
+# without changing the other.
+app_hostname = System.get_env("HOSTNAME", "localhost")
+app_port = String.to_integer(System.get_env("PORT", "4000"))
+db_host = System.get_env("DB_HOST", "localhost")
+db_port = String.to_integer(System.get_env("DB_PORT", "5432"))
+db_name = System.get_env("DB_NAME", "postgres")
+db_user = System.get_env("DB_USER", "postgres")
+db_password = System.get_env("DB_PASSWORD", "postgres")
+# HACK: There's probably a better way to set boolean from env
+db_ssl = System.get_env("DB_SSL", "true") === "true"
+slot_name = String.to_atom(System.get_env("SLOT_NAME", "temporary"))
 configuration_file = System.get_env("CONFIGURATION_FILE")
 
 config :realtime,
@@ -31,5 +34,5 @@ secret_key_base =
     """
 
 config :realtime, RealtimeWeb.Endpoint,
-  http: [:inet6, port: String.to_integer(app_port)],
+  http: [:inet6, port: app_port],
   secret_key_base: secret_key_base

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -9,25 +9,23 @@ defmodule Realtime.Application do
   def start(_type, _args) do
     # Hostname must be a char list for some reason
     # Use this var to convert to sigil at connection
-    host = Application.get_env(:realtime, :db_host, "localhost")
-    port = Application.get_env(:realtime, :db_port, "5432")
+    host = Application.fetch_env!(:realtime, :db_host)
     # Use a named replication slot if you want realtime to pickup from where
     # it left after a restart because of, for example, a crash.
     # You can get a list of active replication slots with
     # `select * from pg_replication_slots`
-    slot_name = Application.get_env(:realtime, :slot_name, :temporary)
-    {port_number, _} = :string.to_integer(to_charlist(port))
+    slot_name = Application.get_env(:realtime, :slot_name)
 
     epgsql_params = %{
       host: ~c(#{host}),
-      username: Application.get_env(:realtime, :db_user, "postgres"),
-      database: Application.get_env(:realtime, :db_name, "postgres"),
-      password: Application.get_env(:realtime, :db_password, "postgres"),
-      port: port_number,
-      ssl: Application.get_env(:realtime, :db_ssl, true)
+      username: Application.fetch_env!(:realtime, :db_user),
+      database: Application.fetch_env!(:realtime, :db_name),
+      password: Application.fetch_env!(:realtime, :db_password),
+      port: Application.fetch_env!(:realtime, :db_port),
+      ssl: Application.fetch_env!(:realtime, :db_ssl)
     }
 
-    configuration_file = Application.get_env(:realtime, :configuration_file)
+    configuration_file = Application.fetch_env!(:realtime, :configuration_file)
 
     # List all child processes to be supervised
     children = [
@@ -35,7 +33,8 @@ defmodule Realtime.Application do
       RealtimeWeb.Endpoint,
       {
         Realtime.Replication,
-        # You can provide a different WAL position if desired, or default to allowing Postgres to send you what it thinks you need
+        # You can provide a different WAL position if desired, or default to
+        # allowing Postgres to send you what it thinks you need
         epgsql: epgsql_params,
         slot: slot_name,
         wal_position: {"0", "0"},


### PR DESCRIPTION
The config handling in #52 was incorrect, so this PR is to remedy that. Other changes I made:

- Moved the handling of unset envs to `config.exs` and `releases.exs`--this shouldn't be `application.ex`'s concern as default values can be set at build/release.
- It should now be possible to run the app with `mix phx.server` (without using mix releases). On the flip side, the configs in `config.exs` (used in `mix phx.server`) should mirror the defaults in `releases.exs` (used in `mix release`).