### PR TITLE
fix: drop replication slot when db deletes wal segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ A few reasons:
 2. Decoupling. For example, if you want to send a new slack message every time someone makes a new purchase you might build that functionality directly into your API. This allows you to decouple your async functionality from your API.
 3. This is built with Phoenix, an [extremely scalable Elixir framework](https://www.phoenixframework.org/blog/the-road-to-2-million-websocket-connections).
 
+### Does this server guarentee delivery of every data change?
+
+Not yet! Due to the following limitations:
+
+1. Postgres database runs out of disk space due to Write-Ahead Logging (WAL) buildup, which can crash the database and prevent Realtime server from streaming replication and broadcasting changes.
+2. Realtime server can crash due to a larger replication lag than available memory, forcing the creation of a new replication slot and resetting streaming replication to read from the latest WAL data.
+3. When Realtime server falls too far behind for any reason, for example disconnecting from database as WAL continues to build up, then database can delete WAL segments the server still needs to read from, for example after reconnecting.
 
 ## Quick start
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Database deletes a WAL segment that Realtime server still needs to replay. Realtime is caught restarting in a loop as it cannot find the WAL segment.

## What is the new behavior?

Database deletes a WAL segment that Realtime server still needs to replay. Realtime recognizes this, drops the replication slot, and on restart a new replication slot is created. All is normal again.

## Additional context

- Re-creating a standby (Realtime server) that falls behind is a suggested solution (see https://www.2ndquadrant.com/en/blog/postgresql-9-4-slots for more details)

- There's no good way to test this live so we'll just have to see if it resolves the issue after deploying.