### PR TITLE
chore: add db queue_target param

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -122,6 +122,7 @@ config :realtime, RLS.Repo,
   port: db_port,
   pool_size: 1,
   ssl: db_ssl,
+  queue_target: 5_000,
   socket_options: [db_ip_version],
   parameters: [
     application_name: "realtime_rls",

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -114,6 +114,7 @@ config :realtime, RLS.Repo,
   port: db_port,
   pool_size: 1,
   ssl: db_ssl,
+  queue_target: 5_000,
   socket_options: [db_ip_version],
   parameters: [
     application_name: "realtime_rls",


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

add `queue_target` to help out longer transactions when database under heavy load.

## Additional context

see: https://elixirforum.com/t/ecto-query-timeout/27946/6
