### PR TITLE
fix: handle filters when column is any type

### DIFF
--- a/server/lib/realtime/subscribers_notification.ex
+++ b/server/lib/realtime/subscribers_notification.ex
@@ -65,10 +65,11 @@ defmodule Realtime.SubscribersNotification do
 
               is_map(record) &&
                 Enum.each(record, fn {k, v} ->
-                  should_notify_column = has_column(event_config, schema, table, k)
-
-                  if is_valid_notification_key(v) and should_notify_column do
-                    "#{table_topic}:#{k}=eq.#{v}"
+                  with true <- is_notification_key_valid(v),
+                       {:ok, stringified_v} <- stringify_value(v),
+                       true <- is_notification_key_length_valid(stringified_v),
+                       true <- has_column(event_config, schema, table, k) do
+                    "#{table_topic}:#{k}=eq.#{stringified_v}"
                     |> broadcast_change(change)
                   end
                 end)
@@ -78,10 +79,11 @@ defmodule Realtime.SubscribersNotification do
 
               is_map(old_record) &&
                 Enum.each(old_record, fn {k, v} ->
-                  should_notify_column = has_column(event_config, schema, table, k)
-
-                  if is_valid_notification_key(v) and should_notify_column do
-                    "#{table_topic}:#{k}=eq.#{v}"
+                  with true <- is_notification_key_valid(v),
+                       {:ok, stringified_v} <- stringify_value(v),
+                       true <- is_notification_key_length_valid(stringified_v),
+                       true <- has_column(event_config, schema, table, k) do
+                    "#{table_topic}:#{k}=eq.#{stringified_v}"
                     |> broadcast_change(change)
                   end
                 end)
@@ -127,7 +129,12 @@ defmodule Realtime.SubscribersNotification do
     Enum.any?(config, fn c -> c.relation in valid_patterns end)
   end
 
-  defp is_valid_notification_key(v) do
-    v != nil and v != :unchanged_toast and String.length(to_string(v)) < 100
+  defp is_notification_key_valid(v) do
+    v != nil and v != :unchanged_toast
   end
+
+  defp stringify_value(v) when is_binary(v), do: {:ok, v}
+  defp stringify_value(v), do: Jason.encode(v)
+
+  defp is_notification_key_length_valid(v), do: String.length(v) < 100
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Column types, such as `json`/`jsonb`, are not properly handled by Realtime filters, resulting in raised errors.

## What is the new behavior?

Column types, such as `json`/`jsonb`, are properly handled.

## Additional context

When subscribing to a `json` column make sure to strip whitespace.

For example, if a `json` column named `details` on `public.test` table has a new insert:

`[{"a": 1}]`

then changes will be received when listening to inserts on topic `realtime:public:details=eq.[{"a":1}]`.