### PR TITLE
fix: default pg_logical_slot_get_changes upto_nchanges to 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ DB_RECONNECT_BACKOFF_MIN   # {number} Specify the minimum amount of time to wait
 DB_RECONNECT_BACKOFF_MAX   # {number} Specify the maximum amount of time to wait before reconnecting to database. Defaults to 120000 (milliseconds).
 REPLICATION_POLL_INTERVAL  # {number} Specify how often Realtime RLS should poll the replication slot for changes. Defaults to 300 (milliseconds).
 SUBSCRIPTION_SYNC_INTERVAL # {number} Specify how often Realtime RLS should confirm connected subscribers and the tables they're listening to. Defaults to 60000 (milliseconds).
+MAX_CHANGES                # {number} Soft limit for the number of database changes to fetch per replication poll. Notice: set to a smaller value as database changes grow in frequency and/or size.
 MAX_RECORD_BYTES           # {number} Controls the maximum size of a WAL record. When the size of the record exceeds max_record_bytes the record and old_record, if applicable, keys are set as empty objects and the errors output array will contain the string "Error 413: Payload Too Large". Defaults to 1048576 (bytes), which is 1MB.
 ```
 

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -81,6 +81,9 @@ db_reconnect_backoff_max = System.get_env("DB_RECONNECT_BACKOFF_MAX", "120000") 
 replication_poll_interval = System.get_env("REPLICATION_POLL_INTERVAL", "300") |> String.to_integer()
 subscription_sync_interval = System.get_env("SUBSCRIPTION_SYNC_INTERVAL", "60000") |> String.to_integer()
 
+# max_changes (default 100): Soft limit for the number of database changes to fetch per replication poll
+max_changes = System.get_env("MAX_CHANGES", "100") |> String.to_integer()
+
 # max_record_bytes (default 1MB): Controls the maximum size of a WAL record that will be
 # emitted with complete record and old_record data. When the size of the wal2json record
 # exceeds max_record_bytes the record and old_record keys are set as empty objects {} and
@@ -109,6 +112,7 @@ config :realtime,
   webhook_headers: webhook_headers,
   replication_poll_interval: replication_poll_interval,
   subscription_sync_interval: subscription_sync_interval,
+  max_changes: max_changes,
   max_record_bytes: max_record_bytes
 
 config :realtime,
@@ -138,7 +142,7 @@ config :realtime, Endpoint,
   url: [host: "localhost"],
   http: [
     port: app_port,
-    transport_options: [max_connections: max_connections]    
+    transport_options: [max_connections: max_connections]
   ],
   render_errors: [view: ErrorView, accepts: ~w(html json)],
   pubsub_server: PubSub,

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -73,6 +73,9 @@ db_reconnect_backoff_max = System.get_env("DB_RECONNECT_BACKOFF_MAX", "120000") 
 replication_poll_interval = System.get_env("REPLICATION_POLL_INTERVAL", "300") |> String.to_integer()
 subscription_sync_interval = System.get_env("SUBSCRIPTION_SYNC_INTERVAL", "60000") |> String.to_integer()
 
+# max_changes (default 100): Soft limit for the number of database changes to fetch per replication poll
+max_changes = System.get_env("MAX_CHANGES", "100") |> String.to_integer()
+
 # max_record_bytes (default 1MB): Controls the maximum size of a WAL record that will be
 # emitted with complete record and old_record data. When the size of the wal2json record
 # exceeds max_record_bytes the record and old_record keys are set as empty objects {} and
@@ -101,6 +104,7 @@ config :realtime,
   webhook_headers: webhook_headers,
   replication_poll_interval: replication_poll_interval,
   subscription_sync_interval: subscription_sync_interval,
+  max_changes: max_changes,
   max_record_bytes: max_record_bytes
 
 config :realtime,

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -94,6 +94,7 @@ defmodule Realtime.Application do
               publication: publication,
               slot_name: slot_name,
               temporary_slot: Application.fetch_env!(:realtime, :temporary_slot),
+              max_changes: Application.fetch_env!(:realtime, :max_changes),
               max_record_bytes: Application.fetch_env!(:realtime, :max_record_bytes)
             }
           ]

--- a/server/lib/realtime/rls/replication_poller.ex
+++ b/server/lib/realtime/rls/replication_poller.ex
@@ -32,6 +32,7 @@ defmodule Realtime.RLS.ReplicationPoller do
       publication: Keyword.fetch!(opts, :publication),
       slot_name: Keyword.fetch!(opts, :slot_name),
       temporary_slot: Keyword.fetch!(opts, :temporary_slot),
+      max_changes: Keyword.fetch!(opts, :max_changes),
       max_record_bytes: Keyword.fetch!(opts, :max_record_bytes)
     }
 
@@ -74,13 +75,14 @@ defmodule Realtime.RLS.ReplicationPoller do
           poll_ref: poll_ref,
           publication: publication,
           slot_name: slot_name,
+          max_changes: max_changes,
           max_record_bytes: max_record_bytes
         } = state
       ) do
     Process.cancel_timer(poll_ref)
 
     try do
-      Replications.list_changes(slot_name, publication, max_record_bytes)
+      Replications.list_changes(slot_name, publication, max_changes, max_record_bytes)
     catch
       :error, error -> {:error, error}
     end

--- a/server/lib/realtime/rls/replications.ex
+++ b/server/lib/realtime/rls/replications.ex
@@ -26,7 +26,7 @@ defmodule Realtime.RLS.Replications do
     end
   end
 
-  def list_changes(slot_name, publication, max_record_bytes) do
+  def list_changes(slot_name, publication, max_changes, max_record_bytes) do
     query(
       "with pub as (
         select
@@ -59,7 +59,7 @@ defmodule Realtime.RLS.Replications do
         from
           pub,
           pg_logical_slot_get_changes(
-            $2, null, null,
+            $2, null, $3,
             'include-pk', '1',
             'include-transaction', 'false',
             'include-timestamp', 'true',
@@ -78,7 +78,7 @@ defmodule Realtime.RLS.Replications do
         w2j,
         realtime.apply_rls(
           wal := w2j.data::jsonb,
-          max_record_bytes := $3
+          max_record_bytes := $4
         ) xyz(wal, is_rls_enabled, subscription_ids, errors)
       where
         w2j.w2j_add_tables <> ''
@@ -86,6 +86,7 @@ defmodule Realtime.RLS.Replications do
       [
         publication,
         slot_name,
+        max_changes,
         max_record_bytes
       ]
     )

--- a/server/lib/realtime_web/channels/realtime_channel.ex
+++ b/server/lib/realtime_web/channels/realtime_channel.ex
@@ -19,10 +19,11 @@ defmodule RealtimeWeb.RealtimeChannel do
         params,
         %Socket{channel_pid: channel_pid, assigns: %{access_token: access_token}} = socket
       ) do
-    token = case params do
-      %{"user_token" => token} -> token
-      _ -> access_token
-    end
+    token =
+      case params do
+        %{"user_token" => token} -> token
+        _ -> access_token
+      end
 
     with {:ok, %{"role" => role} = claims} <- ChannelsAuthorization.authorize(token),
          bin_id <- Ecto.UUID.bingenerate(),

--- a/server/test/realtime/rls_replications_test.exs
+++ b/server/test/realtime/rls_replications_test.exs
@@ -5,6 +5,7 @@ defmodule Realtime.RlsReplicationsTest do
 
   @slot_name "test_realtime_slot_name"
   @publication_name "supabase_realtime_test"
+  @max_changes 10
   @max_record_bytes 1_048_576
 
   setup_all do
@@ -43,7 +44,7 @@ defmodule Realtime.RlsReplicationsTest do
 
   test "list_changes/2, empty response" do
     prepare_replication(@slot_name, false)
-    {:ok, res} = list_changes(@slot_name, @publication_name, @max_record_bytes)
+    {:ok, res} = list_changes(@slot_name, @publication_name, @max_changes, @max_record_bytes)
 
     res2 =
       Enum.filter(res.rows, fn
@@ -61,7 +62,7 @@ defmodule Realtime.RlsReplicationsTest do
     Process.sleep(500)
 
     {:ok, %{rows: [[record, _, _, _]]}} =
-      list_changes(@slot_name, @publication_name, @max_record_bytes)
+      list_changes(@slot_name, @publication_name, @max_changes, @max_record_bytes)
 
     columns = [
       %{"name" => "id", "type" => "int8"},
@@ -84,7 +85,7 @@ defmodule Realtime.RlsReplicationsTest do
     Process.sleep(500)
 
     {:ok, %{rows: [_, [record, _, _, errors]]}} =
-      list_changes(@slot_name, @publication_name, @max_record_bytes)
+      list_changes(@slot_name, @publication_name, @max_changes, @max_record_bytes)
 
     columns = [
       %{"name" => "id", "type" => "int8"},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

polling query waits to end of WAL to return response and can seconds, minutes, etc. to return response depending on frequency and size of database changes.

## What is the new behavior?

polling query returns response after grabbing 100 (default) changes.
