### PR TITLE
remove unnecessary setInterval()

### DIFF
--- a/examples/node-js/src/server.js
+++ b/examples/node-js/src/server.js
@@ -45,6 +45,3 @@ TableListener.on('UPDATE', (change) => {
 TableListener.on('DELETE', (change) => {
   console.log('DELETE on TableListener', change)
 })
-
-// Keep script alive
-setInterval(function () {}, 10000)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Example/docs cleanup

## What is the current behavior?

Runs empty interval timer every 10 seconds

## What is the new behavior?

Not to do that

The listeners added throughout the file take care of this [via the Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#phases-overview).  If you are seeing otherwise, your connections are probably closing unexpectedly and require monitoring + logging out of the scope of a simple example server.

## Additional context

Node server example file
