### PR TITLE
fix: converts the slot_name to lower case so that it matches Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ DB_NAME       # {string} Postgres database name
 DB_USER       # {string} Database user
 DB_PASSWORD   # {string} Database password
 DB_PORT       # {number} Database port
-SLOT_NAME     # {string} A unique name for Postgres to track where this server has "listened until". If the server dies, it can pick up from the last position.
+SLOT_NAME     # {string} A unique name for Postgres to track where this server has "listened until". If the server dies, it can pick up from the last position. This should be lowercase.
 PORT          # {number} Port which you can connect your client/listeners
 ```
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,23 @@
-# Realtime Elixir Instructions
+# Realtime server
+
+## Run locally
+
+```sh
+SECRET_KEY_BASE=SOMETHING_SECRET \
+PORT=4000 \
+HOSTNAME=localhost \
+DB_USER=postgres \
+DB_HOST=localhost \
+DB_PASSWORD=postgres \
+DB_NAME=postgres \
+DB_PORT=5432 \
+DB_PORT=5432 \
+SLOT_NAME=TEST_SLOT \
+mix phx.server
+```
+
+
+## Realtime Elixir Instructions
 
 Create the release:
 
@@ -26,6 +45,7 @@ DB_USER=postgres \
 DB_HOST=localhost \
 DB_PASSWORD=postgres \
 DB_NAME=postgres \
+DB_PORT=5432 \
 DB_PORT=5432 \
 _build/prod/rel/realtime/bin/realtime start
 ```

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -7,19 +7,31 @@
 # General application configuration
 import Config
 
-# These configs mirror the defaults in releases.exs, remember not to change one
+# These defaults mirror the ones in config.exs, remember not to change one
 # without changing the other.
+app_hostname = System.get_env("HOSTNAME", "localhost")
+app_port = String.to_integer(System.get_env("PORT", "4000"))
+db_host = System.get_env("DB_HOST", "localhost")
+db_port = String.to_integer(System.get_env("DB_PORT", "5432"))
+db_name = System.get_env("DB_NAME", "postgres")
+db_user = System.get_env("DB_USER", "postgres")
+db_password = System.get_env("DB_PASSWORD", "postgres")
+# HACK: There's probably a better way to set boolean from env
+db_ssl = System.get_env("DB_SSL", "true") === "true"
+slot_name = System.get_env("SLOT_NAME") || :temporary
+configuration_file = System.get_env("CONFIGURATION_FILE") || nil
+
 config :realtime,
-  app_hostname: "localhost",
-  app_port: 4000,
-  db_host: "localhost",
-  db_port: 5432,
-  db_name: "postgres",
-  db_user: "postgres",
-  db_password: "postgres",
-  db_ssl: true,
-  slot_name: :temporary,
-  configuration_file: nil
+  app_hostname: app_hostname,
+  app_port: app_port,
+  db_host: db_host,
+  db_port: db_port,
+  db_name: db_name,
+  db_user: db_user,
+  db_password: db_password,
+  db_ssl: db_ssl,
+  slot_name: slot_name,
+  configuration_file: configuration_file
 
 # Configures the endpoint
 config :realtime, RealtimeWeb.Endpoint,

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -10,8 +10,10 @@ defmodule Realtime.Application do
     # Hostname must be a char list for some reason
     # Use this var to convert to sigil at connection
     host = Application.fetch_env!(:realtime, :db_host)
+
     # Use a named replication slot if you want realtime to pickup from where
     # it left after a restart because of, for example, a crash.
+    # This will always be converted to lower-case.
     # You can get a list of active replication slots with
     # `select * from pg_replication_slots`
     slot_name = Application.get_env(:realtime, :slot_name)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #22 

## What is the current behavior?

The `SLOT_NAME` variable is getting converted to lowercase in Postgres, so when the server is trying to `SELECT` an existing slot it isn't matching correctly.

## What is the new behavior?

This converts the `SLOT_NAME` to lower case and adds instructions that it should always be lower case.

## Additional context

Long shot: this could possibly solve https://github.com/supabase/realtime/issues/61 if the disk usage is caused by connecting/reconnecting, causing Postgres to create a lot of different temporary slots.
