### PR TITLE
feat: enable IP version specification for DB connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ DB_NAME                 # {string}      Postgres database name
 DB_USER                 # {string}      Database user
 DB_PASSWORD             # {string}      Database password
 DB_PORT                 # {number}      Database port
+DB_IP_VERSION           # {string}      (options: 'IPv4'/'IPv6') Connect to database via either IPv4 or IPv6. Disregarded if database host is an IP address (e.g. '127.0.0.1') and recommended if database host is a name (e.g. 'db.abcd.supabase.co') to prevent potential non-existent domain (NXDOMAIN) errors.
 SLOT_NAME               # {string}      A unique name for Postgres to track where this server has "listened until". If the server dies, it can pick up from the last position. This should be lowercase.
 PORT                    # {number}      Port which you can connect your client/listeners
-SECURE_CHANNELS         # {string}     (options: 'true' or 'false') Enable/Disable channels authorization via JWT verification.
+SECURE_CHANNELS         # {string}      (options: 'true'/'false') Enable/Disable channels authorization via JWT verification.
 JWT_SECRET              # {string}      HS algorithm octet key (e.g. "95x0oR8jq9unl9pOIx"). Only required if SECURE_CHANNELS is set to true.
 JWT_CLAIM_VALIDATORS    # {string}      Expected claim key/value pairs compared to JWT claims via equality checks in order to validate JWT. e.g. '{"iss": "Issuer", "nbf": 1610078130}'. This is optional but encouraged.
 ```

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -39,7 +39,20 @@ jwt_secret = System.get_env("JWT_SECRET", "")
 jwt_claim_validators = System.get_env("JWT_CLAIM_VALIDATORS", "{}")
 
 # The secret key base to built the cookie signing/encryption key.
-session_secret_key_base = System.get_env("SESSION_SECRET_KEY_BASE", "Kyvjr42ZvLcY6yzZ7vmRUniE7Bta9tpknEAvpxtaYOa/marmeI1jsqxhIKeu6V51")
+session_secret_key_base =
+  System.get_env(
+    "SESSION_SECRET_KEY_BASE",
+    "Kyvjr42ZvLcY6yzZ7vmRUniE7Bta9tpknEAvpxtaYOa/marmeI1jsqxhIKeu6V51"
+  )
+
+# Connect to database via specified IP version. Options are either "IPv4" or "IPv6".
+# If IP version is not specified and database host is:
+#   - an IP address, then value ("IPv4"/"IPv6") will be disregarded and Realtime will automatically connect via correct version.
+#   - a name (e.g. "db.abcd.supabase.co"), then Realtime will connect either via IPv4 or IPv6. It is recommended
+#   to specify IP version to prevent potential non-existent domain (NXDOMAIN) errors.
+db_ip_version =
+  %{"ipv4" => :inet, "ipv6" => :inet6}
+  |> Map.fetch(System.get_env("DB_IP_VERSION", "") |> String.downcase())
 
 config :realtime,
   app_hostname: app_hostname,
@@ -50,6 +63,7 @@ config :realtime,
   db_user: db_user,
   db_password: db_password,
   db_ssl: db_ssl,
+  db_ip_version: db_ip_version,
   publications: publications,
   slot_name: slot_name,
   configuration_file: configuration_file,

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -32,7 +32,20 @@ jwt_secret = System.get_env("JWT_SECRET", "")
 jwt_claim_validators = System.get_env("JWT_CLAIM_VALIDATORS", "{}")
 
 # The secret key base to built the cookie signing/encryption key.
-session_secret_key_base = System.get_env("SESSION_SECRET_KEY_BASE", "Kyvjr42ZvLcY6yzZ7vmRUniE7Bta9tpknEAvpxtaYOa/marmeI1jsqxhIKeu6V51")
+session_secret_key_base =
+  System.get_env(
+    "SESSION_SECRET_KEY_BASE",
+    "Kyvjr42ZvLcY6yzZ7vmRUniE7Bta9tpknEAvpxtaYOa/marmeI1jsqxhIKeu6V51"
+  )
+
+# Connect to database via specified IP version. Options are either "IPv4" or "IPv6".
+# If IP version is not specified and database host is:
+#   - an IP address, then value ("IPv4"/"IPv6") will be disregarded and Realtime will automatically connect via correct version.
+#   - a name (e.g. "db.abcd.supabase.co"), then Realtime will connect either via IPv4 or IPv6. It is recommended
+#   to specify IP version to prevent potential non-existent domain (NXDOMAIN) errors.
+db_ip_version =
+  %{"ipv4" => :inet, "ipv6" => :inet6}
+  |> Map.fetch(System.get_env("DB_IP_VERSION", "") |> String.downcase())
 
 config :realtime,
   app_hostname: app_hostname,
@@ -43,6 +56,7 @@ config :realtime,
   db_user: db_user,
   db_password: db_password,
   db_ssl: db_ssl,
+  db_ip_version: db_ip_version,
   publications: publications,
   slot_name: slot_name,
   configuration_file: configuration_file,

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -29,9 +29,18 @@ defmodule Realtime.Application do
       database: Application.fetch_env!(:realtime, :db_name),
       password: Application.fetch_env!(:realtime, :db_password),
       port: Application.fetch_env!(:realtime, :db_port),
-      ssl: Application.fetch_env!(:realtime, :db_ssl),
-      tcp_opts: [:inet]
+      ssl: Application.fetch_env!(:realtime, :db_ssl)
     }
+
+    epgsql_params =
+      with {:ok, ip_version} <- Application.fetch_env!(:realtime, :db_ip_version),
+           {:error, :einval} <- :inet.parse_address(epgsql_params.host) do
+        # only add :tcp_opts to epgsql_params when ip_version is present and host
+        # is not an IP address.
+        Map.put(epgsql_params, :tcp_opts, [ip_version])
+      else
+        _ -> epgsql_params
+      end
 
     configuration_file = Application.fetch_env!(:realtime, :configuration_file)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

User can't pass in the IP version they want to use to connect to db.

## What is the new behavior?

User can pass in either IPv4 or IPv6 in order to connect to db.

## Additional context
