### PR TITLE
feat: Add headers to the Webhook request

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -58,6 +58,8 @@ db_ip_version =
   %{"ipv4" => :inet, "ipv6" => :inet6}
   |> Map.fetch(System.get_env("DB_IP_VERSION", "") |> String.downcase())
 
+webhook_headers = System.get_env("WEBHOOK_HEADERS")
+
 config :realtime,
   app_port: app_port,
   db_host: db_host,
@@ -73,7 +75,9 @@ config :realtime,
   secure_channels: secure_channels,
   jwt_secret: jwt_secret,
   jwt_claim_validators: jwt_claim_validators,
-  max_replication_lag_in_mb: max_replication_lag_in_mb
+  max_replication_lag_in_mb: max_replication_lag_in_mb,
+  webhook_default_headers: [{"Content-Type", "application/json"}],
+  webhook_headers: webhook_headers
 
 # Configures the endpoint
 config :realtime, RealtimeWeb.Endpoint,

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -76,7 +76,7 @@ config :realtime,
   jwt_secret: jwt_secret,
   jwt_claim_validators: jwt_claim_validators,
   max_replication_lag_in_mb: max_replication_lag_in_mb,
-  webhook_default_headers: [{"Content-Type", "application/json"}],
+  webhook_default_headers: %{"content-type" => "application/json"},
   webhook_headers: webhook_headers
 
 # Configures the endpoint

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -76,7 +76,7 @@ config :realtime,
   jwt_secret: jwt_secret,
   jwt_claim_validators: jwt_claim_validators,
   max_replication_lag_in_mb: max_replication_lag_in_mb,
-  webhook_default_headers: %{"content-type" => "application/json"},
+  webhook_default_headers: [{"content-type", "application/json"}],
   webhook_headers: webhook_headers
 
 # Configures the endpoint

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -61,6 +61,18 @@ defmodule Realtime.Application do
       end
     end
 
+    def_headers = Application.fetch_env!(:realtime, :webhook_default_headers)
+
+    headers =
+      with {:ok, env_val} <- Application.fetch_env(:realtime, :webhook_headers),
+           {:ok, decoded_headers} <- Realtime.Helpers.env_kv_to_list(env_val, def_headers) do
+        decoded_headers
+      else
+        _ -> def_headers
+      end
+
+    Application.put_env(:realtime, :webhook_headers, headers)
+
     # List all child processes to be supervised
     children = [
       # Start the endpoint when the application starts

--- a/server/lib/realtime/helpers.ex
+++ b/server/lib/realtime/helpers.ex
@@ -1,25 +1,35 @@
 defmodule Realtime.Helpers do
-  # key1=value1:key2=value2 to [{"key1", "value1"},{"key2", "value2"}]
-  @spec env_kv_to_list(String.t() | nil, keyword() | []) :: {:ok, keyword()} | :error
+  # key1=value1:key2=value2 to %{"key1" => "value1", "key2" => "value2"}
+  @spec env_kv_to_list(String.t() | nil, map() | %{}) :: {:ok, [{binary(), binary()}]} | :error
   def env_kv_to_list("", _), do: :error
 
   def env_kv_to_list(env_val, def_list) when is_binary(env_val) do
-    keywords =
-      String.split(env_val, ":")
-      |> Enum.map(
-        &(String.split(&1, "=")
-          |> List.to_tuple())
-      )
-      |> Enum.concat(def_list)
+    parsed = parse_kv(env_val, def_list)
 
-    try do
-      # check if keywords is valid
-      Keyword.values(keywords)
-      {:ok, keywords}
-    rescue
-      _ -> :error
+    if is_map(parsed) do
+      {:ok, Map.to_list(parsed)}
+    else
+      :error
     end
   end
 
   def env_kv_to_list(_, _), do: :error
+
+  @spec parse_kv(String.t(), map() | %{}) :: map() | nil
+  def parse_kv(kv, default) do
+    String.split(kv, ":")
+    |> Enum.reduce(default, fn
+      _, nil ->
+        nil
+
+      x, acc ->
+        case String.split(x, "=", parts: 2) do
+          [key, value] ->
+            Map.put(acc, key, value)
+
+          _ ->
+            nil
+        end
+    end)
+  end
 end

--- a/server/lib/realtime/helpers.ex
+++ b/server/lib/realtime/helpers.ex
@@ -1,10 +1,10 @@
 defmodule Realtime.Helpers do
   # key1=value1:key2=value2 to %{"key1" => "value1", "key2" => "value2"}
-  @spec env_kv_to_list(String.t() | nil, map() | %{}) :: {:ok, [{binary(), binary()}]} | :error
+  @spec env_kv_to_list(String.t() | nil, list() | []) :: {:ok, [{binary(), binary()}]} | :error
   def env_kv_to_list("", _), do: :error
 
   def env_kv_to_list(env_val, def_list) when is_binary(env_val) do
-    parsed = parse_kv(env_val, def_list)
+    parsed = parse_kv(env_val, :maps.from_list(def_list))
 
     if is_map(parsed) do
       {:ok, Map.to_list(parsed)}

--- a/server/lib/realtime/helpers.ex
+++ b/server/lib/realtime/helpers.ex
@@ -1,5 +1,5 @@
 defmodule Realtime.Helpers do
-  # key1=value1:key2=value2 to %{"key1" => "value1", "key2" => "value2"}
+  # key1=value1:key2=value2 to [{"key1", "value1"}, {"key2", "value2"}]}
   @spec env_kv_to_list(String.t() | nil, list() | []) :: {:ok, [{binary(), binary()}]} | :error
   def env_kv_to_list("", _), do: :error
 

--- a/server/lib/realtime/helpers.ex
+++ b/server/lib/realtime/helpers.ex
@@ -1,0 +1,25 @@
+defmodule Realtime.Helpers do
+  # key1=value1:key2=value2 to [{"key1", "value1"},{"key2", "value2"}]
+  @spec env_kv_to_list(String.t() | nil, keyword() | []) :: {:ok, keyword()} | :error
+  def env_kv_to_list("", _), do: :error
+
+  def env_kv_to_list(env_val, def_list) when is_binary(env_val) do
+    keywords =
+      String.split(env_val, ":")
+      |> Enum.map(
+        &(String.split(&1, "=")
+          |> List.to_tuple())
+      )
+      |> Enum.concat(def_list)
+
+    try do
+      # check if keywords is valid
+      Keyword.values(keywords)
+      {:ok, keywords}
+    rescue
+      _ -> :error
+    end
+  end
+
+  def env_kv_to_list(_, _), do: :error
+end

--- a/server/lib/realtime/webhook_connector.ex
+++ b/server/lib/realtime/webhook_connector.ex
@@ -41,8 +41,11 @@ defmodule Realtime.WebhookConnector do
        when is_binary(endpoint) do
     Logger.debug("Invoking webhook: #{inspect(webhook)}")
 
+    headers = Application.fetch_env!(:realtime, :webhook_headers)
+    Logger.debug("Webhook headers: #{inspect(headers)}")
+
     Task.async(fn ->
-      HTTPoison.post(endpoint, serialized_txn, [{"Content-Type", "application/json"}])
+      HTTPoison.post(endpoint, serialized_txn, headers)
     end)
   end
 

--- a/server/test/helpers_test.exs
+++ b/server/test/helpers_test.exs
@@ -1,0 +1,20 @@
+defmodule Realtime.HelpersTest do
+  use ExUnit.Case
+  alias Realtime.Helpers
+
+  test "env_kv_to_list/1 when env_val is valid" do
+    def_h = [{"key3", "value3"}]
+    env_valid = "key=value1:header2=value2"
+    expect = {:ok, [{"key", "value1"}, {"header2", "value2"}, {"key3", "value3"}]}
+    assert Helpers.env_kv_to_list(env_valid, def_h) === expect
+  end
+
+  test "env_kv_to_list/1 when env_val is not valid" do
+    env_valid = "key=value1:header2value2"
+    assert Helpers.env_kv_to_list(env_valid, []) === :error
+  end
+
+  test "env_kv_to_list/1 when env_val is emtpy" do
+    assert Helpers.env_kv_to_list("", []) === :error
+  end
+end

--- a/server/test/helpers_test.exs
+++ b/server/test/helpers_test.exs
@@ -2,19 +2,48 @@ defmodule Realtime.HelpersTest do
   use ExUnit.Case
   alias Realtime.Helpers
 
-  test "env_kv_to_list/1 when env_val is valid" do
+  test "env_kv_to_list/2 when env_val is valid" do
     def_h = [{"key3", "value3"}]
     env_valid = "key=value1:header2=value2"
     expect = {:ok, [{"header2", "value2"}, {"key", "value1"}, {"key3", "value3"}]}
     assert Helpers.env_kv_to_list(env_valid, def_h) === expect
   end
 
-  test "env_kv_to_list/1 when env_val is not valid" do
+  test "env_kv_to_list/2 when env_val is not valid" do
     env_valid = "key=value1:header2value2"
     assert Helpers.env_kv_to_list(env_valid, []) === :error
   end
 
-  test "env_kv_to_list/1 when env_val is emtpy" do
+  test "env_kv_to_list/2 when env_val is emtpy" do
     assert Helpers.env_kv_to_list("", []) === :error
+  end
+
+  test "parse_kv/2 when string is valid and dafault is map" do
+    expected = %{"key1" => "value1", "key2" => "value2", "key3" => "value3"}
+    parsed = Helpers.parse_kv("key1=value1:key2=value2", %{"key3" => "value3"})
+    assert Map.equal?(expected, parsed)
+  end
+
+  test "parse_kv/2 when dafault is not map" do
+    fun = fn ->
+      Helpers.parse_kv("key1=value1:key2=value2", [{"key3", "value3"}])
+    end
+
+    assert_raise(BadMapError, fun)
+  end
+
+  test "parse_kv/2 when string is empty" do
+    assert Helpers.parse_kv("", %{}) === nil
+  end
+
+  test "parse_kv/2 when string is not valid" do
+    assert Helpers.parse_kv("key1=value1:key2value2", %{}) === nil
+    assert Helpers.parse_kv("key1value1", %{}) === nil
+  end
+
+  test "parse_kv/2 when '=' in value" do
+    expected = %{"key1" => "value_with_=_symbol"}
+    parsed = Helpers.parse_kv("key1=value_with_=_symbol", %{})
+    assert Map.equal?(expected, parsed)
   end
 end

--- a/server/test/helpers_test.exs
+++ b/server/test/helpers_test.exs
@@ -3,18 +3,18 @@ defmodule Realtime.HelpersTest do
   alias Realtime.Helpers
 
   test "env_kv_to_list/1 when env_val is valid" do
-    def_h = [{"key3", "value3"}]
+    def_h = %{"key3" => "value3"}
     env_valid = "key=value1:header2=value2"
-    expect = {:ok, [{"key", "value1"}, {"header2", "value2"}, {"key3", "value3"}]}
+    expect = {:ok, [{"header2", "value2"}, {"key", "value1"}, {"key3", "value3"}]}
     assert Helpers.env_kv_to_list(env_valid, def_h) === expect
   end
 
   test "env_kv_to_list/1 when env_val is not valid" do
     env_valid = "key=value1:header2value2"
-    assert Helpers.env_kv_to_list(env_valid, []) === :error
+    assert Helpers.env_kv_to_list(env_valid, %{}) === :error
   end
 
   test "env_kv_to_list/1 when env_val is emtpy" do
-    assert Helpers.env_kv_to_list("", []) === :error
+    assert Helpers.env_kv_to_list("", %{}) === :error
   end
 end

--- a/server/test/helpers_test.exs
+++ b/server/test/helpers_test.exs
@@ -3,7 +3,7 @@ defmodule Realtime.HelpersTest do
   alias Realtime.Helpers
 
   test "env_kv_to_list/1 when env_val is valid" do
-    def_h = %{"key3" => "value3"}
+    def_h = [{"key3", "value3"}]
     env_valid = "key=value1:header2=value2"
     expect = {:ok, [{"header2", "value2"}, {"key", "value1"}, {"key3", "value3"}]}
     assert Helpers.env_kv_to_list(env_valid, def_h) === expect
@@ -11,10 +11,10 @@ defmodule Realtime.HelpersTest do
 
   test "env_kv_to_list/1 when env_val is not valid" do
     env_valid = "key=value1:header2value2"
-    assert Helpers.env_kv_to_list(env_valid, %{}) === :error
+    assert Helpers.env_kv_to_list(env_valid, []) === :error
   end
 
   test "env_kv_to_list/1 when env_val is emtpy" do
-    assert Helpers.env_kv_to_list("", %{}) === :error
+    assert Helpers.env_kv_to_list("", []) === :error
   end
 end

--- a/server/test/realtime/webhook_connector_test.exs
+++ b/server/test/realtime/webhook_connector_test.exs
@@ -86,7 +86,7 @@ defmodule Realtime.WebhookConnectorTest do
       config: %WebhookEndpoint{}
     }
   ]
-  @request_headers [{"Content-Type", "application/json"}]
+  @request_headers [{"content-type", "application/json"}]
 
   test "notify/1 when webhook POST requests are successful" do
     with_mock HTTPoison,


### PR DESCRIPTION
## What kind of change does this PR introduce?

There are use cases where it needs to add custom headers to Webhook, for example, for authentication. This code implements it through the environment variable `WEBHOOK_HEADERS`. Colon `:` used for split multiple headers.

The `key1=value1:key2=value2` will transform to `[{"key1", "value1"},{"key2", "value2"}]`

## What is the current behavior?
In the current behavior used the only one additional header `[{"content-type", "application/json"}]`

## What is the new behavior?
In new behavior, there is checking the value of `WEBHOOK_HEADERS` variable, and if it's not empty and valid, then it adds to the webhook request. 
If the application has started with `WEBHOOK_HEADERS=key1=value1:key2=value2`, the request on the server part looks like this:
<img width="257" alt="Screenshot 2021-09-09 at 18 54 23" src="https://user-images.githubusercontent.com/1172600/132720110-4dc4dcba-707e-4f97-a5e5-9ba06bf77014.png">


## Additional context
