### PR TITLE
fix: replication fails to trap on :init_db_conn

### DIFF
--- a/server/test/realtime/replication_test.exs
+++ b/server/test/realtime/replication_test.exs
@@ -77,8 +77,18 @@ defmodule Realtime.ReplicationTest do
       init: fn _ ->
         {:error, {:error, :econnrefused}}
       end do
-      assert {:stop, {:error, :econnrefused}} =
-               Realtime.Replication.handle_continue(:init_db_conn, @test_state)
+      assert {
+               :noreply,
+               %State{
+                 config: @test_config,
+                 conn_retry_delays: [_ | _],
+                 connection: nil,
+                 relations: %{},
+                 subscribers: [],
+                 transaction: nil,
+                 types: %{}
+               }
+             } = Realtime.Replication.handle_continue(:init_db_conn, @test_state)
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When the application fails to connect to the DB at start up (`:econnrefused`), it crashes. This is because `handle_continue/2` returns a `:stop` instead of falling back to the `:EXIT` trap.

## What is the new behavior?

Failing to connect during `init` will run the retry logic instead of crashing.

@w3b6x9 would love to hear your input here. Is this the right behavior?