### PR TITLE
Set the maximum number of active connections

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -19,6 +19,7 @@ alias RealtimeWeb.{Endpoint, ErrorView}
 replication_mode = System.get_env("REPLICATION_MODE", "STREAM")
 
 app_port = System.get_env("PORT", "4000") |> String.to_integer()
+max_connections = System.get_env("MAX_CONNECTIONS", "16384") |> String.to_integer()
 db_host = System.get_env("DB_HOST", "localhost")
 db_port = System.get_env("DB_PORT", "5432") |> String.to_integer()
 db_name = System.get_env("DB_NAME", "postgres")
@@ -134,7 +135,10 @@ config :realtime, RLS.Repo,
 # Configures the endpoint
 config :realtime, Endpoint,
   url: [host: "localhost"],
-  http: [port: app_port],
+  http: [
+    port: app_port,
+    transport_options: [max_connections: max_connections]    
+  ],
   render_errors: [view: ErrorView, accepts: ~w(html json)],
   pubsub_server: PubSub,
   secret_key_base: session_secret_key_base


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR allows setting the maximum number of active connections through the Ranch [max_connections](https://ninenines.eu/docs/en/ranch/1.7/manual/ranch/) parameter.

## What is the current behavior?

In current behavior, `Plug.Cowboy` uses the default [16_384](https://github.com/elixir-plug/plug_cowboy/blob/040c53f45bdbd3f1afe9f449fa1cb3b54294e7fb/lib/plug/cowboy.ex#L45) value.

## What is the new behavior?

In new behavior, it's possible to set any maximum number of active connections if start Realtime with environment variable MAX_CONNECTIONS. Soft limit.
By default, it uses 16_384 as earlier.

## Additional context
