### PR TITLE
fix: remove setting search path before replication

### DIFF
--- a/server/lib/realtime/rls/replication_poller.ex
+++ b/server/lib/realtime/rls/replication_poller.ex
@@ -49,7 +49,7 @@ defmodule Realtime.RLS.ReplicationPoller do
       :error, error -> {:error, error}
     end
     |> case do
-      {:ok, %{create_slot: ^slot_name, search_path: :set}} ->
+      {:ok, ^slot_name} ->
         send(self(), :poll)
         {:noreply, state}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Postgres error when calling a Postgres function containing non-schema-qualified table name (e.g. referencing `test` instead of `public.test`) inside a RLS policy because `search_path` is set to `''`

## What is the new behavior?

Realtime RLS works when calling a Postgres function containing non-schema-qualified table name (e.g. referencing `test` instead of `public.test`) inside a RLS policy. This is resolved by removing setting `search_path` to `''`.

## Additional context

Related issues:

- [realtime only emitting DELETE events (no INSERT or UPDATE) #213](https://github.com/supabase/realtime/issues/213)
- [Realtime broken when policy use custom SQL functions #4683](https://github.com/supabase/supabase/issues/4683)

Related PR:

- https://github.com/supabase/walrus/pull/35
