### PR TITLE
fix: handle TRUNCATE events

### DIFF
--- a/server/lib/realtime/configuration.ex
+++ b/server/lib/realtime/configuration.ex
@@ -9,7 +9,7 @@ defmodule Realtime.Configuration do
 
   defmodule(Configuration, do: defstruct(webhooks: [], realtime: []))
 
-  @events ["INSERT", "UPDATE", "DELETE"]
+  @events ["INSERT", "UPDATE", "DELETE", "TRUNCATE"]
 
   @doc """
 

--- a/server/lib/realtime/subscribers_notification.ex
+++ b/server/lib/realtime/subscribers_notification.ex
@@ -49,7 +49,7 @@ defmodule Realtime.SubscribersNotification do
       table_topic = "#{schema_topic}:#{change.table}"
       # Logger.debug inspect(change, pretty: true)
 
-      # Get only the config which includes this event type (INSERT | UPDATE | DELETE)
+      # Get only the config which includes this event type (INSERT | UPDATE | DELETE | TRUNCATE)
       event_config =
         Enum.filter(realtime_config, fn config ->
           change.type in config.events
@@ -95,6 +95,9 @@ defmodule Realtime.SubscribersNotification do
               end
             end)
           end
+
+        "TRUNCATE" ->
+          nil
       end
     end
   end

--- a/server/test/realtime/configuration_test.exs
+++ b/server/test/realtime/configuration_test.exs
@@ -12,15 +12,15 @@ defmodule Realtime.ConfigurationTest do
              realtime: [
                %Realtime{
                  relation: "*",
-                 events: ["INSERT", "UPDATE", "DELETE"]
+                 events: ["INSERT", "UPDATE", "DELETE", "TRUNCATE"]
                },
                %Realtime{
                  relation: "*:*",
-                 events: ["INSERT", "UPDATE", "DELETE"]
+                 events: ["INSERT", "UPDATE", "DELETE", "TRUNCATE"]
                },
                %Realtime{
                  relation: "*:*:*",
-                 events: ["INSERT", "UPDATE", "DELETE"]
+                 events: ["INSERT", "UPDATE", "DELETE", "TRUNCATE"]
                }
              ]
            }

--- a/server/test/realtime_web/channels/realtime_channel_test.exs
+++ b/server/test/realtime_web/channels/realtime_channel_test.exs
@@ -43,4 +43,15 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     assert_push("DELETE", change)
   end
 
+  test "TRUNCATEs are broadcasted to the client", %{socket: socket} do
+    change = %{
+      schema: "public",
+      table: "users",
+      type: "TRUNCATE"
+    }
+
+    RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
+    assert_push("*", change)
+    assert_push("TRUNCATE", change)
+  end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

[This code](https://github.com/supabase/realtime/blob/1220728423ed012ca9dfcd18e79188e4bb96e1fe/server/lib/realtime/subscribers_notification.ex#L74-L98) is not happy when it receives a `TRUNCATE` event. `TRUNCATE` events are not broadcasted.

## What is the new behavior?

`TRUNCATE` events are broadcasted (added the event type in the default config). Event filters are applied (schema and table only). A `TRUNCATE` event looks like this on the client:

```json
{
  "commit_timestamp": "2021-01-06T17:26:35Z",
  "schema": "public",
  "table": "bar",
  "type": "TRUNCATE"
}
```

## Additional context

Re: the discussion on Slack: turns out I was wrong, the decoder + adapter handles `TRUNCATE` in a way that also gives schema and table information. The resulting `TruncatedRelation` is what's received in `SubscribersNotification`.
