### PR TITLE
Reduce memory usage by broadcasting binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,18 +127,18 @@ docker run \
 **OPTIONS**
 
 ```sh
-DB_HOST                 # {string}      Database host URL
-DB_NAME                 # {string}      Postgres database name
-DB_USER                 # {string}      Database user
-DB_PASSWORD             # {string}      Database password
-DB_PORT                 # {number}      Database port
-DB_IP_VERSION           # {string}      (options: 'IPv4'/'IPv6') Connect to database via either IPv4 or IPv6. Disregarded if database host is an IP address (e.g. '127.0.0.1') and recommended if database host is a name (e.g. 'db.abcd.supabase.co') to prevent potential non-existent domain (NXDOMAIN) errors.
-SLOT_NAME               # {string}      A unique name for Postgres to track where this server has "listened until". If the server dies, it can pick up from the last position. This should be lowercase.
-PORT                    # {number}      Port which you can connect your client/listeners
-SECURE_CHANNELS         # {string}      (options: 'true'/'false') Enable/Disable channels authorization via JWT verification.
-JWT_SECRET              # {string}      HS algorithm octet key (e.g. "95x0oR8jq9unl9pOIx"). Only required if SECURE_CHANNELS is set to true.
-JWT_CLAIM_VALIDATORS    # {string}      Expected claim key/value pairs compared to JWT claims via equality checks in order to validate JWT. e.g. '{"iss": "Issuer", "nbf": 1610078130}'. This is optional but encouraged.
-SOCKET_TIMEOUT          # {number/string}    Set websocket timeout value to a larger number, in milliseconds, or "infinity" when consistently processing large transactions and/or high volume of transactions. Defaults to 60000 (milliseconds).
+DB_HOST                 # {string}           Database host URL
+DB_NAME                 # {string}           Postgres database name
+DB_USER                 # {string}           Database user
+DB_PASSWORD             # {string}           Database password
+DB_PORT                 # {number}           Database port
+DB_IP_VERSION           # {string}           (options: 'IPv4'/'IPv6') Connect to database via either IPv4 or IPv6. Disregarded if database host is an IP address (e.g. '127.0.0.1') and recommended if database host is a name (e.g. 'db.abcd.supabase.co') to prevent potential non-existent domain (NXDOMAIN) errors.
+SLOT_NAME               # {string}           A unique name for Postgres to track where this server has "listened until". If the server dies, it can pick up from the last position. This should be lowercase.
+PORT                    # {number}           Port which you can connect your client/listeners
+SECURE_CHANNELS         # {string}           (options: 'true'/'false') Enable/Disable channels authorization via JWT verification.
+JWT_SECRET              # {string}           HS algorithm octet key (e.g. "95x0oR8jq9unl9pOIx"). Only required if SECURE_CHANNELS is set to true.
+JWT_CLAIM_VALIDATORS    # {string}           Expected claim key/value pairs compared to JWT claims via equality checks in order to validate JWT. e.g. '{"iss": "Issuer", "nbf": 1610078130}'. This is optional but encouraged.
+SOCKET_TIMEOUT          # {number/string}    Phoenix Channel transport process will finish broadcasting messages in its mailbox and be killed if no heartbeat message is received from client after SOCKET_TIMEOUT time has lapsed. Set websocket timeout value to a larger number, in milliseconds, or "infinity" (transport process will remain alive regardless of heartbeat message) when consistently processing large transactions and/or high volume of transactions to give client time to receive all broadcasted messages and then send heartbeat message to server. Defaults to 60000 (milliseconds).
 ```
 
 **EXAMPLE: RUNNING SERVER WITH ALL OPTIONS**

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ PORT                    # {number}      Port which you can connect your client/l
 SECURE_CHANNELS         # {string}      (options: 'true'/'false') Enable/Disable channels authorization via JWT verification.
 JWT_SECRET              # {string}      HS algorithm octet key (e.g. "95x0oR8jq9unl9pOIx"). Only required if SECURE_CHANNELS is set to true.
 JWT_CLAIM_VALIDATORS    # {string}      Expected claim key/value pairs compared to JWT claims via equality checks in order to validate JWT. e.g. '{"iss": "Issuer", "nbf": 1610078130}'. This is optional but encouraged.
+SOCKET_TIMEOUT          # {number/string}    Set websocket timeout value to a larger number, in milliseconds, or "infinity" when consistently processing large transactions and/or high volume of transactions. Defaults to 60000 (milliseconds).
 ```
 
 **EXAMPLE: RUNNING SERVER WITH ALL OPTIONS**

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -54,6 +54,16 @@ db_ip_version =
   %{"ipv4" => :inet, "ipv6" => :inet6}
   |> Map.fetch(System.get_env("DB_IP_VERSION", "") |> String.downcase())
 
+# Set Cowboy server idle_timeout value. Set to a larger number, in milliseconds, or "infinity". Default is 60000 (1 minute).
+socket_timeout = case System.get_env("SOCKET_TIMEOUT") do
+  "infinity" -> :infinity
+  timeout -> try do
+    String.to_integer(timeout)
+  rescue
+    ArgumentError -> 60_000
+  end
+end
+
 config :realtime,
   app_hostname: app_hostname,
   app_port: app_port,
@@ -69,7 +79,8 @@ config :realtime,
   configuration_file: configuration_file,
   secure_channels: secure_channels,
   jwt_secret: jwt_secret,
-  jwt_claim_validators: jwt_claim_validators
+  jwt_claim_validators: jwt_claim_validators,
+  socket_timeout: socket_timeout
 
 # Configures the endpoint
 config :realtime, RealtimeWeb.Endpoint,

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -47,6 +47,16 @@ db_ip_version =
   %{"ipv4" => :inet, "ipv6" => :inet6}
   |> Map.fetch(System.get_env("DB_IP_VERSION", "") |> String.downcase())
 
+# Set Cowboy server idle_timeout value. Set to a larger number, in milliseconds, or "infinity". Default is 60000 (1 minute).
+socket_timeout = case System.get_env("SOCKET_TIMEOUT") do
+  "infinity" -> :infinity
+  timeout -> try do
+    String.to_integer(timeout)
+  rescue
+    ArgumentError -> 60_000
+  end
+end
+
 config :realtime,
   app_hostname: app_hostname,
   app_port: app_port,
@@ -62,7 +72,8 @@ config :realtime,
   configuration_file: configuration_file,
   secure_channels: secure_channels,
   jwt_secret: jwt_secret,
-  jwt_claim_validators: jwt_claim_validators
+  jwt_claim_validators: jwt_claim_validators,
+  socket_timeout: socket_timeout
 
 config :realtime, RealtimeWeb.Endpoint,
   http: [:inet6, port: app_port],

--- a/server/lib/realtime/webhook_connector.ex
+++ b/server/lib/realtime/webhook_connector.ex
@@ -8,7 +8,7 @@ defmodule Realtime.WebhookConnector do
   # Task.yield_many/2 timeout default
   @timeout 5_000
 
-  def notify(%Transaction{changes: _} = txn, [_ | _] = config) do
+  def notify(%Transaction{changes: [_ | _]} = txn, [_ | _] = config) do
     with [_ | _] = webhooks <- webhooks_for_txn(config, txn),
          {:ok, serialized_txn} <- Jason.encode(txn) do
       Enum.reduce(webhooks, [], fn webhook, acc ->

--- a/server/lib/realtime_web/channels/realtime_channel.ex
+++ b/server/lib/realtime_web/channels/realtime_channel.ex
@@ -18,8 +18,8 @@ defmodule RealtimeWeb.RealtimeChannel do
   @doc """
   Handles a full, decoded transation.
   """
-  def handle_realtime_transaction(topic, txn) do
-    RealtimeWeb.Endpoint.broadcast_from!(self(), topic, "*", txn)
-    RealtimeWeb.Endpoint.broadcast_from!(self(), topic, txn.type, txn)
+  def handle_realtime_transaction(topic, record_type, encoded_txn) do
+    RealtimeWeb.Endpoint.broadcast_from!(self(), topic, "*", {:binary, encoded_txn})
+    RealtimeWeb.Endpoint.broadcast_from!(self(), topic, record_type, {:binary, encoded_txn})
   end
 end

--- a/server/lib/realtime_web/channels/v1_json_serializer.ex
+++ b/server/lib/realtime_web/channels/v1_json_serializer.ex
@@ -1,0 +1,76 @@
+defmodule Realtime.Socket.V1.JSONSerializer do
+  @moduledoc false
+  @behaviour Phoenix.Socket.Serializer
+
+  alias Phoenix.Socket.{Broadcast, Message, Reply}
+
+  @broadcast 2
+
+  @impl true
+  def fastlane!(%Broadcast{payload: {:binary, data}} = msg) do
+    topic_size = byte_size!(msg.topic, :topic, 255)
+    event_size = byte_size!(msg.event, :event, 255)
+
+    bin = <<
+      @broadcast::size(8),
+      topic_size::size(8),
+      event_size::size(8),
+      msg.topic::binary-size(topic_size),
+      msg.event::binary-size(event_size),
+      data::binary
+    >>
+
+    {:socket_push, :binary, bin}
+  end
+
+  @impl true
+  def fastlane!(%Broadcast{} = msg) do
+    map = %Message{topic: msg.topic, event: msg.event, payload: msg.payload}
+    {:socket_push, :text, encode_v1_fields_only(map)}
+  end
+
+  @impl true
+  def encode!(%Reply{} = reply) do
+    map = %Message{
+      topic: reply.topic,
+      event: "phx_reply",
+      ref: reply.ref,
+      payload: %{status: reply.status, response: reply.payload}
+    }
+
+    {:socket_push, :text, encode_v1_fields_only(map)}
+  end
+
+  def encode!(%Message{} = map) do
+    {:socket_push, :text, encode_v1_fields_only(map)}
+  end
+
+  @impl true
+  def decode!(message, _opts) do
+    message
+    |> Phoenix.json_library().decode!()
+    |> Phoenix.Socket.Message.from_map!()
+  end
+
+  defp encode_v1_fields_only(%Message{} = msg) do
+    msg
+    |> Map.take([:topic, :event, :payload, :ref])
+    |> Phoenix.json_library().encode_to_iodata!()
+  end
+
+  defp byte_size!(bin, kind, max) do
+    case byte_size(bin) do
+      size when size <= max ->
+        size
+
+      oversized ->
+        raise ArgumentError, """
+        unable to convert #{kind} to binary.
+
+            #{inspect(bin)}
+
+        must be less than or equal to #{max} bytes, but is #{oversized} bytes.
+        """
+    end
+  end
+end

--- a/server/lib/realtime_web/endpoint.ex
+++ b/server/lib/realtime_web/endpoint.ex
@@ -2,7 +2,10 @@ defmodule RealtimeWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :realtime
 
   socket "/socket", RealtimeWeb.UserSocket,
-    websocket: true,
+    websocket: [
+      serializer: [{Realtime.Socket.V1.JSONSerializer, "1.0.0"}],
+      timeout: Application.get_env(:realtime, :socket_timeout)
+    ],
     longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/server/test/realtime/replication_test.exs
+++ b/server/test/realtime/replication_test.exs
@@ -4,7 +4,7 @@ defmodule Realtime.ReplicationTest do
   import Mock
 
   alias Realtime.Replication
-  alias Realtime.Adapters.Changes.{Transaction, NewRecord, UpdatedRecord, DeletedRecord}
+  alias Realtime.Adapters.Changes.Transaction
   alias Realtime.Adapters.Postgres.Decoder.Messages.Relation
   alias Realtime.Adapters.Postgres.EpgsqlServer
   alias Realtime.SubscribersNotification
@@ -53,6 +53,7 @@ defmodule Realtime.ReplicationTest do
           replica_identity: :default
         }
       },
+      reverse_changes: [],
       transaction: nil,
       types: %{}
     }
@@ -60,74 +61,73 @@ defmodule Realtime.ReplicationTest do
     {:ok, test_state: test_state}
   end
 
-  test "Integration Test: 0.2.0" do
+  test "transaction begin message" do
     assert {:noreply,
             %Replication.State{
-              relations: %{
-                16386 => %Relation{
-                  columns: [
-                    %Relation.Column{
-                      flags: [:key],
-                      name: "id",
-                      type: "int8",
-                      type_modifier: 4_294_967_295
-                    },
-                    %Relation.Column{
-                      flags: [],
-                      name: "first_name",
-                      type: "text",
-                      type_modifier: 4_294_967_295
-                    },
-                    %Relation.Column{
-                      flags: [],
-                      name: "last_name",
-                      type: "text",
-                      type_modifier: 4_294_967_295
-                    },
-                    %Relation.Column{
-                      flags: [],
-                      name: "info",
-                      type: "jsonb",
-                      type_modifier: 4_294_967_295
-                    },
-                    %Relation.Column{
-                      flags: [],
-                      name: "inserted_at",
-                      type: "timestamp",
-                      type_modifier: 4_294_967_295
-                    },
-                    %Relation.Column{
-                      flags: [],
-                      name: "updated_at",
-                      type: "timestamp",
-                      type_modifier: 4_294_967_295
-                    }
-                  ],
-                  id: 16386,
-                  name: "users",
-                  namespace: "public",
-                  replica_identity: :default
-                }
-              },
-              transaction: nil,
+              relations: %{},
+              reverse_changes: [],
+              transaction:
+                {{0, 49_723_672},
+                 %Realtime.Adapters.Changes.Transaction{
+                   changes: nil,
+                   commit_timestamp: %DateTime{
+                     calendar: Calendar.ISO,
+                     day: 2,
+                     hour: 3,
+                     microsecond: {725_420, 0},
+                     minute: 8,
+                     month: 4,
+                     second: 14,
+                     std_offset: 0,
+                     time_zone: "Etc/UTC",
+                     utc_offset: 0,
+                     year: 2021,
+                     zone_abbr: "UTC"
+                   }
+                 }},
               types: %{}
             }} =
              Replication.handle_info(
-               {:epgsql, 0,
+               {:epgsql, "pid",
                 {:x_log_data, 0, 0,
-                 <<82, 0, 0, 64, 2, 112, 117, 98, 108, 105, 99, 0, 117, 115, 101, 114, 115, 0,
-                   100, 0, 6, 1, 105, 100, 0, 0, 0, 0, 20, 255, 255, 255, 255, 0, 102, 105, 114,
-                   115, 116, 95, 110, 97, 109, 101, 0, 0, 0, 0, 25, 255, 255, 255, 255, 0, 108,
-                   97, 115, 116, 95, 110, 97, 109, 101, 0, 0, 0, 0, 25, 255, 255, 255, 255, 0,
-                   105, 110, 102, 111, 0, 0, 0, 14, 218, 255, 255, 255, 255, 0, 105, 110, 115,
-                   101, 114, 116, 101, 100, 95, 97, 116, 0, 0, 0, 4, 90, 255, 255, 255, 255, 0,
-                   117, 112, 100, 97, 116, 101, 100, 95, 97, 116, 0, 0, 0, 4, 90, 255, 255, 255,
-                   255>>}},
+                 <<66, 0, 0, 0, 0, 2, 246, 185, 24, 0, 2, 97, 243, 109, 116, 149, 44, 0, 0, 2,
+                   254>>}},
                %Replication.State{}
              )
   end
 
-  test "insert record with data type conversion", %{test_state: test_state} do
+  test "transaction relation message" do
+    assert {:noreply,
+            %Realtime.Replication.State{
+              relations: %{
+                16628 => %Realtime.Adapters.Postgres.Decoder.Messages.Relation{
+                  columns: @test_columns,
+                  id: 16628,
+                  name: "test",
+                  namespace: "public",
+                  replica_identity: :default
+                }
+              },
+              reverse_changes: [],
+              transaction: nil,
+              types: %{}
+            }} =
+             Replication.handle_info(
+               {:epgsql, "pid",
+                {:x_log_data, 0, 0,
+                 <<82, 0, 0, 64, 244, 112, 117, 98, 108, 105, 99, 0, 116, 101, 115, 116, 0, 100,
+                   0, 5, 1, 105, 100, 0, 0, 0, 0, 20, 255, 255, 255, 255, 0, 100, 101, 116, 97,
+                   105, 108, 115, 0, 0, 0, 0, 25, 255, 255, 255, 255, 0, 117, 115, 101, 114, 95,
+                   105, 100, 0, 0, 0, 0, 20, 255, 255, 255, 255, 0, 105, 110, 115, 101, 114, 116,
+                   101, 100, 95, 97, 116, 95, 119, 105, 116, 104, 95, 116, 105, 109, 101, 95, 122,
+                   111, 110, 101, 0, 0, 0, 4, 160, 255, 255, 255, 255, 0, 105, 110, 115, 101, 114,
+                   116, 101, 100, 95, 97, 116, 95, 119, 105, 116, 104, 111, 117, 116, 95, 116,
+                   105, 109, 101, 95, 122, 111, 110, 101, 0, 0, 0, 4, 90, 255, 255, 255, 255>>}},
+               %Replication.State{}
+             )
+  end
+
+  test "transaction insert message", %{test_state: test_state} do
     test_state = %{
       test_state
       | transaction:
@@ -151,31 +151,29 @@ defmodule Realtime.ReplicationTest do
            }}
     }
 
-    {:noreply,
-     %Replication.State{
-       transaction: {_lsn, %{changes: [%NewRecord{record: record}]}}
-     }} =
-      Replication.handle_info(
-        {:epgsql, "pid",
-         {:x_log_data, 0, 0,
-          <<73, 0, 0, 104, 101, 78, 0, 5, 116, 0, 0, 0, 1, 51, 116, 0, 0, 0, 17, 83, 117, 112, 97,
-            98, 97, 115, 101, 32, 105, 115, 32, 103, 111, 111, 100, 33, 116, 0, 0, 0, 1, 49, 116,
-            0, 0, 0, 28, 50, 48, 50, 49, 45, 48, 50, 45, 49, 54, 32, 50, 51, 58, 52, 55, 58, 52,
-            55, 46, 53, 49, 54, 49, 51, 43, 48, 48, 116, 0, 0, 0, 25, 50, 48, 50, 49, 45, 48, 50,
-            45, 49, 54, 32, 50, 51, 58, 52, 55, 58, 52, 55, 46, 53, 49, 54, 49, 51>>}},
-        test_state
-      )
-
-    assert %{
-             "details" => "Supabase is good!",
-             "id" => "3",
-             "inserted_at_with_time_zone" => "2021-02-16T23:47:47.51613Z",
-             "inserted_at_without_time_zone" => "2021-02-16T23:47:47.51613Z",
-             "user_id" => "1"
-           } = record
+    assert {:noreply,
+            %Replication.State{
+              reverse_changes: [
+                {26725, "INSERT",
+                 {"3", "Supabase is good!", "1", "2021-02-16 23:47:47.51613+00",
+                  "2021-02-16 23:47:47.51613"}, nil}
+              ],
+              transaction: {_lsn, %Transaction{changes: []}}
+            }} =
+             Replication.handle_info(
+               {:epgsql, "pid",
+                {:x_log_data, 0, 0,
+                 <<73, 0, 0, 104, 101, 78, 0, 5, 116, 0, 0, 0, 1, 51, 116, 0, 0, 0, 17, 83, 117,
+                   112, 97, 98, 97, 115, 101, 32, 105, 115, 32, 103, 111, 111, 100, 33, 116, 0, 0,
+                   0, 1, 49, 116, 0, 0, 0, 28, 50, 48, 50, 49, 45, 48, 50, 45, 49, 54, 32, 50, 51,
+                   58, 52, 55, 58, 52, 55, 46, 53, 49, 54, 49, 51, 43, 48, 48, 116, 0, 0, 0, 25,
+                   50, 48, 50, 49, 45, 48, 50, 45, 49, 54, 32, 50, 51, 58, 52, 55, 58, 52, 55, 46,
+                   53, 49, 54, 49, 51>>}},
+               test_state
+             )
   end
 
-  test "update record with data type conversion", %{test_state: test_state} do
+  test "transaction update message", %{test_state: test_state} do
     test_state = %{
       test_state
       | transaction:
@@ -199,50 +197,40 @@ defmodule Realtime.ReplicationTest do
            }}
     }
 
-    {:noreply,
-     %Replication.State{
-       transaction:
-         {_lsn,
-          %{
-            changes: [
-              %UpdatedRecord{old_record: old_record, record: record}
-            ]
-          }}
-     }} =
-      Replication.handle_info(
-        {:epgsql, "pid",
-         {:x_log_data, 0, 0,
-          <<85, 0, 0, 104, 101, 79, 0, 5, 116, 0, 0, 0, 1, 51, 116, 0, 0, 0, 17, 83, 117, 112, 97,
-            98, 97, 115, 101, 32, 105, 115, 32, 103, 111, 111, 100, 33, 116, 0, 0, 0, 1, 49, 116,
-            0, 0, 0, 28, 50, 48, 50, 49, 45, 48, 50, 45, 49, 54, 32, 50, 51, 58, 52, 55, 58, 52,
-            55, 46, 53, 49, 54, 49, 51, 43, 48, 48, 116, 0, 0, 0, 25, 50, 48, 50, 49, 45, 48, 50,
-            45, 49, 54, 32, 50, 51, 58, 52, 55, 58, 52, 55, 46, 53, 49, 54, 49, 51, 78, 0, 5, 116,
-            0, 0, 0, 1, 51, 116, 0, 0, 0, 22, 78, 111, 44, 32, 83, 117, 112, 97, 98, 97, 115, 101,
-            32, 105, 115, 32, 103, 114, 101, 97, 116, 33, 116, 0, 0, 0, 1, 49, 116, 0, 0, 0, 28,
-            50, 48, 50, 49, 45, 48, 50, 45, 49, 54, 32, 50, 51, 58, 52, 55, 58, 52, 55, 46, 53,
-            49, 54, 49, 51, 43, 48, 48, 116, 0, 0, 0, 25, 50, 48, 50, 49, 45, 48, 50, 45, 49, 54,
-            32, 50, 51, 58, 52, 55, 58, 52, 55, 46, 53, 49, 54, 49, 51>>}},
-        test_state
-      )
-
-    assert %{
-             "details" => "Supabase is good!",
-             "id" => "3",
-             "inserted_at_with_time_zone" => "2021-02-16T23:47:47.51613Z",
-             "inserted_at_without_time_zone" => "2021-02-16T23:47:47.51613Z",
-             "user_id" => "1"
-           } = old_record
-
-    assert %{
-             "details" => "No, Supabase is great!",
-             "id" => "3",
-             "inserted_at_with_time_zone" => "2021-02-16T23:47:47.51613Z",
-             "inserted_at_without_time_zone" => "2021-02-16T23:47:47.51613Z",
-             "user_id" => "1"
-           } = record
+    assert {:noreply,
+            %Replication.State{
+              reverse_changes: [
+                {26725, "UPDATE",
+                 {"3", "No, Supabase is great!", "1", "2021-02-16 23:47:47.51613+00",
+                  "2021-02-16 23:47:47.51613"},
+                 {"3", "Supabase is good!", "1", "2021-02-16 23:47:47.51613+00",
+                  "2021-02-16 23:47:47.51613"}}
+              ],
+              transaction:
+                {_lsn,
+                 %Transaction{
+                   changes: []
+                 }}
+            }} =
+             Replication.handle_info(
+               {:epgsql, "pid",
+                {:x_log_data, 0, 0,
+                 <<85, 0, 0, 104, 101, 79, 0, 5, 116, 0, 0, 0, 1, 51, 116, 0, 0, 0, 17, 83, 117,
+                   112, 97, 98, 97, 115, 101, 32, 105, 115, 32, 103, 111, 111, 100, 33, 116, 0, 0,
+                   0, 1, 49, 116, 0, 0, 0, 28, 50, 48, 50, 49, 45, 48, 50, 45, 49, 54, 32, 50, 51,
+                   58, 52, 55, 58, 52, 55, 46, 53, 49, 54, 49, 51, 43, 48, 48, 116, 0, 0, 0, 25,
+                   50, 48, 50, 49, 45, 48, 50, 45, 49, 54, 32, 50, 51, 58, 52, 55, 58, 52, 55, 46,
+                   53, 49, 54, 49, 51, 78, 0, 5, 116, 0, 0, 0, 1, 51, 116, 0, 0, 0, 22, 78, 111,
+                   44, 32, 83, 117, 112, 97, 98, 97, 115, 101, 32, 105, 115, 32, 103, 114, 101,
+                   97, 116, 33, 116, 0, 0, 0, 1, 49, 116, 0, 0, 0, 28, 50, 48, 50, 49, 45, 48, 50,
+                   45, 49, 54, 32, 50, 51, 58, 52, 55, 58, 52, 55, 46, 53, 49, 54, 49, 51, 43, 48,
+                   48, 116, 0, 0, 0, 25, 50, 48, 50, 49, 45, 48, 50, 45, 49, 54, 32, 50, 51, 58,
+                   52, 55, 58, 52, 55, 46, 53, 49, 54, 49, 51>>}},
+               test_state
+             )
   end
 
-  test "delete record with data type conversion", %{test_state: test_state} do
+  test "transaction delete message", %{test_state: test_state} do
     test_state = %{
       test_state
       | transaction:
@@ -266,57 +254,128 @@ defmodule Realtime.ReplicationTest do
            }}
     }
 
-    {:noreply,
-     %Replication.State{
-       transaction:
-         {_lsn,
-          %{
-            changes: [
-              %DeletedRecord{old_record: old_record}
-            ]
-          }}
-     }} =
-      Replication.handle_info(
-        {:epgsql, "pid",
-         {:x_log_data, 0, 0,
-          <<68, 0, 0, 104, 101, 79, 0, 5, 116, 0, 0, 0, 1, 52, 116, 0, 0, 0, 13, 83, 101, 101, 32,
-            121, 97, 32, 108, 97, 116, 101, 114, 33, 116, 0, 0, 0, 1, 49, 116, 0, 0, 0, 29, 50,
-            48, 50, 49, 45, 48, 50, 45, 49, 55, 32, 48, 49, 58, 48, 48, 58, 53, 54, 46, 50, 49,
-            54, 54, 53, 52, 43, 48, 48, 116, 0, 0, 0, 26, 50, 48, 50, 49, 45, 48, 50, 45, 49, 55,
-            32, 48, 49, 58, 48, 48, 58, 53, 54, 46, 50, 49, 54, 54, 53, 52>>}},
-        test_state
-      )
-
-    assert %{
-             "details" => "See ya later!",
-             "id" => "4",
-             "inserted_at_with_time_zone" => "2021-02-17T01:00:56.216654Z",
-             "inserted_at_without_time_zone" => "2021-02-17T01:00:56.216654Z",
-             "user_id" => "1"
-           } = old_record
+    assert {:noreply,
+            %Replication.State{
+              reverse_changes: [
+                {26725, "DELETE", nil,
+                 {"4", "See ya later!", "1", "2021-02-17 01:00:56.216654+00",
+                  "2021-02-17 01:00:56.216654"}}
+              ],
+              transaction:
+                {_lsn,
+                 %Transaction{
+                   changes: []
+                 }}
+            }} =
+             Replication.handle_info(
+               {:epgsql, "pid",
+                {:x_log_data, 0, 0,
+                 <<68, 0, 0, 104, 101, 79, 0, 5, 116, 0, 0, 0, 1, 52, 116, 0, 0, 0, 13, 83, 101,
+                   101, 32, 121, 97, 32, 108, 97, 116, 101, 114, 33, 116, 0, 0, 0, 1, 49, 116, 0,
+                   0, 0, 29, 50, 48, 50, 49, 45, 48, 50, 45, 49, 55, 32, 48, 49, 58, 48, 48, 58,
+                   53, 54, 46, 50, 49, 54, 54, 53, 52, 43, 48, 48, 116, 0, 0, 0, 26, 50, 48, 50,
+                   49, 45, 48, 50, 45, 49, 55, 32, 48, 49, 58, 48, 48, 58, 53, 54, 46, 50, 49, 54,
+                   54, 53, 52>>}},
+               test_state
+             )
   end
 
-  test "commit record", %{test_state: test_state} do
-    expected_commit_timestamp = %DateTime{
-      calendar: Calendar.ISO,
-      day: 22,
-      hour: 02,
-      microsecond: {0, 0},
-      minute: 15,
-      month: 2,
-      second: 04,
-      std_offset: 0,
-      time_zone: "Etc/UTC",
-      utc_offset: 0,
-      year: 2021,
-      zone_abbr: "UTC"
+  test "transaction truncate message" do
+    test_state = %Replication.State{
+      relations: %{
+        16628 => %Relation{
+          columns: @test_columns,
+          id: 16628,
+          name: "test",
+          namespace: "public",
+          replica_identity: :default
+        }
+      },
+      reverse_changes: [],
+      transaction:
+        {{0, 50_302_656},
+         %Realtime.Adapters.Changes.Transaction{
+           changes: nil,
+           commit_timestamp: %DateTime{
+             calendar: Calendar.ISO,
+             day: 2,
+             hour: 3,
+             microsecond: {0, 0},
+             minute: 58,
+             month: 4,
+             second: 40,
+             std_offset: 0,
+             time_zone: "Etc/UTC",
+             utc_offset: 0,
+             year: 2021,
+             zone_abbr: "UTC"
+           }
+         }}
     }
 
+    assert {
+             :noreply,
+             %Replication.State{
+               relations: %{
+                 16628 => %Relation{
+                   columns: @test_columns,
+                   id: 16628,
+                   name: "test",
+                   namespace: "public",
+                   replica_identity: :default
+                 }
+               },
+               reverse_changes: [{16628, "TRUNCATE", nil, nil}],
+               transaction:
+                 {{0, 50_302_656},
+                  %Transaction{
+                    changes: nil,
+                    commit_timestamp: %DateTime{
+                      calendar: Calendar.ISO,
+                      day: 2,
+                      hour: 3,
+                      microsecond: {0, 0},
+                      minute: 58,
+                      month: 4,
+                      second: 40,
+                      std_offset: 0,
+                      time_zone: "Etc/UTC",
+                      utc_offset: 0,
+                      year: 2021,
+                      zone_abbr: "UTC"
+                    }
+                  }},
+               types: %{}
+             }
+           } =
+             Replication.handle_info(
+               {:epgsql, "pid", {:x_log_data, 0, 0, <<84, 0, 0, 0, 1, 3, 0, 0, 64, 244>>}},
+               test_state
+             )
+  end
+
+  test "transaction commit message", %{test_state: test_state} do
     test_state = %{
       test_state
       | transaction:
           {{0, 2_097_482_504},
-           %Transaction{changes: [], commit_timestamp: expected_commit_timestamp}}
+           %Transaction{
+             changes: [],
+             commit_timestamp: %DateTime{
+               calendar: Calendar.ISO,
+               day: 22,
+               hour: 02,
+               microsecond: {0, 0},
+               minute: 15,
+               month: 2,
+               second: 04,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: 2021,
+               zone_abbr: "UTC"
+             }
+           }}
     }
 
     {:noreply, insert_state} =
@@ -331,39 +390,47 @@ defmodule Realtime.ReplicationTest do
         test_state
       )
 
-    {:noreply,
-     %Replication.State{transaction: {_lsn, %Transaction{changes: changes}}} = insert_state} =
-      Replication.handle_info(
-        {:epgsql, "pid",
-         {:x_log_data, 0, 0,
-          <<73, 0, 0, 104, 101, 78, 0, 5, 116, 0, 0, 0, 1, 50, 116, 0, 0, 0, 10, 67, 111, 111,
-            107, 32, 114, 97, 109, 101, 110, 116, 0, 0, 0, 1, 49, 116, 0, 0, 0, 29, 50, 48, 50,
-            49, 45, 48, 50, 45, 50, 50, 32, 48, 50, 58, 49, 53, 58, 51, 57, 46, 57, 53, 48, 55,
-            50, 54, 43, 48, 48, 116, 0, 0, 0, 26, 50, 48, 50, 49, 45, 48, 50, 45, 50, 50, 32, 48,
-            50, 58, 49, 53, 58, 51, 57, 46, 57, 53, 48, 55, 50, 54>>}},
-        insert_state
-      )
-
-    assert [
-             %NewRecord{
-               record: %{
-                 "details" => "Cook ramen",
-                 "id" => "2",
-                 "inserted_at_with_time_zone" => "2021-02-22T02:15:39.950726Z",
-                 "inserted_at_without_time_zone" => "2021-02-22T02:15:39.950726Z",
-                 "user_id" => "1"
-               }
-             },
-             %NewRecord{
-               record: %{
-                 "details" => "Boil water",
-                 "id" => "1",
-                 "inserted_at_with_time_zone" => "2021-02-22T02:15:39.950726Z",
-                 "inserted_at_without_time_zone" => "2021-02-22T02:15:39.950726Z",
-                 "user_id" => "1"
-               }
-             }
-           ] = changes
+    assert {:noreply,
+            %Replication.State{
+              reverse_changes: [
+                {26725, "INSERT",
+                 {"2", "Cook ramen", "1", "2021-02-22 02:15:39.950726+00",
+                  "2021-02-22 02:15:39.950726"}, nil},
+                {26725, "INSERT",
+                 {"1", "Boil water", "1", "2021-02-22 02:15:39.950726+00",
+                  "2021-02-22 02:15:39.950726"}, nil}
+              ],
+              transaction:
+                {_lsn,
+                 %Transaction{
+                   changes: [],
+                   commit_timestamp: %DateTime{
+                     calendar: Calendar.ISO,
+                     day: 22,
+                     hour: 02,
+                     microsecond: {0, 0},
+                     minute: 15,
+                     month: 2,
+                     second: 04,
+                     std_offset: 0,
+                     time_zone: "Etc/UTC",
+                     utc_offset: 0,
+                     year: 2021,
+                     zone_abbr: "UTC"
+                   }
+                 }}
+            }} =
+             Replication.handle_info(
+               {:epgsql, "pid",
+                {:x_log_data, 0, 0,
+                 <<73, 0, 0, 104, 101, 78, 0, 5, 116, 0, 0, 0, 1, 50, 116, 0, 0, 0, 10, 67, 111,
+                   111, 107, 32, 114, 97, 109, 101, 110, 116, 0, 0, 0, 1, 49, 116, 0, 0, 0, 29,
+                   50, 48, 50, 49, 45, 48, 50, 45, 50, 50, 32, 48, 50, 58, 49, 53, 58, 51, 57, 46,
+                   57, 53, 48, 55, 50, 54, 43, 48, 48, 116, 0, 0, 0, 26, 50, 48, 50, 49, 45, 48,
+                   50, 45, 50, 50, 32, 48, 50, 58, 49, 53, 58, 51, 57, 46, 57, 53, 48, 55, 50,
+                   54>>}},
+               insert_state
+             )
 
     with_mocks([
       {
@@ -381,7 +448,22 @@ defmodule Realtime.ReplicationTest do
         ]
       }
     ]) do
-      {:noreply, commit_state} =
+      {:noreply,
+       %Replication.State{
+         relations: %{
+           26725 => %Relation{
+             columns: @test_columns,
+             id: 26725,
+             name: "todos",
+             namespace: "public",
+             replica_identity: :default
+           }
+         },
+         reverse_changes: [],
+         transaction: nil,
+         types: %{}
+       },
+       :hibernate} =
         Replication.handle_info(
           {:epgsql, "pid",
            {:x_log_data, 0, 0,
@@ -391,44 +473,66 @@ defmodule Realtime.ReplicationTest do
         )
 
       assert called(
-               SubscribersNotification.notify(%Transaction{
-                 commit_timestamp: expected_commit_timestamp,
-                 changes: [
-                   %Realtime.Adapters.Changes.NewRecord{
+               SubscribersNotification.notify(%Replication.State{
+                 relations: %{
+                   26725 => %Relation{
                      columns: @test_columns,
-                     commit_timestamp: expected_commit_timestamp,
-                     record: %{
-                       "details" => "Boil water",
-                       "id" => "1",
-                       "inserted_at_with_time_zone" => "2021-02-22T02:15:39.950726Z",
-                       "inserted_at_without_time_zone" => "2021-02-22T02:15:39.950726Z",
-                       "user_id" => "1"
-                     },
-                     schema: "public",
-                     table: "todos",
-                     type: "INSERT"
-                   },
-                   %Realtime.Adapters.Changes.NewRecord{
-                     columns: @test_columns,
-                     commit_timestamp: expected_commit_timestamp,
-                     record: %{
-                       "details" => "Cook ramen",
-                       "id" => "2",
-                       "inserted_at_with_time_zone" => "2021-02-22T02:15:39.950726Z",
-                       "inserted_at_without_time_zone" => "2021-02-22T02:15:39.950726Z",
-                       "user_id" => "1"
-                     },
-                     schema: "public",
-                     table: "todos",
-                     type: "INSERT"
+                     id: 26725,
+                     name: "todos",
+                     namespace: "public",
+                     replica_identity: :default
                    }
-                 ]
+                 },
+                 reverse_changes: [],
+                 transaction:
+                   {{0, 2_097_482_504},
+                    %Transaction{
+                      changes: [
+                        {26725, "INSERT",
+                         {"1", "Boil water", "1", "2021-02-22 02:15:39.950726+00",
+                          "2021-02-22 02:15:39.950726"}, nil}
+                      ],
+                      commit_timestamp: ~U[2021-02-22 02:15:04Z]
+                    }},
+                 types: %{}
                })
              )
 
       assert called(EpgsqlServer.acknowledge_lsn({0, 2_097_482_992}))
-
-      assert %Replication.State{transaction: nil} = commit_state
     end
+  end
+
+  test "Replication :: data_tuple_to_map/2 when columns and tuple_data inputs are correct" do
+    assert %{
+             "details" => "supabase launch week!",
+             "id" => "1",
+             "inserted_at_with_time_zone" => "2021-04-02T04:11:30.834234Z",
+             "inserted_at_without_time_zone" => "2021-04-02T04:11:30.834234Z",
+             "user_id" => "1"
+           } =
+             Replication.data_tuple_to_map(
+               @test_columns,
+               {"1", "supabase launch week!", "1", "2021-04-02 04:11:30.834234+00",
+                "2021-04-02 04:11:30.834234"}
+             )
+  end
+
+  test "Replication :: data_tuple_to_map/2 when columns and tuple_data inputs are mismatched" do
+    assert %{
+             "details" => "rain check",
+             "id" => "1"
+           } =
+             Replication.data_tuple_to_map(
+               @test_columns,
+               {"1", "rain check"}
+             )
+  end
+
+  test "Replication :: data_tuple_to_map/2 when columns is not list" do
+    assert %{} = Replication.data_tuple_to_map(%{}, {})
+  end
+
+  test "Replication :: data_tuple_to_map/2 when tuple_data is not a tuple" do
+    assert %{} = Replication.data_tuple_to_map(%{}, [])
   end
 end

--- a/server/test/realtime/v1_json_serializer_test.exs
+++ b/server/test/realtime/v1_json_serializer_test.exs
@@ -1,0 +1,95 @@
+# Adopted from https://github.com/phoenixframework/phoenix/blob/master/test/phoenix/socket/v1_json_serializer_test.exs and
+# https://github.com/phoenixframework/phoenix/blob/master/test/phoenix/socket/v2_json_serializer_test.exs
+# License: https://github.com/phoenixframework/phoenix/blob/master/LICENSE.md
+
+defmodule Realtime.Socket.V1.JSONSerializerTest do
+  use ExUnit.Case, async: true
+
+  alias Phoenix.Socket.{Broadcast, Message, Reply}
+
+  # v1 responses must not contain join_ref
+  @serializer Realtime.Socket.V1.JSONSerializer
+  @v1_msg_json "{\"event\":\"e\",\"payload\":\"m\",\"ref\":null,\"topic\":\"t\"}"
+  @v1_reply_json "{\"event\":\"phx_reply\",\"payload\":{\"response\":null,\"status\":null},\"ref\":\"null\",\"topic\":\"t\"}"
+  @v1_fastlane_json "{\"event\":\"e\",\"payload\":\"m\",\"ref\":null,\"topic\":\"t\"}"
+  @broadcast <<
+    # broadcast
+    2::size(8),
+    # topic_size
+    5,
+    # event_size
+    5,
+    "topic",
+    "event",
+    101,
+    102,
+    103
+  >>
+
+  def encode!(serializer, msg) do
+    {:socket_push, :text, encoded} = serializer.encode!(msg)
+    IO.iodata_to_binary(encoded)
+  end
+
+  def decode!(serializer, msg, opts), do: serializer.decode!(msg, opts)
+
+  def fastlane!(serializer, msg) do
+    case serializer.fastlane!(msg) do
+      {:socket_push, :text, encoded} ->
+        assert is_list(encoded)
+        IO.iodata_to_binary(encoded)
+
+      {:socket_push, :binary, encoded} ->
+        assert is_binary(encoded)
+        encoded
+    end
+  end
+
+  test "encode!/1 encodes `Phoenix.Socket.Message` as JSON" do
+    msg = %Message{topic: "t", event: "e", payload: "m"}
+    assert encode!(@serializer, msg) == @v1_msg_json
+  end
+
+  test "encode!/1 encodes `Phoenix.Socket.Reply` as JSON" do
+    msg = %Reply{topic: "t", ref: "null"}
+    assert encode!(@serializer, msg) == @v1_reply_json
+  end
+
+  test "decode!/2 decodes `Phoenix.Socket.Message` from JSON" do
+    assert %Message{topic: "t", event: "e", payload: "m"} ==
+             decode!(@serializer, @v1_msg_json, opcode: :text)
+  end
+
+  test "fastlane!/1 encodes a broadcast into a message as JSON" do
+    msg = %Broadcast{topic: "t", event: "e", payload: "m"}
+    assert fastlane!(@serializer, msg) == @v1_fastlane_json
+  end
+
+  describe "binary encode" do
+    test "fastlane" do
+      assert fastlane!(@serializer, %Broadcast{
+               topic: "topic",
+               event: "event",
+               payload: {:binary, <<101, 102, 103>>}
+             }) == @broadcast
+    end
+
+    test "fastlane with oversized headers" do
+      assert_raise ArgumentError, ~r/unable to convert topic to binary/, fn ->
+        fastlane!(@serializer, %Broadcast{
+          topic: String.duplicate("t", 256),
+          event: "event",
+          payload: {:binary, <<101, 102, 103>>}
+        })
+      end
+
+      assert_raise ArgumentError, ~r/unable to convert event to binary/, fn ->
+        fastlane!(@serializer, %Broadcast{
+          topic: "topic",
+          event: String.duplicate("e", 256),
+          payload: {:binary, <<101, 102, 103>>}
+        })
+      end
+    end
+  end
+end

--- a/server/test/realtime_web/channels/realtime_channel_test.exs
+++ b/server/test/realtime_web/channels/realtime_channel_test.exs
@@ -10,51 +10,60 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     {:ok, socket: socket}
   end
 
-  test "INSERTS are broadcasts to the client" do
-    change = %{
-      schema: "public",
-      table: "users",
-      type: "INSERT"
-    }
+  test "INSERTs are broadcasts to the client" do
+    RealtimeWeb.RealtimeChannel.handle_realtime_transaction(
+      "realtime:*",
+      "INSERT",
+      Jason.encode!(%{
+        schema: "public",
+        table: "users",
+        type: "INSERT"
+      })
+    )
 
-    RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
-    assert_push("*", change)
-    assert_push("INSERT", change)
+    assert_push("*", {:binary, "{\"schema\":\"public\",\"table\":\"users\",\"type\":\"INSERT\"}"})
+
+    assert_push(
+      "INSERT",
+      {:binary, "{\"schema\":\"public\",\"table\":\"users\",\"type\":\"INSERT\"}"}
+    )
   end
 
-  test "UPDATES are broadcasts to the client" do
-    change = %{
-      schema: "public",
-      table: "users",
-      type: "UPDATES"
-    }
+  test "UPDATEs are broadcasts to the client" do
+    RealtimeWeb.RealtimeChannel.handle_realtime_transaction(
+      "realtime:*",
+      "UPDATE",
+      Jason.encode!(%{
+        schema: "public",
+        table: "users",
+        type: "UPDATE"
+      })
+    )
 
-    RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
-    assert_push("*", change)
-    assert_push("UPDATES", change)
+    assert_push("*", {:binary, "{\"schema\":\"public\",\"table\":\"users\",\"type\":\"UPDATE\"}"})
+
+    assert_push(
+      "UPDATE",
+      {:binary, "{\"schema\":\"public\",\"table\":\"users\",\"type\":\"UPDATE\"}"}
+    )
   end
 
-  test "DELETES are broadcasts to the client" do
-    change = %{
-      schema: "public",
-      table: "users",
-      type: "DELETE"
-    }
+  test "DELETEs are broadcasts to the client" do
+    RealtimeWeb.RealtimeChannel.handle_realtime_transaction(
+      "realtime:*",
+      "DELETE",
+      Jason.encode!(%{
+        schema: "public",
+        table: "users",
+        type: "DELETE"
+      })
+    )
 
-    RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
-    assert_push("*", change)
-    assert_push("DELETE", change)
-  end
+    assert_push("*", {:binary, "{\"schema\":\"public\",\"table\":\"users\",\"type\":\"DELETE\"}"})
 
-  test "TRUNCATEs are broadcasted to the client" do
-    change = %{
-      schema: "public",
-      table: "users",
-      type: "TRUNCATE"
-    }
-
-    RealtimeWeb.RealtimeChannel.handle_realtime_transaction("realtime:*", change)
-    assert_push("*", change)
-    assert_push("TRUNCATE", change)
+    assert_push(
+      "DELETE",
+      {:binary, "{\"schema\":\"public\",\"table\":\"users\",\"type\":\"DELETE\"}"}
+    )
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Memory improvement

## What is the current behavior?

All change records are saved to Replication state as final struct form, causing memory bloat. All messages are broadcast as json.

## What is the new behavior?

Minimal data stored to Replication state and then transformed when looping through all transaction changes. All messages are broadcast as binary.

## Additional context

Related: https://github.com/supabase/realtime-js/pull/81 and https://github.com/supabase/realtime-js/pull/80