### PR TITLE
Use X-API-Key header param for authenticating

### DIFF
--- a/server/lib/realtime_web/channels/user_socket.ex
+++ b/server/lib/realtime_web/channels/user_socket.ex
@@ -25,11 +25,32 @@ defmodule RealtimeWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(params, socket) do
-    case Application.fetch_env!(:realtime, :secure_channels)
-         |> authorize_conn(params) do
-      :ok -> {:ok, socket}
-      _ -> :error
+  def connect(params, socket, %{x_headers: headers}) do
+    if Application.fetch_env!(:realtime, :secure_channels) do
+      token = access_token(headers, params)
+      case ChannelsAuthorization.authorize(token) do
+        {:ok, _} -> {:ok, socket}
+        _ -> :error
+      end
+    else
+      {:ok, socket}
+    end
+  end
+
+  @spec access_token([{String.t(), String.t()}], map) :: String.t() | nil
+  def access_token(headers, params) do
+    case :proplists.get_value("x-api-key", headers, nil) do
+      nil ->
+        # WARNING: "token" and "apikey" param keys will be deprecated.
+        # Please use "x-api-key" header param key to pass in auth token.
+        case params do
+          %{"apikey" => token} -> token
+          %{"token" => token} -> token
+          _ -> nil
+        end
+
+      token ->
+        token
     end
   end
 
@@ -44,23 +65,4 @@ defmodule RealtimeWeb.UserSocket do
   #
   # Returning `nil` makes this socket anonymous.
   def id(_socket), do: nil
-
-  defp authorize_conn(true, %{"token" => token}) do
-    # WARNING: "token" param key will be deprecated.
-    # Please use "apikey" param key to pass in auth token.
-    case ChannelsAuthorization.authorize(token) do
-      {:ok, _} -> :ok
-      _ -> :error
-    end
-  end
-
-  defp authorize_conn(true, %{"apikey" => token}) do
-    case ChannelsAuthorization.authorize(token) do
-      {:ok, _} -> :ok
-      _ -> :error
-    end
-  end
-
-  defp authorize_conn(true, _params), do: :error
-  defp authorize_conn(false, _params), do: :ok
 end

--- a/server/lib/realtime_web/endpoint.ex
+++ b/server/lib/realtime_web/endpoint.ex
@@ -2,7 +2,9 @@ defmodule RealtimeWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :realtime
 
   socket "/socket", RealtimeWeb.UserSocket,
-    websocket: true,
+    websocket: [
+      connect_info: [:x_headers]
+    ],
     longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/server/test/realtime_web/channels/user_socket_test.exs
+++ b/server/test/realtime_web/channels/user_socket_test.exs
@@ -9,19 +9,33 @@ defmodule RealtimeWeb.UserSocketTest do
   test "connect/2 when :secure_channels config is false" do
     Application.put_env(:realtime, :secure_channels, false)
 
-    assert {:ok, %Socket{}} = UserSocket.connect(%{}, socket(UserSocket))
+    assert {:ok, %Socket{}} = UserSocket.connect(%{}, socket(UserSocket), %{x_headers: []})
   end
 
   test "connect/2 when :secure_channels config is true and token is authorized" do
-    with_mock ChannelsAuthorization, authorize: fn _token -> {:ok, %{}} end do
+    with_mock ChannelsAuthorization,
+      authorize: fn
+        token when is_binary(token) -> {:ok, %{}}
+        _ -> :error
+      end do
       Application.put_env(:realtime, :secure_channels, true)
 
       # WARNING: "token" param key will be deprecated.
       assert {:ok, %Socket{}} =
-               UserSocket.connect(%{"token" => "auth_token123"}, socket(UserSocket))
+               UserSocket.connect(%{"token" => "auth_token123"}, socket(UserSocket), %{
+                 x_headers: []
+               })
+
+      # WARNING: "apikey" param key will be deprecated.
+      assert {:ok, %Socket{}} =
+               UserSocket.connect(%{"apikey" => "auth_token123"}, socket(UserSocket), %{
+                 x_headers: []
+               })
 
       assert {:ok, %Socket{}} =
-               UserSocket.connect(%{"apikey" => "auth_token123"}, socket(UserSocket))
+               UserSocket.connect(%{}, socket(UserSocket), %{
+                 x_headers: [{"x-api-key", "auth_token123"}]
+               })
     end
   end
 
@@ -29,13 +43,35 @@ defmodule RealtimeWeb.UserSocketTest do
     with_mock ChannelsAuthorization, authorize: fn _token -> {:error, "unauthorized"} end do
       Application.put_env(:realtime, :secure_channels, true)
 
-      assert :error = UserSocket.connect(%{"token" => "bad_token9"}, socket(UserSocket))
+      assert :error =
+               UserSocket.connect(%{"token" => "bad_token9"}, socket(UserSocket), %{x_headers: []})
+
+      assert :error =
+               UserSocket.connect(%{}, socket(UserSocket), %{x_headers: [{"token", "bad_token9"}]})
     end
   end
 
   test "connect/2 when :secure_channels config is true and token is missing" do
     Application.put_env(:realtime, :secure_channels, true)
 
-    assert :error = UserSocket.connect(%{}, socket(UserSocket))
+    assert :error = UserSocket.connect(%{}, socket(UserSocket), %{x_headers: []})
+  end
+
+  test "access_token/2 on different keys" do
+    assert nil == UserSocket.access_token([], %{})
+
+    assert "apikey" ==
+             UserSocket.access_token([{"wrong_x-api-key", "x-api-key"}], %{
+               "token" => "token",
+               "apikey" => "apikey"
+             })
+
+    assert "token" ==
+             UserSocket.access_token([{"wrong_x-api-key", "x-api-key"}], %{
+               "token" => "token",
+               "wrong_apikey" => "apikey"
+             })
+
+    assert "apikey" == UserSocket.access_token([], %{"token" => "token", "apikey" => "apikey"})
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the possibility to get access token from x-api-key request header. 

## What is the current behavior?

The current behavior uses GET parameters "apikey" or "token" for passing token to the `RealtimeWeb.ChannelsAuthorization`.

## What is the new behavior?

The new behavior gets token from `X-API-Key` request header. Also, previous behavior stays for backward compatibility and can be removed in the future.

## Additional context

`Realtime` issue: https://github.com/supabase/realtime/issues/186
`realtime-js` issue: https://github.com/supabase/realtime-js/issues/108
