### PR TITLE
Set commit_timestamp value for every change record

### DIFF
--- a/server/lib/realtime/subscribers_notification.ex
+++ b/server/lib/realtime/subscribers_notification.ex
@@ -43,8 +43,7 @@ defmodule Realtime.SubscribersNotification do
 
     {:ok, realtime_config} = Realtime.ConfigurationManager.get_config(:realtime)
 
-    for raw_change <- txn.changes do
-      change = Map.put(raw_change, :commit_timestamp, txn.commit_timestamp)
+    for change <- txn.changes do
       topic = "realtime"
       schema_topic = "#{topic}:#{change.schema}"
       table_topic = "#{schema_topic}:#{change.table}"

--- a/server/test/realtime/replication_test.exs
+++ b/server/test/realtime/replication_test.exs
@@ -191,7 +191,7 @@ defmodule Realtime.ReplicationTest do
     end
   end
 
-  test "Realtime.DatabaseRetryMonitor.get_retry_delay/1 when conn_retry_delays is empty" do
+  test "Realtime.Replication.get_retry_delay/1 when conn_retry_delays is empty" do
     state = %State{
       conn_retry_delays: [],
       config: [
@@ -209,7 +209,7 @@ defmodule Realtime.ReplicationTest do
     assert Enum.all?(delays, &(is_integer(&1) and &1 > 0))
   end
 
-  test "Realtime.DatabaseRetryMonitor.get_retry_delay/1 when conn_retry_delays is not empty" do
+  test "Realtime.Replication.get_retry_delay/1 when conn_retry_delays is not empty" do
     state = %State{
       conn_retry_delays: [489, 1011, 1996, 4023]
     }
@@ -220,7 +220,7 @@ defmodule Realtime.ReplicationTest do
     assert delays == [1011, 1996, 4023]
   end
 
-  test "Realtime.DatabaseRetryMonitor.reset_retry_delay/1" do
+  test "Realtime.Replication.reset_retry_delay/1" do
     state = %State{
       conn_retry_delays: [198, 403, 781]
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Every webhook change record's commit_timestamp is set to null:

```
{
  "changes": [
    {
      "columns": [
        {
          "flags": [
            "key"
          ],
          "name": "id",
          "type": "int8",
          "type_modifier": 4294967295
        },
        {
          "flags": [],
          "name": "details",
          "type": "text",
          "type_modifier": 4294967295
        },
        {
          "flags": [],
          "name": "user_id",
          "type": "int8",
          "type_modifier": 4294967295
        }
      ],
      "commit_timestamp": null,
      "record": {
        "details": "If we generate the monitor, we can get to the SMS array through the online CSS circuit!",
        "id": "1",
        "user_id": "1"
      },
      "schema": "public",
      "table": "todos",
      "type": "INSERT"
    }
  ],
  "commit_timestamp": "2020-12-15T20:50:03Z"
}
```

## What is the new behavior?

Every webhook change record's commit_stamp is set to the transaction's commit_timestamp:

```
{
  "changes": [
    {
      "columns": [
        {
          "flags": [
            "key"
          ],
          "name": "id",
          "type": "int8",
          "type_modifier": 4294967295
        },
        {
          "flags": [],
          "name": "details",
          "type": "text",
          "type_modifier": 4294967295
        },
        {
          "flags": [],
          "name": "user_id",
          "type": "int8",
          "type_modifier": 4294967295
        }
      ],
      "commit_timestamp": "2020-12-15T21:31:16Z",
      "record": {
        "details": "asdfsdf",
        "id": "5",
        "user_id": "1"
      },
      "schema": "public",
      "table": "todos",
      "type": "INSERT"
    },
    {
      "columns": [
        {
          "flags": [
            "key"
          ],
          "name": "id",
          "type": "int8",
          "type_modifier": 4294967295
        },
        {
          "flags": [],
          "name": "details",
          "type": "text",
          "type_modifier": 4294967295
        },
        {
          "flags": [],
          "name": "user_id",
          "type": "int8",
          "type_modifier": 4294967295
        }
      ],
      "commit_timestamp": "2020-12-15T21:31:16Z",
      "record": {
        "details": "hahaha",
        "id": "6",
        "user_id": "1"
      },
      "schema": "public",
      "table": "todos",
      "type": "INSERT"
    }
  ],
  "commit_timestamp": "2020-12-15T21:31:16Z"
}
```

## Additional context
