### PR TITLE
fix: drop replication slot when lag exceeds max replication lag value

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ PORT                    # {number}      Port which you can connect your client/l
 SECURE_CHANNELS         # {string}      (options: 'true'/'false') Enable/Disable channels authorization via JWT verification.
 JWT_SECRET              # {string}      HS algorithm octet key (e.g. "95x0oR8jq9unl9pOIx"). Only required if SECURE_CHANNELS is set to true.
 JWT_CLAIM_VALIDATORS    # {string}      Expected claim key/value pairs compared to JWT claims via equality checks in order to validate JWT. e.g. '{"iss": "Issuer", "nbf": 1610078130}'. This is optional but encouraged.
+MAX_REPLICATION_LAG_MB  # {number}      If set, when the replication lag exceeds MAX_REPLICATION_LAG_MB (value must be a positive integer in megabytes), then replication slot is dropped, Realtime is restarted, and a new slot is created. Warning: setting MAX_REPLICATION_SLOT_MB could cause database changes to be lost when the replication slot is dropped.
 ```
 
 **EXAMPLE: RUNNING SERVER WITH ALL OPTIONS**
@@ -216,6 +217,7 @@ docker run                                                       \
   -e SECURE_CHANNELS='true'                                      \
   -e JWT_SECRET='SOMETHING_SUPER_SECRET'                         \
   -e JWT_CLAIM_VALIDATORS='{"iss": "Issuer", "nbf": 1610078130}' \
+  -e MAX_REPLICATION_LAG_MB=1000                                 \
   -p 4000:4000                                                   \
   supabase/realtime
 ```

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -21,6 +21,11 @@ publications = System.get_env("PUBLICATIONS", "[\"supabase_realtime\"]")
 slot_name = System.get_env("SLOT_NAME") || :temporary
 configuration_file = System.get_env("CONFIGURATION_FILE") || nil
 
+# If the replication lag exceeds the set MAX_REPLICATION_LAG_MB (make sure the value is a positive integer in megabytes) value
+# then replication slot named SLOT_NAME (e.g. "realtime") will be dropped and Realtime will
+# restart with a new slot.
+max_replication_lag_in_mb = String.to_integer(System.get_env("MAX_REPLICATION_LAG_MB", "0"))
+
 # Channels are not secured by default in development and
 # are secured by default in production.
 secure_channels = System.get_env("SECURE_CHANNELS", "true") != "false"
@@ -67,7 +72,8 @@ config :realtime,
   configuration_file: configuration_file,
   secure_channels: secure_channels,
   jwt_secret: jwt_secret,
-  jwt_claim_validators: jwt_claim_validators
+  jwt_claim_validators: jwt_claim_validators,
+  max_replication_lag_in_mb: max_replication_lag_in_mb
 
 # Configures the endpoint
 config :realtime, RealtimeWeb.Endpoint,

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -14,6 +14,11 @@ publications = System.get_env("PUBLICATIONS", "[\"supabase_realtime\"]")
 slot_name = System.get_env("SLOT_NAME") || :temporary
 configuration_file = System.get_env("CONFIGURATION_FILE")
 
+# If the replication lag exceeds the set MAX_REPLICATION_LAG_MB (make sure the value is a positive integer in megabytes) value
+# then replication slot named SLOT_NAME (e.g. "realtime") will be dropped and Realtime will
+# restart with a new slot.
+max_replication_lag_in_mb = String.to_integer(System.get_env("MAX_REPLICATION_LAG_MB", "0"))
+
 # Channels are not secured by default in development and
 # are secured by default in production.
 secure_channels = System.get_env("SECURE_CHANNELS", "true") != "false"
@@ -60,7 +65,8 @@ config :realtime,
   configuration_file: configuration_file,
   secure_channels: secure_channels,
   jwt_secret: jwt_secret,
-  jwt_claim_validators: jwt_claim_validators
+  jwt_claim_validators: jwt_claim_validators,
+  max_replication_lag_in_mb: max_replication_lag_in_mb
 
 config :realtime, RealtimeWeb.Endpoint,
   http: [:inet6, port: app_port],

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -21,6 +21,8 @@ defmodule Realtime.Application do
     # `select * from pg_replication_slots`
     slot_name = Application.get_env(:realtime, :slot_name)
 
+    max_replication_lag_in_mb = Application.fetch_env!(:realtime, :max_replication_lag_in_mb)
+
     publications = Application.get_env(:realtime, :publications) |> Jason.decode!()
 
     epgsql_params = %{
@@ -78,7 +80,8 @@ defmodule Realtime.Application do
         epgsql_params: epgsql_params,
         publications: publications,
         slot_name: slot_name,
-        wal_position: {"0", "0"}
+        wal_position: {"0", "0"},
+        max_replication_lag_in_mb: max_replication_lag_in_mb
       }
     ]
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Prod improvement

## What is the current behavior?

Running on a production instance, a big replication lag will use a lot of CPU and continuously crash Realtime due to instance memory limits.

## What is the new behavior?

Running on a production instance, when a big replication lag exceeds a set limit (`MAX_REPLICATION_SLOT_MB`), then replication slot will be dropped, Realtime will be restarted, and a new slot will be created. This will allow the instance to keep operating as normal.

## Additional context

**WARNING**: Setting `MAX_REPLICATION_SLOT_MB` could cause database changes to be lost when the replication slot is dropped.
