### PR TITLE
fix: recreate realtime.build_prepared_statement_sql function

### DIFF
--- a/server/priv/repo/migrations/20220712093339_recreate_realtime_build_prepared_statement_sql_function.exs
+++ b/server/priv/repo/migrations/20220712093339_recreate_realtime_build_prepared_statement_sql_function.exs
@@ -1,0 +1,40 @@
+defmodule Realtime.RLS.Repo.Migrations.RecreateRealtimeBuildPreparedStatementSqlFunction do
+  use Ecto.Migration
+
+  def change do
+    execute "
+      create or replace function realtime.build_prepared_statement_sql(
+          prepared_statement_name text,
+          entity regclass,
+          columns realtime.wal_column[]
+      )
+          returns text
+          language sql
+      as $$
+      /*
+      Builds a sql string that, if executed, creates a prepared statement to
+      tests retrive a row from *entity* by its primary key columns.
+      Example
+          select realtime.build_prepared_statement_sql('public.notes', '{\"id\"}'::text[], '{\"bigint\"}'::text[])
+      */
+          select
+      'prepare ' || prepared_statement_name || ' as
+          select
+              exists(
+                  select
+                      1
+                  from
+                      ' || entity || '
+                  where
+                      ' || string_agg(quote_ident(pkc.name) || '=' || quote_nullable(pkc.value #>> '{}') , ' and ') || '
+              )'
+          from
+              unnest(columns) pkc
+          where
+              pkc.is_pkey
+          group by
+              entity
+      $$;
+    "
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`realtime.build_prepared_statement_sql` function is accidentally dropped via `cascade` from a migration file. The error arises when RLS is enabled.

## What is the new behavior?

`realtime.build_prepared_statement_sql` function is added back.

## Additional context

Related issues:

- https://github.com/supabase/realtime/issues/263
- https://github.com/supabase/realtime/issues/265
