### PR TITLE
fix: prevent duplicate broadcast when multiple roles are subscribed

### DIFF
--- a/server/lib/adapters/changes.ex
+++ b/server/lib/adapters/changes.ex
@@ -7,7 +7,7 @@ defmodule Realtime.Adapters.Changes do
   defmodule(Transaction, do: defstruct([:changes, :commit_timestamp]))
 
   defmodule NewRecord do
-    @derive {Jason.Encoder, except: [:is_rls_enabled, :subscription_ids]}
+    @derive {Jason.Encoder, except: [:subscription_ids]}
     defstruct [
       :columns,
       :commit_timestamp,
@@ -16,13 +16,12 @@ defmodule Realtime.Adapters.Changes do
       :table,
       :record,
       :subscription_ids,
-      :type,
-      is_rls_enabled: true
+      :type
     ]
   end
 
   defmodule UpdatedRecord do
-    @derive {Jason.Encoder, except: [:is_rls_enabled, :subscription_ids]}
+    @derive {Jason.Encoder, except: [:subscription_ids]}
     defstruct [
       :columns,
       :commit_timestamp,
@@ -32,13 +31,12 @@ defmodule Realtime.Adapters.Changes do
       :old_record,
       :record,
       :subscription_ids,
-      :type,
-      is_rls_enabled: true
+      :type
     ]
   end
 
   defmodule DeletedRecord do
-    @derive {Jason.Encoder, except: [:is_rls_enabled, :subscription_ids]}
+    @derive {Jason.Encoder, except: [:subscription_ids]}
     defstruct [
       :columns,
       :commit_timestamp,
@@ -47,8 +45,7 @@ defmodule Realtime.Adapters.Changes do
       :table,
       :old_record,
       :subscription_ids,
-      :type,
-      is_rls_enabled: true
+      :type
     ]
   end
 

--- a/server/lib/realtime/replication.ex
+++ b/server/lib/realtime/replication.ex
@@ -128,8 +128,7 @@ defmodule Realtime.Replication do
           table: name,
           columns: columns,
           record: data,
-          commit_timestamp: commit_timestamp,
-          is_rls_enabled: false
+          commit_timestamp: commit_timestamp
         }
 
         %State{state | transaction: {lsn, %{txn | changes: [new_record | changes]}}}
@@ -163,8 +162,7 @@ defmodule Realtime.Replication do
           columns: columns,
           old_record: old_data,
           record: data,
-          commit_timestamp: commit_timestamp,
-          is_rls_enabled: false
+          commit_timestamp: commit_timestamp
         }
 
         %State{
@@ -199,8 +197,7 @@ defmodule Realtime.Replication do
           table: name,
           columns: columns,
           old_record: data,
-          commit_timestamp: commit_timestamp,
-          is_rls_enabled: false
+          commit_timestamp: commit_timestamp
         }
 
         %State{state | transaction: {lsn, %{txn | changes: [deleted_record | changes]}}}

--- a/server/lib/realtime/rls/replication_poller.ex
+++ b/server/lib/realtime/rls/replication_poller.ex
@@ -140,16 +140,15 @@ defmodule Realtime.RLS.ReplicationPoller do
            "schema" => schema,
            "table" => table
          } = wal},
-        {"is_rls_enabled", is_rls_enabled},
+        {"is_rls_enabled", _},
         {"subscription_ids", subscription_ids},
         {"errors", errors}
       ])
-      when is_boolean(is_rls_enabled) and is_list(subscription_ids) do
+      when is_list(subscription_ids) do
     %NewRecord{
       columns: Map.get(wal, "columns", []),
       commit_timestamp: Map.get(wal, "commit_timestamp"),
       errors: convert_errors(errors),
-      is_rls_enabled: is_rls_enabled,
       schema: schema,
       table: table,
       type: type,
@@ -165,16 +164,15 @@ defmodule Realtime.RLS.ReplicationPoller do
            "schema" => schema,
            "table" => table
          } = wal},
-        {"is_rls_enabled", is_rls_enabled},
+        {"is_rls_enabled", _},
         {"subscription_ids", subscription_ids},
         {"errors", errors}
       ])
-      when is_boolean(is_rls_enabled) and is_list(subscription_ids) do
+      when is_list(subscription_ids) do
     %UpdatedRecord{
       columns: Map.get(wal, "columns", []),
       commit_timestamp: Map.get(wal, "commit_timestamp"),
       errors: convert_errors(errors),
-      is_rls_enabled: is_rls_enabled,
       schema: schema,
       table: table,
       type: type,
@@ -191,16 +189,15 @@ defmodule Realtime.RLS.ReplicationPoller do
            "schema" => schema,
            "table" => table
          } = wal},
-        {"is_rls_enabled", is_rls_enabled},
+        {"is_rls_enabled", _},
         {"subscription_ids", subscription_ids},
         {"errors", errors}
       ])
-      when is_boolean(is_rls_enabled) and is_list(subscription_ids) do
+      when is_list(subscription_ids) do
     %DeletedRecord{
       columns: Map.get(wal, "columns", []),
       commit_timestamp: Map.get(wal, "commit_timestamp"),
       errors: convert_errors(errors),
-      is_rls_enabled: is_rls_enabled,
       schema: schema,
       table: table,
       type: type,

--- a/server/test/realtime/message_dispatcher_test.exs
+++ b/server/test/realtime/message_dispatcher_test.exs
@@ -1,19 +1,27 @@
 defmodule Realtime.MessageDispatcherTest do
   use ExUnit.Case
   import Realtime.MessageDispatcher
+  alias Phoenix.Socket.Broadcast
   alias Phoenix.Socket.V1.JSONSerializer
+  alias Realtime.Adapters.Changes.NewRecord
 
   @subscription_id <<187, 181, 30, 78, 243, 113, 68, 99, 191, 10, 175, 143, 86, 220, 154, 115>>
 
-  test "dispatch/3 for subscriber_fastlane when rls disabled and no subscription_ids" do
-    msg = msg(false, [])
-    dispatch([{self(), {:subscriber_fastlane, self(), JSONSerializer, ""}}], self(), msg)
+  test "dispatch/3 for subscriber_fastlane when subscription_ids is empty" do
+    msg = msg([])
+
+    dispatch(
+      [{self(), {:subscriber_fastlane, self(), JSONSerializer, @subscription_id}}],
+      self(),
+      msg
+    )
+
     expected = JSONSerializer.fastlane!(msg)
-    assert_received ^expected
+    refute_received ^expected
   end
 
-  test "dispatch/3 for subscriber_fastlane when rls enabled and subscription_id in subscription_ids" do
-    msg = msg(true, MapSet.new([@subscription_id]))
+  test "dispatch/3 for subscriber_fastlane when subscription_id in subscription_ids" do
+    msg = msg(MapSet.new([@subscription_id]))
 
     dispatch(
       [{self(), {:subscriber_fastlane, self(), JSONSerializer, @subscription_id}}],
@@ -25,55 +33,44 @@ defmodule Realtime.MessageDispatcherTest do
     assert_received ^expected
   end
 
-  test "dispatch/3 for subscriber_fastlane when rls enabled and subscription_id not in subscription_ids" do
-    msg = msg(true, MapSet.new([@subscription_id]))
+  test "dispatch/3 for subscriber_fastlane when subscription_id not in subscription_ids" do
+    msg = msg(MapSet.new([@subscription_id]))
+
+    other_subscription_id =
+      <<160, 66, 132, 13, 21, 219, 69, 221, 164, 160, 40, 72, 156, 208, 114, 4>>
 
     dispatch(
-      [{self(), {:subscriber_fastlane, self(), JSONSerializer, "wrong_subscription_id"}}],
+      [{self(), {:subscriber_fastlane, self(), JSONSerializer, other_subscription_id}}],
       self(),
       msg
     )
 
     expected = JSONSerializer.fastlane!(msg)
-    refute_receive ^expected
+    refute_received ^expected
   end
 
-  test "dispatch/3 for fastlane when rls enabled" do
-    msg = msg(true, [])
-    dispatch([{self(), {:fastlane, self(), JSONSerializer, ""}}], self(), msg)
-    expected = JSONSerializer.fastlane!(msg)
-    refute_receive ^expected
-  end
-
-  test "dispatch/3 for fastlane when rls disabled" do
-    msg = msg(false, [])
-    dispatch([{self(), {:fastlane, self(), JSONSerializer, ""}}], self(), msg)
-    expected = JSONSerializer.fastlane!(msg)
-    assert_received ^expected
-  end
-
-  @spec msg(atom, list) :: map()
-  defp msg(rls, subscription_ids) do
-    %Phoenix.Socket.Broadcast{
+  @spec msg(list) :: map()
+  defp msg(subscription_ids) do
+    %Broadcast{
       event: "INSERT",
-      payload: %Realtime.Adapters.Changes.NewRecord{
+      payload: %NewRecord{
         columns: [
           %{"name" => "id", "type" => "int8"},
           %{"name" => "details", "type" => "text"},
           %{"name" => "user_id", "type" => "int8"}
         ],
         commit_timestamp: "2021-11-05T09:45:40.512962+00:00",
-        is_rls_enabled: rls,
+        errors: nil,
+        schema: "public",
+        table: "todos",
         record: %{
           "details" =>
             "programming the interface won't do anything, we need to quantify the primary SMS feed!",
           "id" => 32,
           "user_id" => 1
         },
-        schema: "public",
-        table: "todos",
-        type: "INSERT",
-        subscription_ids: subscription_ids
+        subscription_ids: MapSet.new(subscription_ids),
+        type: "INSERT"
       },
       topic: "realtime:public:todos"
     }

--- a/server/test/realtime/replication_poller_test.exs
+++ b/server/test/realtime/replication_poller_test.exs
@@ -38,7 +38,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %NewRecord{
       columns: @columns,
       commit_timestamp: @ts,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "INSERT",
@@ -70,7 +69,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %UpdatedRecord{
       columns: @columns,
       commit_timestamp: @ts,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "UPDATE",
@@ -102,7 +100,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %DeletedRecord{
       columns: @columns,
       commit_timestamp: @ts,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "DELETE",
@@ -133,7 +130,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %NewRecord{
       columns: @columns,
       commit_timestamp: @ts,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "INSERT",
@@ -161,7 +157,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %NewRecord{
       columns: [],
       commit_timestamp: nil,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "INSERT",
@@ -193,7 +188,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %UpdatedRecord{
       columns: @columns,
       commit_timestamp: @ts,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "UPDATE",
@@ -222,7 +216,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %UpdatedRecord{
       columns: [],
       commit_timestamp: nil,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "UPDATE",
@@ -254,7 +247,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %DeletedRecord{
       columns: @columns,
       commit_timestamp: @ts,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "DELETE",
@@ -282,7 +274,6 @@ defmodule Realtime.ReplicationPollerTest do
     expected = %DeletedRecord{
       columns: [],
       commit_timestamp: nil,
-      is_rls_enabled: false,
       schema: "public",
       table: "todos",
       type: "DELETE",

--- a/server/test/realtime/replication_test.exs
+++ b/server/test/realtime/replication_test.exs
@@ -406,8 +406,7 @@ defmodule Realtime.ReplicationTest do
                      },
                      schema: "public",
                      table: "todos",
-                     type: "INSERT",
-                     is_rls_enabled: false
+                     type: "INSERT"
                    },
                    %NewRecord{
                      columns: @test_columns,
@@ -421,8 +420,7 @@ defmodule Realtime.ReplicationTest do
                      },
                      schema: "public",
                      table: "todos",
-                     type: "INSERT",
-                     is_rls_enabled: false
+                     type: "INSERT"
                    }
                  ]
                })

--- a/server/test/realtime/subscribers_notification_test.exs
+++ b/server/test/realtime/subscribers_notification_test.exs
@@ -521,8 +521,7 @@ defmodule Realtime.SubscribersNotificationTest do
         },
         schema: "public",
         table: "users",
-        type: "INSERT",
-        is_rls_enabled: false
+        type: "INSERT"
       }
 
       valid_notification_record_id_value = %NewRecord{
@@ -535,8 +534,7 @@ defmodule Realtime.SubscribersNotificationTest do
         },
         schema: "public",
         table: "users",
-        type: "INSERT",
-        is_rls_enabled: false
+        type: "INSERT"
       }
 
       txn = %Transaction{

--- a/server/test/realtime_web/channels/realtime_channel_test.exs
+++ b/server/test/realtime_web/channels/realtime_channel_test.exs
@@ -21,38 +21,38 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     end
   end
 
-  test "INSERT message is pushed to the client" do
+  test "INSERT message is pushed to the client", %{socket: %{assigns: %{id: id}}} do
     change = %{
       schema: "public",
       table: "users",
       type: "INSERT"
     }
 
-    broadcast_change("realtime:*", change)
+    broadcast_change("realtime:*", Map.put(change, :subscription_ids, MapSet.new([id])))
 
     assert_push("INSERT", ^change)
   end
 
-  test "UPDATE message is pushed to the client" do
+  test "UPDATE message is pushed to the client", %{socket: %{assigns: %{id: id}}} do
     change = %{
       schema: "public",
       table: "users",
       type: "UPDATE"
     }
 
-    broadcast_change("realtime:*", change)
+    broadcast_change("realtime:*", Map.put(change, :subscription_ids, MapSet.new([id])))
 
     assert_push("UPDATE", ^change)
   end
 
-  test "DELETE message is pushed to the client" do
+  test "DELETE message is pushed to the client", %{socket: %{assigns: %{id: id}}} do
     change = %{
       schema: "public",
       table: "users",
       type: "DELETE"
     }
 
-    broadcast_change("realtime:*", change)
+    broadcast_change("realtime:*", Map.put(change, :subscription_ids, MapSet.new([id])))
 
     assert_push("DELETE", ^change)
   end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When RLS is disabled for a table and there are multiple database roles subscribed to Realtime (e.g. one `anon` user and `authenticated` user) then clients will receive duplicate messages for the same change.

## What is the new behavior?

Clients will receive a single message for the same change regardless of which database roles are subscribed.

## Additional context

Related issue: https://github.com/supabase/realtime/issues/236
