### PR TITLE
feat: remove all (*) event broadcasting

### DIFF
--- a/server/lib/realtime_web/channels/realtime_channel.ex
+++ b/server/lib/realtime_web/channels/realtime_channel.ex
@@ -19,7 +19,6 @@ defmodule RealtimeWeb.RealtimeChannel do
   Handles a full, decoded transation.
   """
   def handle_realtime_transaction(topic, txn) do
-    RealtimeWeb.Endpoint.broadcast_from!(self(), topic, "*", txn)
     RealtimeWeb.Endpoint.broadcast_from!(self(), topic, txn.type, txn)
   end
 end

--- a/server/test/realtime_web/channels/realtime_channel_test.exs
+++ b/server/test/realtime_web/channels/realtime_channel_test.exs
@@ -10,7 +10,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     {:ok, socket: socket}
   end
 
-  test "INSERTS are broadcasts to the client" do
+  test "INSERT message is pushed to the client" do
     change = %{
       schema: "public",
       table: "users",
@@ -18,23 +18,23 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     }
 
     RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
-    assert_push("*", change)
+
     assert_push("INSERT", change)
   end
 
-  test "UPDATES are broadcasts to the client" do
+  test "UPDATE message is pushed to the client" do
     change = %{
       schema: "public",
       table: "users",
-      type: "UPDATES"
+      type: "UPDATE"
     }
 
     RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
-    assert_push("*", change)
-    assert_push("UPDATES", change)
+
+    assert_push("UPDATE", change)
   end
 
-  test "DELETES are broadcasts to the client" do
+  test "DELETE message is pushed to the client" do
     change = %{
       schema: "public",
       table: "users",
@@ -42,19 +42,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     }
 
     RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
-    assert_push("*", change)
+
     assert_push("DELETE", change)
-  end
-
-  test "TRUNCATEs are broadcasted to the client" do
-    change = %{
-      schema: "public",
-      table: "users",
-      type: "TRUNCATE"
-    }
-
-    RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
-    assert_push("*", change)
-    assert_push("TRUNCATE", change)
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Txn change is broadcast to both * and specific type (INSERT/UPDATE/DELETE)

## What is the new behavior?

Txn change is broadcast only specific type (INSERT/UPDATE/DELETE)

## Additional context

- Related PR: https://github.com/supabase/realtime-js/pull/75
- `realtime-js` v1.0.7 was version bumped in `supabase-js` via this commit: https://github.com/supabase/supabase-js/commit/22a9c030b4fef6395e69efaa21b4baba693cf05f