### PR TITLE
fix: specify db connect via IPv4

### DIFF
--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -29,7 +29,8 @@ defmodule Realtime.Application do
       database: Application.fetch_env!(:realtime, :db_name),
       password: Application.fetch_env!(:realtime, :db_password),
       port: Application.fetch_env!(:realtime, :db_port),
-      ssl: Application.fetch_env!(:realtime, :db_ssl)
+      ssl: Application.fetch_env!(:realtime, :db_ssl),
+      tcp_opts: [:inet]
     }
 
     configuration_file = Application.fetch_env!(:realtime, :configuration_file)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

connect to db via IPv6 on occasion as well as via IPv4.

## What is the new behavior?

connect to db via IPv4 only.

## Additional context