### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A few reasons:
 2. Decoupling. For example, if you want to send a new slack message every time someone makes a new purchase you might build that functionality directly into your API. This allows you to decouple your async functionality from your API.
 3. This is built with Phoenix, an [extremely scalable Elixir framework](https://www.phoenixframework.org/blog/the-road-to-2-million-websocket-connections).
 
-### Does this server guarentee delivery of every data change?
+### Does this server guarantee delivery of every data change?
 
 Not yet! Due to the following limitations:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes incorrect spelling of "guarantee".

## What is the current behavior?

"guarentee", which is not a word.

## What is the new behavior?

"guarantee", which is a word 👍
 
## Additional context

yeet