### PR TITLE
Replace pg_authid table for pg_roles

### DIFF
--- a/server/lib/realtime/rls/subscriptions/subscriptions.ex
+++ b/server/lib/realtime/rls/subscriptions/subscriptions.ex
@@ -49,7 +49,7 @@ defmodule Realtime.RLS.Subscriptions do
   defp fetch_database_roles(%Multi{} = multi) do
     Multi.run(multi, :database_roles, fn _, _ ->
       Repo.query(
-        "select rolname from pg_authid",
+        "select rolname from pg_roles",
         []
       )
       |> case do


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Hotfix for Security] Changing table name to fetch database roles.

- It improve security to use `pg_roles` insted of `pg_authid`. 
  - `pg_roles` is the view without password of `pg_authid` 
- It enable to work with Amazon RDS/Aurora.
  - Because you can't have permission to read `pg_authid` table on Amazon RDS/Aurora.

## What is the current behavior?

Using `pg_authid` table.
https://github.com/supabase/realtime/issues/270

## What is the new behavior?

Using `pg_roles` table.

## Additional context

Add any other context or screenshots.
