### PR TITLE
fix: add quoted regtype support and output when payload too large

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   db:
-    image: supabase/postgres:13.3.0
+    image: supabase/postgres:14.1.0.34
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - db
   db:
-    image: supabase/postgres:13.3.0
+    image: supabase/postgres:14.1.0.34
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.rls.dev.yml
+++ b/docker-compose.rls.dev.yml
@@ -25,7 +25,7 @@ services:
       bash -c "./prod/rel/realtime/bin/realtime eval Realtime.Release.migrate
       && ./prod/rel/realtime/bin/realtime start"
   db:
-    image: supabase/postgres:13.3.0
+    image: supabase/postgres:14.1.0.34
     ports:
       - 5432:5432
     volumes:

--- a/server/lib/realtime/rls/replications.ex
+++ b/server/lib/realtime/rls/replications.ex
@@ -60,10 +60,10 @@ defmodule Realtime.RLS.Replications do
           pub,
           pg_logical_slot_get_changes(
             $2, null, $3,
-            'include-pk', '1',
+            'include-pk', 'true',
             'include-transaction', 'false',
             'include-timestamp', 'true',
-            'write-in-chunks', 'true',
+            'include-type-oids', 'true',
             'format-version', '2',
             'actions', pub.w2j_actions,
             'add-tables', pub.w2j_add_tables

--- a/server/priv/repo/migrations/20220603231003_add_quoted_regtypes_support.exs
+++ b/server/priv/repo/migrations/20220603231003_add_quoted_regtypes_support.exs
@@ -2,11 +2,17 @@ defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesSupport do
   use Ecto.Migration
 
   def change do
+    execute("drop type if exists realtime.wal_column cascade;")
+
     execute("
-      alter type realtime.wal_column
-      add attribute type_oid oid cascade,
-      drop attribute if exists type cascade,
-      add attribute type_name text cascade;
+      create type realtime.wal_column as (
+        name text,
+        type_name text,
+        type_oid oid,
+        value jsonb,
+        is_pkey boolean,
+        is_selectable boolean
+      );
     ")
 
     execute("

--- a/server/priv/repo/migrations/20220603231003_add_quoted_regtypes_support.exs
+++ b/server/priv/repo/migrations/20220603231003_add_quoted_regtypes_support.exs
@@ -1,0 +1,291 @@
+defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesSupport do
+  use Ecto.Migration
+
+  def change do
+    execute("
+      alter type realtime.wal_column
+      add attribute type_oid oid cascade,
+      drop attribute if exists type cascade,
+      add attribute type_name text cascade;
+    ")
+
+    execute("
+      create or replace function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
+          returns bool
+          language sql
+          immutable
+      as $$
+      /*
+      Should the record be visible (true) or filtered out (false) after *filters* are applied
+      */
+          select
+              -- Default to allowed when no filters present
+              coalesce(
+                  sum(
+                      realtime.check_equality_op(
+                          op:=f.op,
+                          type_:=col.type_oid::regtype,
+                          -- cast jsonb to text
+                          val_1:=col.value #>> '{}',
+                          val_2:=f.value
+                      )::int
+                  ) = count(1),
+                  true
+              )
+          from
+              unnest(filters) f
+              join unnest(columns) col
+                  on f.column_name = col.name;
+      $$;")
+
+    execute("
+        create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+            returns setof realtime.wal_rls
+            language plpgsql
+            volatile
+        as $$
+        declare
+            -- Regclass of the table e.g. public.notes
+            entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
+            -- I, U, D, T: insert, update ...
+            action realtime.action = (
+                case wal ->> 'action'
+                    when 'I' then 'INSERT'
+                    when 'U' then 'UPDATE'
+                    when 'D' then 'DELETE'
+                    else 'ERROR'
+                end
+            );
+            -- Is row level security enabled for the table
+            is_rls_enabled bool = relrowsecurity from pg_class where oid = entity_;
+            subscriptions realtime.subscription[] = array_agg(subs)
+                from
+                    realtime.subscription subs
+                where
+                    subs.entity = entity_;
+            -- Subscription vars
+            roles regrole[] = array_agg(distinct us.claims_role)
+                from
+                    unnest(subscriptions) us;
+            working_role regrole;
+            claimed_role regrole;
+            claims jsonb;
+            subscription_id uuid;
+            subscription_has_access bool;
+            visible_to_subscription_ids uuid[] = '{}';
+            -- structured info for wal's columns
+            columns realtime.wal_column[];
+            -- previous identity values for update/delete
+            old_columns realtime.wal_column[];
+
+            error_record_exceeds_max_size boolean = octet_length(wal::text) > max_record_bytes;
+
+            -- Primary jsonb output for record
+            output jsonb;
+
+        begin
+            perform set_config('role', null, true);
+
+            columns =
+                array_agg(
+                    (
+                        x->>'name',
+                        x->>'type',
+                        x->>'typeoid',
+                        realtime.cast(
+                            (x->'value') #>> '{}',
+                            (x->>'typeoid')::regtype
+                        ),
+                        (pks ->> 'name') is not null,
+                        true
+                    )::realtime.wal_column
+                )
+                from
+                    jsonb_array_elements(wal -> 'columns') x
+                    left join jsonb_array_elements(wal -> 'pk') pks
+                        on (x ->> 'name') = (pks ->> 'name');
+
+            old_columns =
+                array_agg(
+                    (
+                        x->>'name',
+                        x->>'type',
+                        x->>'typeoid',
+                        realtime.cast(
+                            (x->'value') #>> '{}',
+                            (x->>'typeoid')::regtype
+                        ),
+                        (pks ->> 'name') is not null,
+                        true
+                    )::realtime.wal_column
+                )
+                from
+                    jsonb_array_elements(wal -> 'identity') x
+                    left join jsonb_array_elements(wal -> 'pk') pks
+                        on (x ->> 'name') = (pks ->> 'name');
+
+            for working_role in select * from unnest(roles) loop
+
+                -- Update `is_selectable` for columns and old_columns
+                columns =
+                    array_agg(
+                        (
+                            c.name,
+                            c.type_name,
+                            c.type_oid,
+                            c.value,
+                            c.is_pkey,
+                            pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                        )::realtime.wal_column
+                    )
+                    from
+                        unnest(columns) c;
+
+                old_columns =
+                        array_agg(
+                            (
+                                c.name,
+                                c.type_name,
+                                c.type_oid,
+                                c.value,
+                                c.is_pkey,
+                                pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                            )::realtime.wal_column
+                        )
+                        from
+                            unnest(old_columns) c;
+
+                if action <> 'DELETE' and count(1) = 0 from unnest(columns) c where c.is_pkey then
+                    return next (
+                        jsonb_build_object(
+                            'schema', wal ->> 'schema',
+                            'table', wal ->> 'table',
+                            'type', action
+                        ),
+                        is_rls_enabled,
+                        -- subscriptions is already filtered by entity
+                        (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                        array['Error 400: Bad Request, no primary key']
+                    )::realtime.wal_rls;
+
+                -- The claims role does not have SELECT permission to the primary key of entity
+                elsif action <> 'DELETE' and sum(c.is_selectable::int) <> count(1) from unnest(columns) c where c.is_pkey then
+                    return next (
+                        jsonb_build_object(
+                            'schema', wal ->> 'schema',
+                            'table', wal ->> 'table',
+                            'type', action
+                        ),
+                        is_rls_enabled,
+                        (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                        array['Error 401: Unauthorized']
+                    )::realtime.wal_rls;
+
+                else
+                    output = jsonb_build_object(
+                        'schema', wal ->> 'schema',
+                        'table', wal ->> 'table',
+                        'type', action,
+                        'commit_timestamp', to_char(
+                            (wal ->> 'timestamp')::timestamptz,
+                            'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'
+                        ),
+                        'columns', (
+                            select
+                                jsonb_agg(
+                                    jsonb_build_object(
+                                        'name', pa.attname,
+                                        'type', pt.typname
+                                    )
+                                    order by pa.attnum asc
+                                )
+                            from
+                                pg_attribute pa
+                                join pg_type pt
+                                    on pa.atttypid = pt.oid
+                            where
+                                attrelid = entity_
+                                and attnum > 0
+                                and pg_catalog.has_column_privilege(working_role, entity_, pa.attname, 'SELECT')
+                        )
+                    )
+                    -- Add \"record\" key for insert and update
+                    || case
+                        when error_record_exceeds_max_size then jsonb_build_object('record', '{}'::jsonb)
+                        when action in ('INSERT', 'UPDATE') then
+                            jsonb_build_object(
+                                'record',
+                                (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
+                            )
+                        else '{}'::jsonb
+                    end
+                    -- Add \"old_record\" key for update and delete
+                    || case
+                        when error_record_exceeds_max_size then jsonb_build_object('old_record', '{}'::jsonb)
+                        when action in ('UPDATE', 'DELETE') then
+                            jsonb_build_object(
+                                'old_record',
+                                (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
+                            )
+                        else '{}'::jsonb
+                    end;
+
+                    -- Create the prepared statement
+                    if is_rls_enabled and action <> 'DELETE' then
+                        if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
+                            deallocate walrus_rls_stmt;
+                        end if;
+                        execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+                    end if;
+
+                    visible_to_subscription_ids = '{}';
+
+                    for subscription_id, claims in (
+                            select
+                                subs.subscription_id,
+                                subs.claims
+                            from
+                                unnest(subscriptions) subs
+                            where
+                                subs.entity = entity_
+                                and subs.claims_role = working_role
+                                and realtime.is_visible_through_filters(columns, subs.filters)
+                    ) loop
+
+                        if not is_rls_enabled or action = 'DELETE' then
+                            visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                        else
+                            -- Check if RLS allows the role to see the record
+                            perform
+                                set_config('role', working_role::text, true),
+                                set_config('request.jwt.claims', claims::text, true);
+
+                            execute 'execute walrus_rls_stmt' into subscription_has_access;
+
+                            if subscription_has_access then
+                                visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                            end if;
+                        end if;
+                    end loop;
+
+                    perform set_config('role', null, true);
+
+                    return next (
+                        output,
+                        is_rls_enabled,
+                        visible_to_subscription_ids,
+                        case
+                            when error_record_exceeds_max_size then array['Error 413: Payload Too Large']
+                            else '{}'
+                        end
+                    )::realtime.wal_rls;
+
+                end if;
+            end loop;
+
+            perform set_config('role', null, true);
+        end;
+      $$;
+      ")
+  end
+end

--- a/server/priv/repo/migrations/20220603232444_add_output_for_data_less_than_equal_64_bytes_when_payload_too_large.exs
+++ b/server/priv/repo/migrations/20220603232444_add_output_for_data_less_than_equal_64_bytes_when_payload_too_large.exs
@@ -1,0 +1,277 @@
+defmodule Realtime.RLS.Repo.Migrations.AddOutputForDataLessThanEqual64BytesWhenPayloadTooLarge do
+  use Ecto.Migration
+
+  def change do
+    execute("
+      create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+          returns setof realtime.wal_rls
+          language plpgsql
+          volatile
+      as $$
+      declare
+          -- Regclass of the table e.g. public.notes
+          entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
+          -- I, U, D, T: insert, update ...
+          action realtime.action = (
+              case wal ->> 'action'
+                  when 'I' then 'INSERT'
+                  when 'U' then 'UPDATE'
+                  when 'D' then 'DELETE'
+                  else 'ERROR'
+              end
+          );
+          -- Is row level security enabled for the table
+          is_rls_enabled bool = relrowsecurity from pg_class where oid = entity_;
+          subscriptions realtime.subscription[] = array_agg(subs)
+              from
+                  realtime.subscription subs
+              where
+                  subs.entity = entity_;
+          -- Subscription vars
+          roles regrole[] = array_agg(distinct us.claims_role)
+              from
+                  unnest(subscriptions) us;
+          working_role regrole;
+          claimed_role regrole;
+          claims jsonb;
+          subscription_id uuid;
+          subscription_has_access bool;
+          visible_to_subscription_ids uuid[] = '{}';
+          -- structured info for wal's columns
+          columns realtime.wal_column[];
+          -- previous identity values for update/delete
+          old_columns realtime.wal_column[];
+
+          error_record_exceeds_max_size boolean = octet_length(wal::text) > max_record_bytes;
+
+          -- Primary jsonb output for record
+          output jsonb;
+
+      begin
+          perform set_config('role', null, true);
+
+          columns =
+              array_agg(
+                  (
+                      x->>'name',
+                      x->>'type',
+                      x->>'typeoid',
+                      realtime.cast(
+                          (x->'value') #>> '{}',
+                          (x->>'typeoid')::regtype
+                      ),
+                      (pks ->> 'name') is not null,
+                      true
+                  )::realtime.wal_column
+              )
+              from
+                  jsonb_array_elements(wal -> 'columns') x
+                  left join jsonb_array_elements(wal -> 'pk') pks
+                      on (x ->> 'name') = (pks ->> 'name');
+
+          old_columns =
+              array_agg(
+                  (
+                      x->>'name',
+                      x->>'type',
+                      x->>'typeoid',
+                      realtime.cast(
+                          (x->'value') #>> '{}',
+                          (x->>'typeoid')::regtype
+                      ),
+                      (pks ->> 'name') is not null,
+                      true
+                  )::realtime.wal_column
+              )
+              from
+                  jsonb_array_elements(wal -> 'identity') x
+                  left join jsonb_array_elements(wal -> 'pk') pks
+                      on (x ->> 'name') = (pks ->> 'name');
+
+          for working_role in select * from unnest(roles) loop
+
+              -- Update `is_selectable` for columns and old_columns
+              columns =
+                  array_agg(
+                      (
+                          c.name,
+                          c.type_name,
+                          c.type_oid,
+                          c.value,
+                          c.is_pkey,
+                          pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                      )::realtime.wal_column
+                  )
+                  from
+                      unnest(columns) c;
+
+              old_columns =
+                      array_agg(
+                          (
+                              c.name,
+                              c.type_name,
+                              c.type_oid,
+                              c.value,
+                              c.is_pkey,
+                              pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                          )::realtime.wal_column
+                      )
+                      from
+                          unnest(old_columns) c;
+
+              if action <> 'DELETE' and count(1) = 0 from unnest(columns) c where c.is_pkey then
+                  return next (
+                      jsonb_build_object(
+                          'schema', wal ->> 'schema',
+                          'table', wal ->> 'table',
+                          'type', action
+                      ),
+                      is_rls_enabled,
+                      -- subscriptions is already filtered by entity
+                      (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                      array['Error 400: Bad Request, no primary key']
+                  )::realtime.wal_rls;
+
+              -- The claims role does not have SELECT permission to the primary key of entity
+              elsif action <> 'DELETE' and sum(c.is_selectable::int) <> count(1) from unnest(columns) c where c.is_pkey then
+                  return next (
+                      jsonb_build_object(
+                          'schema', wal ->> 'schema',
+                          'table', wal ->> 'table',
+                          'type', action
+                      ),
+                      is_rls_enabled,
+                      (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                      array['Error 401: Unauthorized']
+                  )::realtime.wal_rls;
+
+              else
+                  output = jsonb_build_object(
+                      'schema', wal ->> 'schema',
+                      'table', wal ->> 'table',
+                      'type', action,
+                      'commit_timestamp', to_char(
+                          (wal ->> 'timestamp')::timestamptz,
+                          'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'
+                      ),
+                      'columns', (
+                          select
+                              jsonb_agg(
+                                  jsonb_build_object(
+                                      'name', pa.attname,
+                                      'type', pt.typname
+                                  )
+                                  order by pa.attnum asc
+                              )
+                          from
+                              pg_attribute pa
+                              join pg_type pt
+                                  on pa.atttypid = pt.oid
+                          where
+                              attrelid = entity_
+                              and attnum > 0
+                              and pg_catalog.has_column_privilege(working_role, entity_, pa.attname, 'SELECT')
+                      )
+                  )
+                  -- Add \"record\" key for insert and update
+                  || case
+                      when action in ('INSERT', 'UPDATE') then
+                          case
+                              when error_record_exceeds_max_size then
+                                  jsonb_build_object(
+                                      'record',
+                                      (
+                                          select jsonb_object_agg((c).name, (c).value)
+                                          from unnest(columns) c
+                                          where (c).is_selectable and (octet_length((c).value::text) <= 64)
+                                      )
+                                  )
+                              else
+                                  jsonb_build_object(
+                                      'record',
+                                      (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
+                                  )
+                          end
+                      else '{}'::jsonb
+                  end
+                  -- Add \"old_record\" key for update and delete
+                  || case
+                      when action in ('UPDATE', 'DELETE') then
+                          case
+                              when error_record_exceeds_max_size then
+                                  jsonb_build_object(
+                                      'old_record',
+                                      (
+                                          select jsonb_object_agg((c).name, (c).value)
+                                          from unnest(old_columns) c
+                                          where (c).is_selectable and (octet_length((c).value::text) <= 64)
+                                      )
+                                  )
+                              else
+                                  jsonb_build_object(
+                                      'old_record',
+                                      (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
+                                  )
+                          end
+                      else '{}'::jsonb
+                  end;
+
+                  -- Create the prepared statement
+                  if is_rls_enabled and action <> 'DELETE' then
+                      if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
+                          deallocate walrus_rls_stmt;
+                      end if;
+                      execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+                  end if;
+
+                  visible_to_subscription_ids = '{}';
+
+                  for subscription_id, claims in (
+                          select
+                              subs.subscription_id,
+                              subs.claims
+                          from
+                              unnest(subscriptions) subs
+                          where
+                              subs.entity = entity_
+                              and subs.claims_role = working_role
+                              and realtime.is_visible_through_filters(columns, subs.filters)
+                  ) loop
+
+                      if not is_rls_enabled or action = 'DELETE' then
+                          visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                      else
+                          -- Check if RLS allows the role to see the record
+                          perform
+                              set_config('role', working_role::text, true),
+                              set_config('request.jwt.claims', claims::text, true);
+
+                          execute 'execute walrus_rls_stmt' into subscription_has_access;
+
+                          if subscription_has_access then
+                              visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                          end if;
+                      end if;
+                  end loop;
+
+                  perform set_config('role', null, true);
+
+                  return next (
+                      output,
+                      is_rls_enabled,
+                      visible_to_subscription_ids,
+                      case
+                          when error_record_exceeds_max_size then array['Error 413: Payload Too Large']
+                          else '{}'
+                      end
+                  )::realtime.wal_rls;
+
+              end if;
+          end loop;
+
+          perform set_config('role', null, true);
+      end;
+      $$;
+    ")
+  end
+end

--- a/server/priv/repo/migrations/20220615214548_add_quoted_regtypes_backward_compatibility_support.exs
+++ b/server/priv/repo/migrations/20220615214548_add_quoted_regtypes_backward_compatibility_support.exs
@@ -1,0 +1,323 @@
+defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesBackwardCompatibilitySupport do
+  use Ecto.Migration
+
+  def change do
+    execute("
+      create or replace function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
+            returns bool
+            language sql
+            immutable
+        as $$
+        /*
+        Should the record be visible (true) or filtered out (false) after *filters* are applied
+        */
+            select
+                -- Default to allowed when no filters present
+                coalesce(
+                    sum(
+                        realtime.check_equality_op(
+                            op:=f.op,
+                            type_:=coalesce(
+                                col.type_oid::regtype, -- null when wal2json version <= 2.4
+                                col.type_name::regtype
+                            ),
+                            -- cast jsonb to text
+                            val_1:=col.value #>> '{}',
+                            val_2:=f.value
+                        )::int
+                    ) = count(1),
+                    true
+                )
+            from
+                unnest(filters) f
+                join unnest(columns) col
+                    on f.column_name = col.name;
+        $$;
+    ")
+
+    execute("
+    create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+          returns setof realtime.wal_rls
+          language plpgsql
+          volatile
+      as $$
+      declare
+          -- Regclass of the table e.g. public.notes
+          entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
+
+          -- I, U, D, T: insert, update ...
+          action realtime.action = (
+              case wal ->> 'action'
+                  when 'I' then 'INSERT'
+                  when 'U' then 'UPDATE'
+                  when 'D' then 'DELETE'
+                  else 'ERROR'
+              end
+          );
+
+          -- Is row level security enabled for the table
+          is_rls_enabled bool = relrowsecurity from pg_class where oid = entity_;
+
+          subscriptions realtime.subscription[] = array_agg(subs)
+              from
+                  realtime.subscription subs
+              where
+                  subs.entity = entity_;
+
+          -- Subscription vars
+          roles regrole[] = array_agg(distinct us.claims_role)
+              from
+                  unnest(subscriptions) us;
+
+          working_role regrole;
+          claimed_role regrole;
+          claims jsonb;
+
+          subscription_id uuid;
+          subscription_has_access bool;
+          visible_to_subscription_ids uuid[] = '{}';
+
+          -- structured info for wal's columns
+          columns realtime.wal_column[];
+          -- previous identity values for update/delete
+          old_columns realtime.wal_column[];
+
+          error_record_exceeds_max_size boolean = octet_length(wal::text) > max_record_bytes;
+
+          -- Primary jsonb output for record
+          output jsonb;
+
+      begin
+          perform set_config('role', null, true);
+
+          columns =
+              array_agg(
+                  (
+                      x->>'name',
+                      x->>'type',
+                      x->>'typeoid',
+                      realtime.cast(
+                          (x->'value') #>> '{}',
+                          coalesce(
+                              (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                              (x->>'type')::regtype
+                          )
+                      ),
+                      (pks ->> 'name') is not null,
+                      true
+                  )::realtime.wal_column
+              )
+              from
+                  jsonb_array_elements(wal -> 'columns') x
+                  left join jsonb_array_elements(wal -> 'pk') pks
+                      on (x ->> 'name') = (pks ->> 'name');
+
+          old_columns =
+              array_agg(
+                  (
+                      x->>'name',
+                      x->>'type',
+                      x->>'typeoid',
+                      realtime.cast(
+                          (x->'value') #>> '{}',
+                          coalesce(
+                              (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                              (x->>'type')::regtype
+                          )
+                      ),
+                      (pks ->> 'name') is not null,
+                      true
+                  )::realtime.wal_column
+              )
+              from
+                  jsonb_array_elements(wal -> 'identity') x
+                  left join jsonb_array_elements(wal -> 'pk') pks
+                      on (x ->> 'name') = (pks ->> 'name');
+
+          for working_role in select * from unnest(roles) loop
+
+              -- Update `is_selectable` for columns and old_columns
+              columns =
+                  array_agg(
+                      (
+                          c.name,
+                          c.type_name,
+                          c.type_oid,
+                          c.value,
+                          c.is_pkey,
+                          pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                      )::realtime.wal_column
+                  )
+                  from
+                      unnest(columns) c;
+
+              old_columns =
+                      array_agg(
+                          (
+                              c.name,
+                              c.type_name,
+                              c.type_oid,
+                              c.value,
+                              c.is_pkey,
+                              pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                          )::realtime.wal_column
+                      )
+                      from
+                          unnest(old_columns) c;
+
+              if action <> 'DELETE' and count(1) = 0 from unnest(columns) c where c.is_pkey then
+                  return next (
+                      jsonb_build_object(
+                          'schema', wal ->> 'schema',
+                          'table', wal ->> 'table',
+                          'type', action
+                      ),
+                      is_rls_enabled,
+                      -- subscriptions is already filtered by entity
+                      (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                      array['Error 400: Bad Request, no primary key']
+                  )::realtime.wal_rls;
+
+              -- The claims role does not have SELECT permission to the primary key of entity
+              elsif action <> 'DELETE' and sum(c.is_selectable::int) <> count(1) from unnest(columns) c where c.is_pkey then
+                  return next (
+                      jsonb_build_object(
+                          'schema', wal ->> 'schema',
+                          'table', wal ->> 'table',
+                          'type', action
+                      ),
+                      is_rls_enabled,
+                      (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                      array['Error 401: Unauthorized']
+                  )::realtime.wal_rls;
+
+              else
+                  output = jsonb_build_object(
+                      'schema', wal ->> 'schema',
+                      'table', wal ->> 'table',
+                      'type', action,
+                      'commit_timestamp', to_char(
+                          (wal ->> 'timestamp')::timestamptz,
+                          'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'
+                      ),
+                      'columns', (
+                          select
+                              jsonb_agg(
+                                  jsonb_build_object(
+                                      'name', pa.attname,
+                                      'type', pt.typname
+                                  )
+                                  order by pa.attnum asc
+                              )
+                          from
+                              pg_attribute pa
+                              join pg_type pt
+                                  on pa.atttypid = pt.oid
+                          where
+                              attrelid = entity_
+                              and attnum > 0
+                              and pg_catalog.has_column_privilege(working_role, entity_, pa.attname, 'SELECT')
+                      )
+                  )
+                  -- Add \"record\" key for insert and update
+                  || case
+                      when action in ('INSERT', 'UPDATE') then
+                          case
+                              when error_record_exceeds_max_size then
+                                  jsonb_build_object(
+                                      'record',
+                                      (
+                                          select jsonb_object_agg((c).name, (c).value)
+                                          from unnest(columns) c
+                                          where (c).is_selectable and (octet_length((c).value::text) <= 64)
+                                      )
+                                  )
+                              else
+                                  jsonb_build_object(
+                                      'record',
+                                      (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
+                                  )
+                          end
+                      else '{}'::jsonb
+                  end
+                  -- Add \"old_record\" key for update and delete
+                  || case
+                      when action in ('UPDATE', 'DELETE') then
+                          case
+                              when error_record_exceeds_max_size then
+                                  jsonb_build_object(
+                                      'old_record',
+                                      (
+                                          select jsonb_object_agg((c).name, (c).value)
+                                          from unnest(old_columns) c
+                                          where (c).is_selectable and (octet_length((c).value::text) <= 64)
+                                      )
+                                  )
+                              else
+                                  jsonb_build_object(
+                                      'old_record',
+                                      (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
+                                  )
+                          end
+                      else '{}'::jsonb
+                  end;
+
+                  -- Create the prepared statement
+                  if is_rls_enabled and action <> 'DELETE' then
+                      if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
+                          deallocate walrus_rls_stmt;
+                      end if;
+                      execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+                  end if;
+
+                  visible_to_subscription_ids = '{}';
+
+                  for subscription_id, claims in (
+                          select
+                              subs.subscription_id,
+                              subs.claims
+                          from
+                              unnest(subscriptions) subs
+                          where
+                              subs.entity = entity_
+                              and subs.claims_role = working_role
+                              and realtime.is_visible_through_filters(columns, subs.filters)
+                  ) loop
+
+                      if not is_rls_enabled or action = 'DELETE' then
+                          visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                      else
+                          -- Check if RLS allows the role to see the record
+                          perform
+                              set_config('role', working_role::text, true),
+                              set_config('request.jwt.claims', claims::text, true);
+
+                          execute 'execute walrus_rls_stmt' into subscription_has_access;
+
+                          if subscription_has_access then
+                              visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                          end if;
+                      end if;
+                  end loop;
+
+                  perform set_config('role', null, true);
+
+                  return next (
+                      output,
+                      is_rls_enabled,
+                      visible_to_subscription_ids,
+                      case
+                          when error_record_exceeds_max_size then array['Error 413: Payload Too Large']
+                          else '{}'
+                      end
+                  )::realtime.wal_rls;
+
+              end if;
+          end loop;
+
+          perform set_config('role', null, true);
+      end;
+    $$;
+    ")
+  end
+end

--- a/server/test/realtime/rls_replications_test.exs
+++ b/server/test/realtime/rls_replications_test.exs
@@ -97,8 +97,8 @@ defmodule Realtime.RlsReplicationsTest do
     assert record["schema"] == "public"
     assert record["table"] == "todos"
     assert record["type"] == "UPDATE"
-    assert record["old_record"] == %{}
-    assert record["record"] == %{}
+    assert record["old_record"] == %{"id" => 1}
+    assert record["record"] == %{"id" => 1, "user_id" => 1}
     assert errors == ["Error 413: Payload Too Large"]
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

1. Realtime WALRUS doesn't work with quoted regtypes. This has been a huge pain point for developers who use Prisma.
2. When payload size too large developers don't get enough information on the client.

## What is the new behavior?

1. Realtime WALRUS works with quoted regtypes ([WALRUS PR](https://github.com/supabase/walrus/pull/46))
2. When payload size too large developers receive columns whose payload size is less than or equal to 64 bytes ([WALRUS PR](https://github.com/supabase/walrus/pull/47))

## Additional context

Related issues:

1. https://github.com/supabase/supabase/issues/5685#issuecomment-1142714282
2. https://github.com/supabase/realtime/issues/252


