### PR TITLE
Update Elixir actions in release.yml and ci.yml to erlef/setup-beam@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-18.04]
-        otp: [21.x, 22.x]
-        elixir: [1.9.x, 1.10.x]
+        otp: [23.x]
+        elixir: [1.11.x]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         run: docker-compose -f ../docker-compose.db.yml up -d
 
       - name: Set up Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
 
     strategy:
       matrix:
-        elixir: ["1.11.x"]
-        otp: ["23.x"]
+        elixir: [1.11.x]
+        otp: [23.x]
 
     runs-on: ubuntu-18.04
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Set up Elixir
         if: env.VERSION_BEFORE != env.VERSION_AFTER
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update action from `actions/setup-elixir@v1` to `erlef/setup-beam@v1` to fix failing Elixir setup step.

## What is the current behavior?

Elixir setup is failing with the following error:

> Error: 2.433 [error] Unable to load crypto library. Failed with error:
> ":load_failed, Failed to load NIF library /home/runner/work/_temp/.setup-elixir/otp/lib/crypto-4.6.5/priv/lib/crypto: 'libcrypto.so.1.0.0: cannot open shared object file: No such file or directory'"
> OpenSSL might not be installed on this system.

## What is the new behavior?

Elixir setup succeeds and CI passes.

## Additional context

`actions/setup-elixir@v1` is no longer maintained and `erlef/setup-beam@v1` is recommended. See https://github.com/actions/setup-elixir for more details.
