### PR TITLE
fix: handle incoming access_token message from client

### DIFF
--- a/server/lib/realtime_web/channels/realtime_channel.ex
+++ b/server/lib/realtime_web/channels/realtime_channel.ex
@@ -27,4 +27,8 @@ defmodule RealtimeWeb.RealtimeChannel do
     Realtime.Metrics.SocketMonitor.track_channel(socket)
     {:noreply, socket}
   end
+
+  def handle_in("access_token", _, socket) do
+    {:noreply, socket}
+  end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`access_token` messages are not handled by channel processes.

## What is the new behavior?

`access_token` messages are handled by channel processes until Realtime security (WALRUS) is shipped.

## Additional context

Related PR: https://github.com/supabase/realtime-js/pull/116
