### PR TITLE
feat: enable IP version specification for realtime app

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ REPLICATION_MODE           # {string}      (options: 'STREAM'/'RLS') Spin up ser
 SLOT_NAME                  # {string}      A unique name for Postgres to track where this server has "listened until". If the server dies, it can pick up from the last position. This should be lowercase.
 TEMPORARY_SLOT             # {string}      (options: 'true'/'false') Start logical replication slot as either temporary or permanent.
 PORT                       # {number}      Port which you can connect your client/listeners
+REALTIME_IP_VERSION        # {string}      (options: 'IPv4'/'IPv6') Bind realtime via either IPv4 or IPv6. (default: IPv6)
 PUBLICATIONS               # {string} JSON encoded array of publication names. Realtime RLS currently accepts one publication.
 SECURE_CHANNELS            # {string}      (options: 'true'/'false') Enable/Disable channels authorization via JWT verification.
 JWT_SECRET                 # {string}      HS algorithm octet key (e.g. "95x0oR8jq9unl9pOIx"). Only required if SECURE_CHANNELS is set to true.
@@ -281,6 +282,7 @@ DB_IP_VERSION           # {string}      (options: 'IPv4'/'IPv6') Connect to data
 REPLICATION_MODE        # {string}      (options: 'STREAM'/'RLS') Spin up server as Realtime or Realtime RLS. Defaults to 'STREAM'.
 SLOT_NAME               # {string}      A unique name for Postgres to track where this server has "listened until". If the server dies, it can pick up from the last position. This should be lowercase. If not provided then Realtime is started with a temporary slot.
 PORT                    # {number}      Port which you can connect your client/listeners
+REALTIME_IP_VERSION     # {string}      (options: 'IPv4'/'IPv6') Bind realtime via either IPv4 or IPv6. (default: IPv6)
 PUBLICATIONS            # {string} JSON encoded array of publication names
 SECURE_CHANNELS         # {string}      (options: 'true'/'false') Enable/Disable channels authorization via JWT verification.
 JWT_SECRET              # {string}      HS algorithm octet key (e.g. "95x0oR8jq9unl9pOIx"). Only required if SECURE_CHANNELS is set to true.
@@ -304,6 +306,7 @@ docker run                                                       \
   -e REPLICATION_MODE='STREAM'                                   \
   -e SLOT_NAME='supabase_realtime'                               \
   -e PORT=4000                                                   \
+  -e REALTIME_IP_VERSION='IPv6'                                  \
   -e PUBLICATIONS="[\"supabase_realtime\"]"                      \
   -e SECURE_CHANNELS='true'                                      \
   -e JWT_SECRET='SOMETHING_SUPER_SECRET'                         \

--- a/server/config/releases.exs
+++ b/server/config/releases.exs
@@ -61,6 +61,14 @@ db_ip_version =
     :inet
   )
 
+# Bind Realtime via specified IP version. Options are either "IPv4" or "Ipv6"
+realtime_ip_version =
+  Map.get(
+    %{"ipv4" => :inet, "ipv6" => :inet6},
+    System.get_env("REALTIME_IP_VERSION", "IPv6") |> String.downcase(),
+    :inet6
+  )
+
 # Expose Prometheus metrics
 # Defaults to true in development and false in production
 expose_metrics = System.get_env("EXPOSE_METRICS", "false") == "true"
@@ -136,7 +144,7 @@ config :realtime, RLS.Repo,
   log: false
 
 config :realtime, Endpoint,
-  http: [:inet6, port: app_port],
+  http: [realtime_ip_version, port: app_port],
   pubsub_server: PubSub,
   secret_key_base: session_secret_key_base
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Machine which does not support IPv6 can't run realtime due to there is no options for this.

## What is the new behavior?

User can specify IP version for realtime app.
Default behavior does not change.

## Additional context

I'm new to supabase, and does not have any experience on Elixir and Phoenix.
Is there any possible issue when realtime is binded to IPv4?
