### PR TITLE
fix: Add docker image for arm64 architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,15 @@ jobs:
       - uses: actions/checkout@v2
         if: env.VERSION_BEFORE != env.VERSION_AFTER
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: arm64,amd64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
       - name: Upload build to Docker Hub
         if: env.VERSION_BEFORE != env.VERSION_AFTER
         uses: docker/build-push-action@v1
@@ -202,3 +211,5 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: supabase/realtime
           tags: latest,v${{ env.VERSION_AFTER }}
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/cli/issues/23

## What is the current behavior?

There is no docker build shipped for ARM architectures, so the realtime container fails when running the CLI on M1 Macs.

## What is the new behavior?

Building a docker images locally fixes the issue, this _should_ publish a compatible image for ARM architectures to Docker Hub.