### PR TITLE
Config file name should be .env.local

### DIFF
--- a/examples/next-js/README.md
+++ b/examples/next-js/README.md
@@ -6,7 +6,7 @@ A simple Next.js example which listens to database changes.
 
 1. Install dependencies with `npm install`
 2. Spin up database and Realtime server with `docker-compose -f docker-compose.dev.yml up` or `docker-compose -f docker-compose.rls.dev.yml up` in Realtime's root directory
-3. Add *.env* file in Next.js example directory with the following DB config env vars:
+3. Add `.env.local` file in Next.js example directory with the following DB config env vars:
     * DB_HOST=localhost
     * DB_PORT=5432
     * DB_NAME=postgres


### PR DESCRIPTION
Point .3 in `examples/next-js/README.md` mentions creating `.env` file which does not work. Should be `.env.local`

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

API requests from nextjs client fail because environment variables are not set (because README says to create `.env` which does not get detected when running `npm run dev`)

## What is the new behavior?

Works (environment variables are read from correct file `.env.local`
