### PR TITLE
fix: set :check_origin to false in prod.exs

### DIFF
--- a/server/config/prod.exs
+++ b/server/config/prod.exs
@@ -10,6 +10,7 @@ use Mix.Config
 # which you should run after static files are built and
 # before starting your production server.
 config :realtime, RealtimeWeb.Endpoint,
+  check_origin: false,
   load_from_system_env: true,
   server: true
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

client is unable to connect to realtime websocket in prod due to domain origin check by default.

## What is the new behavior?

client is able to connect to realtime websocket in prod by allowing all domains to connect.

## Additional information

This is caused by removing `url: [host: Application.get_env(:demo, :app_hostname), port: Application.get_env(:demo, :app_port)]` from `prod.exs`
