### PR TITLE
fix: enable recovery when publication is dropped

### DIFF
--- a/server/lib/adapters/postgres/adapter_behavior.ex
+++ b/server/lib/adapters/postgres/adapter_behavior.ex
@@ -2,7 +2,7 @@
 # License: https://github.com/cainophile/cainophile/blob/master/LICENSE
 defmodule Realtime.Adapters.Postgres.AdapterBehaviour do
   @callback init(config :: term) ::
-              {:ok, %Realtime.Replication.State{}} | {:stop, reason :: binary}
+              {:ok, pid()} | {:error, reason :: binary()}
 
   @callback acknowledge_lsn(connection :: pid, {xlog :: integer, offset :: integer}) :: :ok
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After dropping publication, the `realtime` server immediately retries. After creating a new publication, the server is unable to recover.

## What is the new behavior?

After dropping publication, the `realtime` server retries with backoff and jitter. Existing replication slot is dropped. When publication is created, the server now recovers and creates a new replication slot.

## Additional context

This is still WIP as I need to continue testing different edge cases. The way this fix works is:

1. Server recognizes that publication has been dropped. Retries with backoff and jitter, which will prevent spikes in CPU usage.
2. Server drops replication slot. If replication slot fails to be dropped, then server will continue retrying.
3. When server has successfully dropped replication slot, it will check if a new publication has been created.
4. When new publication has been created, then server will create a replication slot and start replication.
