### PR TITLE
Add Truncate option 3 and add commit_timestamp to all DB Changes

### DIFF
--- a/server/lib/decoder/decoder.ex
+++ b/server/lib/decoder/decoder.ex
@@ -94,7 +94,6 @@ defmodule Realtime.Decoder do
   end
 
   defp decode_message_impl(<<"R", id::integer-32, rest::binary>>) do
-    
     [
       namespace
       | [name | [<<replica_identity::binary-1, _number_of_columns::integer-16, columns::binary>>]]
@@ -190,6 +189,7 @@ defmodule Realtime.Decoder do
         0 -> []
         1 -> [:cascade]
         2 -> [:restart_identity]
+        3 -> [:cascade, :restart_identity]
       end
 
     %Truncate{

--- a/server/test/decoder/decoder_test.exs
+++ b/server/test/decoder/decoder_test.exs
@@ -91,7 +91,7 @@ defmodule Realtime.DecoderTest do
                    type: "numeric",
                    type_modifier: 4_294_967_295
                  }
-               ],
+               ]
              }
   end
 
@@ -131,6 +131,15 @@ defmodule Realtime.DecoderTest do
                %Truncate{
                  number_of_relations: 1,
                  options: [:restart_identity],
+                 truncated_relations: [24576]
+               }
+    end
+
+    test "decodes messages with cascade and restart identity options" do
+      assert Realtime.Decoder.decode_message(<<84, 0, 0, 0, 1, 3, 0, 0, 96, 0>>) ==
+               %Truncate{
+                 number_of_relations: 1,
+                 options: [:cascade, :restart_identity],
                  truncated_relations: [24576]
                }
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Selecting Cascade and Restart Identity when truncating data from table results in the following error: `(CaseClauseError) no case clause matching: 3`

Addresses issue #102. 

## What is the new behavior?

Selecting Cascade and Restart Identity when truncating data from table doesn't raise error and everything works as expected.

## Additional context

- Tested to make sure both realtime channel and webhook messages contained the right commit timestamps.
- `%Truncate{}` options (e.g. `2 -> [:restart_identity]`) aren't used anywhere else so we can consider removing altogether.
- I did some refactoring while making sure that all the Changes (i.e. `NewRecord`, `UpdatedRecord`, `DeletedRecord`, `TruncatedRelation`) had `commit_timestamp`s during creation.