### PR TITLE
feat: change socket param from token to apikey

### DIFF
--- a/server/lib/realtime_web/channels/user_socket.ex
+++ b/server/lib/realtime_web/channels/user_socket.ex
@@ -38,6 +38,15 @@ defmodule RealtimeWeb.UserSocket do
   def id(_socket), do: nil
 
   defp authorize_conn(true, %{"token" => token}) do
+    # WARNING: "token" param key will be deprecated.
+    # Please use "apikey" param key to pass in auth token.
+    case ChannelsAuthorization.authorize(token) do
+      {:ok, _} -> :ok
+      _ -> :error
+    end
+  end
+
+  defp authorize_conn(true, %{"apikey" => token}) do
     case ChannelsAuthorization.authorize(token) do
       {:ok, _} -> :ok
       _ -> :error

--- a/server/test/realtime_web/channels/user_socket_test.exs
+++ b/server/test/realtime_web/channels/user_socket_test.exs
@@ -16,8 +16,12 @@ defmodule RealtimeWeb.UserSocketTest do
     with_mock ChannelsAuthorization, authorize: fn _token -> {:ok, %{}} end do
       Application.put_env(:realtime, :secure_channels, true)
 
+      # WARNING: "token" param key will be deprecated.
       assert {:ok, %Socket{}} =
                UserSocket.connect(%{"token" => "auth_token123"}, socket(UserSocket))
+
+      assert {:ok, %Socket{}} =
+               UserSocket.connect(%{"apikey" => "auth_token123"}, socket(UserSocket))
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

socket param auth token key is 'token'

## What is the new behavior?

socket param auth token key is 'apikey'

## Additional context

Related issue: #95 
