### PR TITLE
Add runtime debug logging ability

### DIFF
--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -35,16 +35,16 @@ defmodule Realtime.Application do
 
     replication_mode = Application.fetch_env!(:realtime, :replication_mode)
 
-    # When UNSAFE_ALL_DEBUG_LOGS is set, we show log-level of debug.
+    # When UNSAFE_SHOW_DEBUG_LOGS is set, we show log-level of debug.
     # This is marked unsafe, because it should not be used in production,
     # and is not generally guaranteed that DEBUG-level logs will be performant.
     unsafe_all_debug_logs =
       System.get_env(
-        "UNSAFE_ALL_DEBUG_LOGS",
+        "UNSAFE_SHOW_DEBUG_LOGS",
         nil
       )
     if unsafe_all_debug_logs do
-      Logger.info("UNSAFE_ALL_DEBUG_LOGS was set. Debug-level logs will be shown.")
+      Logger.info("UNSAFE_SHOW_DEBUG_LOGS was set. Debug-level logs will be shown.")
       Logger.configure(level: :debug)
     end
 

--- a/server/lib/realtime/application.ex
+++ b/server/lib/realtime/application.ex
@@ -35,6 +35,20 @@ defmodule Realtime.Application do
 
     replication_mode = Application.fetch_env!(:realtime, :replication_mode)
 
+    # When UNSAFE_ALL_DEBUG_LOGS is set, we show log-level of debug.
+    # This is marked unsafe, because it should not be used in production,
+    # and is not generally guaranteed that DEBUG-level logs will be performant.
+    unsafe_all_debug_logs =
+      System.get_env(
+        "UNSAFE_ALL_DEBUG_LOGS",
+        nil
+      )
+    if unsafe_all_debug_logs do
+      Logger.info("UNSAFE_ALL_DEBUG_LOGS was set. Debug-level logs will be shown.")
+      Logger.configure(level: :debug)
+    end
+
+
     replication_children =
       case replication_mode do
         "STREAM" ->


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds `UNSAFE_SHOW_DEBUG_LOGS` environment variable, which allows for easier debugging of the built Realtime container.

## What is the current behavior?

Currently, the default log-level is info -- but in certain circumstances it is helpful to be able to override the log-level with verbosity.
