### PR TITLE
Support event filter

### DIFF
--- a/dev/postgres/mnt/init-permissions.sh
+++ b/dev/postgres/mnt/init-permissions.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-{ echo "host replication $POSTGRES_USER 0.0.0.0/0 trust"; } >> "$PGDATA/pg_hba.conf"

--- a/examples/next-js/pages/index.js
+++ b/examples/next-js/pages/index.js
@@ -19,18 +19,21 @@ export default class Index extends React.Component {
   componentDidMount() {
     this.socket.connect()
     this.addChannel('realtime:*')
+    this.addChannel('realtime:public')
     this.addChannel('realtime:public:todos')
     this.addChannel('realtime:public:users')
-    this.addChannel('realtime:public:users:id=eq.2')
+    this.addChannel('realtime:public:users:id=eq.16')
+    this.addChannel('realtime:public:users:id=eq.17')
+    this.addChannel('realtime:public:users:id=eq.18')
     this.fetchData()
   }
   addChannel(topic) {
     let channel = this.socket.channel(topic)
     channel.on('INSERT', msg => this.messageReceived(topic, msg))
-    // channel.on('*', msg => console.log('INSERT', msg))
-    // channel.on('INSERT', msg => console.log('INSERT', msg))
-    // channel.on('UPDATE', msg => console.log('UPDATE', msg))
-    // channel.on('DELETE', msg => console.log('DELETE', msg))
+    channel.on('*', msg => console.log('*', msg))
+    channel.on('INSERT', msg => console.log('INSERT', msg))
+    channel.on('UPDATE', msg => console.log('UPDATE', msg))
+    channel.on('DELETE', msg => console.log('DELETE', msg))
     channel
       .join()
       .receive('ok', () => console.log('Connecting'))

--- a/server/lib/realtime/configuration.ex
+++ b/server/lib/realtime/configuration.ex
@@ -1,15 +1,34 @@
 defmodule Realtime.Configuration do
   defmodule(WebhookEndpoint, do: defstruct([:endpoint]))
   defmodule(Webhook, do: defstruct([:event, :relation, :config]))
+  defmodule(Realtime, do: defstruct([:event, :relation]))
 
-  defmodule(Configuration, do: defstruct([:webhooks]))
+  defmodule(Configuration, do: defstruct([:webhooks, :realtime]))
 
   @doc """
   Load Configuration from a json file.
   """
   def from_json_file(nil) do
-    {:ok, %Configuration{webhooks: []}}
+    {:ok,
+     %Configuration{
+       webhooks: [],
+       realtime: [
+         %Realtime{
+           event: "*",
+           relation: "*"
+         },
+         %Realtime{
+           event: "*",
+           relation: "*:*"
+         },
+         %Realtime{
+           event: "*",
+           relation: "*:*:*"
+         }
+       ]
+     }}
   end
+
   def from_json_file(filename) do
     with {:ok, body} <- File.read(filename), do: from_json(body)
   end

--- a/server/lib/realtime/configuration.ex
+++ b/server/lib/realtime/configuration.ex
@@ -1,7 +1,7 @@
 defmodule Realtime.Configuration do
   defmodule(WebhookEndpoint, do: defstruct([:endpoint]))
   defmodule(Webhook, do: defstruct([:event, :relation, :config]))
-  defmodule(Realtime, do: defstruct([:event, :relation]))
+  defmodule(Realtime, do: defstruct([:events, :relation]))
 
   defmodule(Configuration, do: defstruct([:webhooks, :realtime]))
 
@@ -14,16 +14,16 @@ defmodule Realtime.Configuration do
        webhooks: [],
        realtime: [
          %Realtime{
-           event: "*",
-           relation: "*"
+           relation: "*",
+           events: ["INSERT", "UPDATE", "DELETE"]
          },
          %Realtime{
-           event: "*",
-           relation: "*:*"
+           relation: "*:*",
+           events: ["INSERT", "UPDATE", "DELETE"]
          },
          %Realtime{
-           event: "*",
-           relation: "*:*:*"
+           relation: "*:*:*",
+           events: ["INSERT", "UPDATE", "DELETE"]
          }
        ]
      }}
@@ -64,7 +64,7 @@ defmodule Realtime.Configuration do
     with {:ok, raw_endpoint} <- Map.fetch(config, "config"),
          {:ok, endpoint} <- to_webhook_endpoint_configuration(raw_endpoint)
     do
-      event = Map.get(config, "event", "*") # default to all events
+      event = Map.get(config, "events", "*") # default to all events
       relation = Map.get(config, "relation", "*") # default to all relations
       {:ok, %Webhook{event: event, relation: relation, config: endpoint}}
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

Closes #73.

## What is the new behavior?

Default config is:

```elixir
realtime: [
  %Realtime{
    event: "*",
    relation: "*"
  },
  %Realtime{
    event: "*",
    relation: "*:*"
  },
  %Realtime{
    event: "*",
    relation: "*:*:*"
  }
]
```

This allows all events to be broadcasted to all room types:
- `realtime:*`
- `realtime:<schema>`
- `realtime:<schema>:<table>`
- `realtime:<schema>:<table>:<column>`

## Additional context

I removed the leading `realtime:` for `relation` from our discussion. Looks cleaner imo, but let me know if you want to add it back.

One problem: there's no way to 1. allow events to `realtime:*`, and 2. allow events only for specific schemas, at the same time. This is because the relevant config `relation` is the same: `*`
