### PR TITLE
Build arm64 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,119 +3,181 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - da/arm64
 
 jobs:
-  release:
-    name: Release
+  # release:
+  #   name: Release
 
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v2
+
+  #     - name: Get version before
+  #       run: echo VERSION_BEFORE=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+
+  #     - name: Release on GitHub
+  #       run: npx semantic-release -p        \
+  #         @semantic-release/commit-analyzer \
+  #         @semantic-release/github          \
+  #         @semantic-release/release-notes-generator
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Get version after
+  #       run: echo VERSION_AFTER=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+
+  #     - name: Check version difference
+  #       run: |
+  #         if [ ${{ env.VERSION_BEFORE }} = ${{ env.VERSION_AFTER }} ]; then
+  #           echo 0 > has-new-release
+  #         else
+  #           echo 1 > has-new-release
+  #         fi
+
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: has-new-release
+  #         path: has-new-release
+
+  # upload:
+  #   name: Upload / Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}
+
+  #   needs:
+  #     - release
+
+  #   strategy:
+  #     matrix:
+  #       elixir: ["1.10.x"]
+  #       otp: ["22.x"]
+
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: has-new-release
+
+  #     - name: Check for new release
+  #       run: echo HAS_NEW_RELEASE=$(cat has-new-release/has-new-release) >> $GITHUB_ENV
+
+  #     - uses: actions/checkout@v2
+  #       if: env.HAS_NEW_RELEASE == 1
+
+  #     - name: Cache Mix
+  #       if: env.HAS_NEW_RELEASE == 1
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: deps
+  #         key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-mix-
+
+  #     - name: Set up Elixir
+  #       if: env.HAS_NEW_RELEASE == 1
+  #       uses: actions/setup-elixir@v1
+  #       with:
+  #         elixir-version: ${{ matrix.elixir }}
+  #         otp-version: ${{ matrix.otp }}
+
+  #     - name: Get version
+  #       if: env.HAS_NEW_RELEASE == 1
+  #       run: echo VERSION=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+
+  #     - name: Prepare release
+  #       if: env.HAS_NEW_RELEASE == 1
+  #       run: |
+  #         cd server
+  #         mix deps.get
+  #         mix compile
+  #         mix release
+  #         tar -czf ../realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz -C ./_build/prod/rel realtime
+  #       env:
+  #         MIX_ENV: prod
+
+  #     - name: Get upload url
+  #       if: env.HAS_NEW_RELEASE == 1
+  #       run: echo UPLOAD_URL=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .upload_url -r) >> $GITHUB_ENV
+
+  #     - name: Upload release asset
+  #       if: env.HAS_NEW_RELEASE == 1
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ env.UPLOAD_URL }}
+  #         asset_path: ./realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz
+  #         asset_name: realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz
+  #         asset_content_type: application/gzip
+
+  # upload-docker-image:
+  #   name: Upload Docker image
+
+  #   needs:
+  #     - release
+
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: has-new-release
+
+  #     - name: Check for new release
+  #       run: echo HAS_NEW_RELEASE=$(cat has-new-release/has-new-release) >> $GITHUB_ENV
+
+  #     - uses: actions/checkout@v2
+  #       if: env.HAS_NEW_RELEASE == 1
+
+  #     - name: Get version
+  #       if: env.HAS_NEW_RELEASE == 1
+  #       run: echo VERSION=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+
+  #     - name: Upload build to Docker Hub
+  #       if: env.HAS_NEW_RELEASE == 1
+  #       uses: docker/build-push-action@v1
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+  #         repository: supabase/realtime
+  #         tags: latest,${{ env.VERSION }}
+
+  build-arm64-binary:
+    name: Build and upload arm64 binaries
+    # needs:
+    #   - release
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Get version before
-        run: echo VERSION_BEFORE=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
-
-      - name: Release on GitHub
-        run: npx semantic-release -p        \
-          @semantic-release/commit-analyzer \
-          @semantic-release/github          \
-          @semantic-release/release-notes-generator
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get version after
-        run: echo VERSION_AFTER=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
-
-      - name: Check version difference
-        run: |
-          if [ ${{ env.VERSION_BEFORE }} = ${{ env.VERSION_AFTER }} ]; then
-            echo 0 > has-new-release
-          else
-            echo 1 > has-new-release
-          fi
-
-      - uses: actions/upload-artifact@v1
-        with:
-          name: has-new-release
-          path: has-new-release
-
-  upload:
-    name: Upload / Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}
-
-    needs:
-      - release
-
-    strategy:
-      matrix:
-        elixir: ["1.10.x"]
-        otp: ["22.x"]
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: has-new-release
-
-      - name: Check for new release
-        run: echo HAS_NEW_RELEASE=$(cat has-new-release/has-new-release) >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
-        if: env.HAS_NEW_RELEASE == 1
-
-      - name: Cache Mix
-        if: env.HAS_NEW_RELEASE == 1
-        uses: actions/cache@v1
-        with:
-          path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-mix-
-
-      - name: Set up Elixir
-        if: env.HAS_NEW_RELEASE == 1
-        uses: actions/setup-elixir@v1
-        with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
 
       - name: Get version
-        if: env.HAS_NEW_RELEASE == 1
-        run: echo VERSION=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+        run: echo VERSION=testing >> $GITHUB_ENV
 
-      - name: Prepare release
-        if: env.HAS_NEW_RELEASE == 1
-        run: |
-          cd server
-          mix deps.get
-          mix compile
-          mix release
-          tar -czf ../realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz -C ./_build/prod/rel realtime
-        env:
-          MIX_ENV: prod
-
-      - name: Get upload url
-        if: env.HAS_NEW_RELEASE == 1
-        run: echo UPLOAD_URL=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .upload_url -r) >> $GITHUB_ENV
-
-      - name: Upload release asset
-        if: env.HAS_NEW_RELEASE == 1
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Build realtime for aarch64
+        id: runcmd
         with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz
-          asset_name: realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz
-          asset_content_type: application/gzip
+          arch: aarch64
+          distro: ubuntu18.04
 
-      - name: Upload build to Docker Hub
-        if: env.HAS_NEW_RELEASE == 1
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: supabase/realtime
-          tags: latest,${{ env.VERSION }}
+          run: |
+            export DEBIAN_FRONTEND=noninteractive
+            export MIX_ENV=prod
+            export LANG=C.UTF-8
+
+            apt-get update
+            apt-get -y install --no-install-recommends wget gnupg ca-certificates
+            wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb
+            dpkg -i erlang-solutions_2.0_all.deb
+            apt-get update
+            apt-get -y install --no-install-recommends esl-erlang=1:22.3.4.9-1 elixir=1.10.4-1
+
+            cd server
+            mix local.hex --force
+            mix local.rebar --force
+            mix deps.get
+            mix deps.compile
+            mix release
+            tar -czf ../realtime-${{ env.VERSION }}-aarch64-linux-gnu.tar.gz -C ./_build/prod/rel realtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,159 +3,164 @@ name: Release
 on:
   push:
     branches:
-      - da/arm64
+      - master
 
 jobs:
-  # release:
-  #   name: Release
+  release:
+    name: Release
 
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/checkout@v2
-
-  #     - name: Get version before
-  #       run: echo VERSION_BEFORE=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
-
-  #     - name: Release on GitHub
-  #       run: npx semantic-release -p        \
-  #         @semantic-release/commit-analyzer \
-  #         @semantic-release/github          \
-  #         @semantic-release/release-notes-generator
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Get version after
-  #       run: echo VERSION_AFTER=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
-
-  #     - name: Check version difference
-  #       run: |
-  #         if [ ${{ env.VERSION_BEFORE }} = ${{ env.VERSION_AFTER }} ]; then
-  #           echo 0 > has-new-release
-  #         else
-  #           echo 1 > has-new-release
-  #         fi
-
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: has-new-release
-  #         path: has-new-release
-
-  # upload:
-  #   name: Upload / Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}
-
-  #   needs:
-  #     - release
-
-  #   strategy:
-  #     matrix:
-  #       elixir: ["1.10.x"]
-  #       otp: ["22.x"]
-
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: has-new-release
-
-  #     - name: Check for new release
-  #       run: echo HAS_NEW_RELEASE=$(cat has-new-release/has-new-release) >> $GITHUB_ENV
-
-  #     - uses: actions/checkout@v2
-  #       if: env.HAS_NEW_RELEASE == 1
-
-  #     - name: Cache Mix
-  #       if: env.HAS_NEW_RELEASE == 1
-  #       uses: actions/cache@v1
-  #       with:
-  #         path: deps
-  #         key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-mix-
-
-  #     - name: Set up Elixir
-  #       if: env.HAS_NEW_RELEASE == 1
-  #       uses: actions/setup-elixir@v1
-  #       with:
-  #         elixir-version: ${{ matrix.elixir }}
-  #         otp-version: ${{ matrix.otp }}
-
-  #     - name: Get version
-  #       if: env.HAS_NEW_RELEASE == 1
-  #       run: echo VERSION=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
-
-  #     - name: Prepare release
-  #       if: env.HAS_NEW_RELEASE == 1
-  #       run: |
-  #         cd server
-  #         mix deps.get
-  #         mix compile
-  #         mix release
-  #         tar -czf ../realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz -C ./_build/prod/rel realtime
-  #       env:
-  #         MIX_ENV: prod
-
-  #     - name: Get upload url
-  #       if: env.HAS_NEW_RELEASE == 1
-  #       run: echo UPLOAD_URL=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .upload_url -r) >> $GITHUB_ENV
-
-  #     - name: Upload release asset
-  #       if: env.HAS_NEW_RELEASE == 1
-  #       uses: actions/upload-release-asset@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         upload_url: ${{ env.UPLOAD_URL }}
-  #         asset_path: ./realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz
-  #         asset_name: realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz
-  #         asset_content_type: application/gzip
-
-  # upload-docker-image:
-  #   name: Upload Docker image
-
-  #   needs:
-  #     - release
-
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: has-new-release
-
-  #     - name: Check for new release
-  #       run: echo HAS_NEW_RELEASE=$(cat has-new-release/has-new-release) >> $GITHUB_ENV
-
-  #     - uses: actions/checkout@v2
-  #       if: env.HAS_NEW_RELEASE == 1
-
-  #     - name: Get version
-  #       if: env.HAS_NEW_RELEASE == 1
-  #       run: echo VERSION=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
-
-  #     - name: Upload build to Docker Hub
-  #       if: env.HAS_NEW_RELEASE == 1
-  #       uses: docker/build-push-action@v1
-  #       with:
-  #         username: ${{ secrets.DOCKER_USERNAME }}
-  #         password: ${{ secrets.DOCKER_PASSWORD }}
-  #         repository: supabase/realtime
-  #         tags: latest,${{ env.VERSION }}
-
-  build-arm64-binary:
-    name: Build and upload arm64 binaries
-    # needs:
-    #   - release
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get version before
+        run: echo VERSION_BEFORE=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+
+      - name: Release on GitHub
+        run: npx semantic-release -p        \
+          @semantic-release/commit-analyzer \
+          @semantic-release/github          \
+          @semantic-release/release-notes-generator
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get version after
+        run: echo VERSION_AFTER=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+
+      - name: Check version difference
+        run: |
+          if [ ${{ env.VERSION_BEFORE }} = ${{ env.VERSION_AFTER }} ]; then
+            echo 0 > has-new-release
+          else
+            echo 1 > has-new-release
+          fi
+
+      - uses: actions/upload-artifact@v1
+        with:
+          name: has-new-release
+          path: has-new-release
+
+  upload:
+    name: Upload / Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}
+
+    needs:
+      - release
+
+    strategy:
+      matrix:
+        elixir: ["1.10.x"]
+        otp: ["22.x"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: has-new-release
+
+      - name: Check for new release
+        run: echo HAS_NEW_RELEASE=$(cat has-new-release/has-new-release) >> $GITHUB_ENV
+
+      - uses: actions/checkout@v2
+        if: env.HAS_NEW_RELEASE == 1
+
+      - name: Cache Mix
+        if: env.HAS_NEW_RELEASE == 1
+        uses: actions/cache@v1
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Set up Elixir
+        if: env.HAS_NEW_RELEASE == 1
+        uses: actions/setup-elixir@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+
       - name: Get version
-        run: echo VERSION=testing >> $GITHUB_ENV
+        if: env.HAS_NEW_RELEASE == 1
+        run: echo VERSION=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+
+      - name: Prepare release
+        if: env.HAS_NEW_RELEASE == 1
+        run: |
+          cd server
+          mix deps.get
+          mix compile
+          mix release
+          tar -czf ../realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz -C ./_build/prod/rel realtime
+        env:
+          MIX_ENV: prod
+
+      - name: Get upload url
+        if: env.HAS_NEW_RELEASE == 1
+        run: echo UPLOAD_URL=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .upload_url -r) >> $GITHUB_ENV
+
+      - name: Upload release asset
+        if: env.HAS_NEW_RELEASE == 1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz
+          asset_name: realtime-${{ env.VERSION }}-x86_64-linux-gnu.tar.gz
+          asset_content_type: application/gzip
+
+  upload-docker-image:
+    name: Upload Docker image
+
+    needs:
+      - release
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: has-new-release
+
+      - name: Check for new release
+        run: echo HAS_NEW_RELEASE=$(cat has-new-release/has-new-release) >> $GITHUB_ENV
+
+      - uses: actions/checkout@v2
+        if: env.HAS_NEW_RELEASE == 1
+
+      - name: Get version
+        if: env.HAS_NEW_RELEASE == 1
+        run: echo VERSION=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
+
+      - name: Upload build to Docker Hub
+        if: env.HAS_NEW_RELEASE == 1
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: supabase/realtime
+          tags: latest,${{ env.VERSION }}
+
+  build-arm64-binary:
+    name: Build and upload arm64 binaries
+    needs:
+      - release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check for new release
+        run: echo HAS_NEW_RELEASE=$(cat has-new-release/has-new-release) >> $GITHUB_ENV
+
+      - name: Get version
+        if: env.HAS_NEW_RELEASE == 1
+        run: echo VERSION=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .name -r) >> $GITHUB_ENV
 
       - uses: uraimo/run-on-arch-action@v2.0.5
+        if: env.HAS_NEW_RELEASE == 1
         name: Build realtime for aarch64
         id: runcmd
         with:
@@ -181,3 +186,18 @@ jobs:
             mix deps.compile
             mix release
             tar -czf ../realtime-${{ env.VERSION }}-aarch64-linux-gnu.tar.gz -C ./_build/prod/rel realtime
+
+      - name: Get upload url
+        if: env.HAS_NEW_RELEASE == 1
+        run: echo UPLOAD_URL=$(curl -s https://api.github.com/repos/supabase/realtime/releases/latest | jq .upload_url -r) >> $GITHUB_ENV
+
+      - name: Upload release asset
+        if: env.HAS_NEW_RELEASE == 1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./realtime-${{ env.VERSION }}-aarch64-linux-gnu.tar.gz
+          asset_name: realtime-${{ env.VERSION }}-aarch64-linux-gnu.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         elixir: ["1.10.x"]
         otp: ["22.x"]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/download-artifact@v1


### PR DESCRIPTION
# Changes introduced

- Breaks out build jobs into separate github jobs to allow for parallel execution, given there are no inter-dependencies
- Adds a new arm64 docker build
- Pins the OS for the native x86 build to u18 (from ubuntu-latest), which I _believe_ will imminently break once u-latest moves to u20 https://github.com/actions/virtual-environments/issues/1816

The arm64 docker build is only executed on releases, so the increased CI times shouldn't present a significant overhead for iterating on PRs. Additionally, an extremely straightforward speed-up would be to publish a base docker image with the appropriate OTP/elixir versions installed on the u18 base.

Note that unlike our other services, were publishing a separate tarball for arm64 here, rather than a single tarball with two binaries.

Fixes #86 

## Testing performed

On a graviton instance, connecting against a local test database, the service came up w/o any issues. However, I haven't performed any testing of the actual functioning of the service beyond that.

```
ubuntu@ip-172-31-39-228:~/realtime$ uname -a
Linux ip-172-31-39-228 5.4.0-1029-aws #30~18.04.1-Ubuntu SMP Tue Oct 20 11:08:38 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
ubuntu@ip-172-31-39-228:~/realtime$ ./bin/realtime start
2020-12-16 02:30:00.342 [info] Running RealtimeWeb.Endpoint with cowboy 2.6.3 at :::4000 (http)
2020-12-16 02:30:00.343 [info] Access RealtimeWeb.Endpoint at http://localhost:4000
```