### PR TITLE
feat: simplify topic subscriptions insert query

### DIFF
--- a/server/lib/realtime/message_dispatcher.ex
+++ b/server/lib/realtime/message_dispatcher.ex
@@ -13,22 +13,21 @@ defmodule Realtime.MessageDispatcher do
           Phoenix.Socket.Broadcast.t()
         ) :: :ok
   def dispatch([_ | _] = topic_subscriptions, _from, %Broadcast{payload: payload}) do
-    new_payload = Map.drop(payload, [:subscription_ids])
-
     Enum.reduce(topic_subscriptions, %{}, fn
-      {_pid, {:subscriber_fastlane, fastlane_pid, serializer, join_topic, is_new_api}}, cache ->
+      {_pid, {:subscriber_fastlane, fastlane_pid, serializer, id, join_topic, is_new_api}},
+      cache ->
         new_payload =
           if is_new_api do
             %Broadcast{
               topic: join_topic,
-              event: "realtime",
-              payload: %{payload: new_payload, event: new_payload.type}
+              event: "postgres_changes",
+              payload: %{id: id, data: payload}
             }
           else
             %Broadcast{
               topic: join_topic,
-              event: new_payload.type,
-              payload: new_payload
+              event: payload.type,
+              payload: payload
             }
           end
 

--- a/server/lib/realtime/rls/replication_poller.ex
+++ b/server/lib/realtime/rls/replication_poller.ex
@@ -108,6 +108,8 @@ defmodule Realtime.RLS.ReplicationPoller do
           end)
           |> Enum.reverse()
           |> Enum.each(fn %{subscription_ids: ids} = change ->
+            change = Map.drop(change, [:subscription_ids])
+
             for id <- ids do
               broadcast_change("postgres_changes:#{Ecto.UUID.cast!(id)}", change)
             end

--- a/server/lib/realtime/rls/subscriptions/subscriptions.ex
+++ b/server/lib/realtime/rls/subscriptions/subscriptions.ex
@@ -1,232 +1,110 @@
 defmodule Realtime.RLS.Subscriptions do
   import Ecto.Query, only: [from: 2]
 
-  alias Ecto.{Changeset, Multi}
   alias Realtime.RLS.Repo
   alias Realtime.RLS.Subscriptions.Subscription
 
-  @spec create_topic_subscribers(list(%{topic: String.t(), id: Ecto.UUID.raw(), claims: map()})) ::
-          {:ok, term()}
-          | {:error, term()}
-          | {:error, Ecto.Multi.name(), term(), %{required(Ecto.Multi.name()) => term()}}
+  @spec create_topic_subscribers(list(%{id: Ecto.UUID.raw(), claims: map(), params: map()})) ::
+          {:ok, any()}
+          | {:error, any()}
+          | {:error, Ecto.Multi.name(), any(), %{required(Ecto.Multi.name()) => any()}}
   def create_topic_subscribers(params_list) do
-    Multi.new()
-    |> Multi.put(:params_list, params_list)
-    |> fetch_database_roles()
-    |> fetch_publication_tables()
-    |> enrich_subscription_params()
-    |> generate_topic_subscriptions()
-    |> insert_topic_subscriptions()
-    |> Repo.transaction()
+    query = "with sub_tables as (
+		    select
+			    rr.entity
+		    from
+			    pg_publication_tables pub,
+			    lateral (
+				    select
+					    format('%I.%I', pub.schemaname, pub.tablename)::regclass entity
+			    ) rr
+		    where
+			    pub.pubname = $1
+			  and pub.schemaname like (case $2 when '*' then '%' else $2 end)
+			  and pub.tablename like (case $3 when '*' then '%' else $3 end)
+	    )
+	    insert into realtime.subscription as x(
+		    subscription_id,
+		    entity,
+        filters,
+        claims
+      )
+      select
+        $4::text::uuid,
+        sub_tables.entity,
+        $6,
+        $5
+      from
+        sub_tables
+        on conflict
+        (subscription_id, entity, filters)
+        do update set
+        claims = excluded.claims,
+        created_at = now()
+      returning
+         id"
+
+    Repo.transaction(fn ->
+      params_list
+      |> Enum.map(fn %{
+                       id: id,
+                       claims: claims,
+                       params: params
+                     } ->
+        with [schema, table, filters] <-
+               (case params do
+                  %{"schema" => schema, "table" => table, "filter" => filter} ->
+                    with [col, rest] <- String.split(filter, "=", parts: 2),
+                         [filter_type, value] <- String.split(rest, ".", parts: 2) do
+                      [schema, table, [{col, filter_type, value}]]
+                    else
+                      _ -> []
+                    end
+
+                  %{"schema" => schema, "table" => table} ->
+                    [schema, table, []]
+
+                  %{"schema" => schema} ->
+                    [schema, "*", []]
+
+                  _ ->
+                    []
+                end) do
+          Ecto.Adapters.SQL.query!(
+            Repo,
+            query,
+            [
+              Application.get_env(:realtime, :publications) |> Jason.decode!() |> List.first(),
+              schema,
+              table,
+              id |> Ecto.UUID.cast!(),
+              claims,
+              filters
+            ]
+          )
+        else
+          _ -> Repo.rollback("malformed postgres params")
+        end
+      end)
+    end)
   end
 
-  @spec delete_topic_subscriber(map()) :: {integer(), nil | [term()]}
-  def delete_topic_subscriber(%{
-        id: id,
-        entities: [_ | _] = oids,
-        filters: filters
-      }) do
+  @spec delete_topic_subscriber(Ecto.UUID.raw()) :: {integer(), nil | [term()]}
+  def delete_topic_subscriber(id) do
     from(s in Subscription,
-      where: s.subscription_id == ^id and s.entity in ^oids and s.filters == ^filters
+      where: s.subscription_id == ^id
     )
     |> Repo.delete_all()
   end
 
-  def delete_topic_subscriber(_), do: {0, nil}
-
+  @spec sync_subscriptions(list(%{id: Ecto.UUID.raw(), claims: map(), params: map()})) ::
+          {:ok, any()}
+          | {:error, any()}
+          | {:error, Ecto.Multi.name(), any(), %{required(Ecto.Multi.name()) => any()}}
   def sync_subscriptions(params_list) do
-    Multi.new()
-    |> Ecto.Multi.delete_all(:delete_all, Subscription)
-    |> Multi.put(:params_list, params_list)
-    |> fetch_database_roles()
-    |> fetch_publication_tables()
-    |> enrich_subscription_params()
-    |> generate_topic_subscriptions()
-    |> insert_topic_subscriptions()
-    |> Repo.transaction()
-  end
-
-  defp fetch_database_roles(%Multi{} = multi) do
-    Multi.run(multi, :database_roles, fn _, _ ->
-      Repo.query(
-        "select rolname from pg_roles",
-        []
-      )
-      |> case do
-        {:ok, %Postgrex.Result{columns: ["rolname"], rows: rows}} ->
-          {:ok, rows |> List.flatten() |> MapSet.new()}
-
-        _ ->
-          {:ok, MapSet.new()}
-      end
-    end)
-  end
-
-  defp fetch_publication_tables(%Multi{} = multi) do
-    Multi.run(multi, :publication_entities, fn _, _ ->
-      Repo.query(
-        "select
-          schemaname,
-          tablename,
-          format('%I.%I', schemaname, tablename)::regclass as oid
-        from pg_publication_tables
-        where pubname = $1",
-        ["supabase_realtime"]
-      )
-      |> case do
-        {:ok,
-         %Postgrex.Result{
-           columns: ["schemaname", "tablename", "oid"] = columns,
-           num_rows: num_rows,
-           rows: rows
-         }}
-        when num_rows > 0 ->
-          publication_entities =
-            Enum.reduce(rows, %{}, fn row, acc ->
-              [{"schemaname", schema}, {"tablename", table}, {"oid", oid}] =
-                Enum.zip(columns, row)
-
-              acc
-              |> Map.put({schema, table}, [oid])
-              |> Map.update({schema}, [oid], fn oids -> [oid | oids] end)
-              |> Map.update({"*"}, [oid], fn oids -> [oid | oids] end)
-            end)
-
-          {:ok, publication_entities}
-
-        _ ->
-          {:ok, %{}}
-      end
-    end)
-  end
-
-  defp enrich_subscription_params(%Multi{} = multi) do
-    Multi.run(multi, :enriched_subscription_params, fn _,
-                                                       %{
-                                                         database_roles: database_roles,
-                                                         params_list: params_list,
-                                                         publication_entities: oids
-                                                       } ->
-      enriched_params =
-        case params_list do
-          [_ | _] ->
-            Enum.reduce(params_list, [], fn %{id: id, claims: claims, topic: topic}, acc ->
-              claims_role = claims["role"]
-
-              claims_role =
-                if MapSet.member?(database_roles, claims_role) do
-                  claims_role
-                else
-                  nil
-                end
-
-              [schema_table_column | filter_value_list] = String.split(topic, "=eq.")
-              schema_table_column_list = String.split(schema_table_column, ":")
-
-              search_key =
-                case schema_table_column_list do
-                  [schema, table | _] -> {schema, table}
-                  [schema] -> {schema}
-                end
-
-              filters =
-                case filter_value_list do
-                  [value] -> [List.last(schema_table_column_list), "eq", value]
-                  _ -> []
-                end
-
-              [
-                %{
-                  id: id,
-                  claims: claims,
-                  claims_role: claims_role,
-                  entities: Map.get(oids, search_key, []),
-                  filters: filters,
-                  topic: topic
-                }
-                | acc
-              ]
-            end)
-
-          _ ->
-            []
-        end
-
-      {:ok, enriched_params}
-    end)
-  end
-
-  defp generate_topic_subscriptions(%Multi{} = multi) do
-    Multi.run(multi, :valid_topic_subscriptions, fn _,
-                                                    %{
-                                                      enriched_subscription_params:
-                                                        enriched_subscription_params
-                                                    } ->
-      topic_subs =
-        case enriched_subscription_params do
-          [_ | _] ->
-            Enum.reduce(enriched_subscription_params, [], fn %{
-                                                               id: id,
-                                                               claims: claims,
-                                                               claims_role: claims_role,
-                                                               entities: entities,
-                                                               filters: filters
-                                                             },
-                                                             acc ->
-              case entities do
-                [_ | _] ->
-                  [
-                    Enum.reduce(entities, [], fn oid, i_acc ->
-                      %Subscription{}
-                      |> Subscription.changeset(%{
-                        subscription_id: id,
-                        entity: oid,
-                        filters: filters,
-                        claims: claims,
-                        claims_role: claims_role
-                      })
-                      |> case do
-                        %Changeset{changes: topic_sub, valid?: true} -> [topic_sub | i_acc]
-                        _ -> i_acc
-                      end
-                    end)
-                    | acc
-                  ]
-
-                _ ->
-                  acc
-              end
-            end)
-            |> List.flatten()
-
-          _ ->
-            []
-        end
-
-      {:ok, topic_subs}
-    end)
-  end
-
-  defp insert_topic_subscriptions(%Multi{} = multi) do
-    Multi.run(multi, :insert_topic_subscriptions, fn _,
-                                                     %{
-                                                       valid_topic_subscriptions: valid_subs
-                                                     } ->
-      total_inserts =
-        valid_subs
-        |> Enum.uniq()
-        |> Enum.chunk_every(20_000)
-        |> Enum.reduce(0, fn batch_subs, acc ->
-          {inserts, nil} =
-            Repo.insert_all(Subscription, batch_subs,
-              on_conflict: {:replace, [:claims]},
-              conflict_target: [:subscription_id, :entity, :filters]
-            )
-
-          inserts + acc
-        end)
-
-      {:ok, {total_inserts, nil}}
+    Repo.transaction(fn ->
+      Repo.delete_all(Subscription)
+      create_topic_subscribers(params_list)
     end)
   end
 end

--- a/server/lib/realtime/rls/subscriptions/subscriptions.ex
+++ b/server/lib/realtime/rls/subscriptions/subscriptions.ex
@@ -4,7 +4,7 @@ defmodule Realtime.RLS.Subscriptions do
   alias Realtime.RLS.Repo
   alias Realtime.RLS.Subscriptions.Subscription
 
-  @spec create_topic_subscribers(list(%{id: Ecto.UUID.raw(), claims: map(), params: map()})) ::
+  @spec create_topic_subscribers(list(%{id: Ecto.UUID.t(), claims: map(), params: map()})) ::
           {:ok, any()}
           | {:error, any()}
           | {:error, Ecto.Multi.name(), any(), %{required(Ecto.Multi.name()) => any()}}
@@ -77,7 +77,7 @@ defmodule Realtime.RLS.Subscriptions do
               Application.get_env(:realtime, :publications) |> Jason.decode!() |> List.first(),
               schema,
               table,
-              id |> Ecto.UUID.cast!(),
+              id,
               claims,
               filters
             ]
@@ -89,7 +89,7 @@ defmodule Realtime.RLS.Subscriptions do
     end)
   end
 
-  @spec delete_topic_subscriber(Ecto.UUID.raw()) :: {integer(), nil | [term()]}
+  @spec delete_topic_subscriber(Ecto.UUID.t()) :: {integer(), nil | [term()]}
   def delete_topic_subscriber(id) do
     from(s in Subscription,
       where: s.subscription_id == ^id
@@ -97,7 +97,7 @@ defmodule Realtime.RLS.Subscriptions do
     |> Repo.delete_all()
   end
 
-  @spec sync_subscriptions(list(%{id: Ecto.UUID.raw(), claims: map(), params: map()})) ::
+  @spec sync_subscriptions(list(%{id: Ecto.UUID.t(), claims: map(), params: map()})) ::
           {:ok, any()}
           | {:error, any()}
           | {:error, Ecto.Multi.name(), any(), %{required(Ecto.Multi.name()) => any()}}

--- a/server/lib/realtime/subscription_manager.ex
+++ b/server/lib/realtime/subscription_manager.ex
@@ -38,7 +38,7 @@ defmodule Realtime.SubscriptionManager do
 
   @spec track_topic_subscribers(
           list(%{
-            id: Ecto.UUID.raw(),
+            id: Ecto.UUID.t(),
             channel_pid: pid(),
             claims: map(),
             params: map()

--- a/server/lib/realtime_web/channels/realtime_channel.ex
+++ b/server/lib/realtime_web/channels/realtime_channel.ex
@@ -43,7 +43,7 @@ defmodule RealtimeWeb.RealtimeChannel do
         end
 
       if is_new_api do
-        params["configs"]["realtime"]
+        params["configs"]["postgres_changes"]
         |> case do
           [_ | _] = params_list ->
             pg_change_params =
@@ -110,8 +110,11 @@ defmodule RealtimeWeb.RealtimeChannel do
               _ -> Ecto.UUID.generate()
             end
 
-          for %{id: id} <- pg_change_params do
-            metadata = {:subscriber_fastlane, transport_pid, serializer, id, topic, is_new_api}
+          for %{id: id, params: params} <- pg_change_params do
+            metadata =
+              {:subscriber_fastlane, transport_pid, serializer, id, topic,
+               params |> Map.get("event", "") |> String.upcase(), is_new_api}
+
             Endpoint.subscribe("postgres_changes:#{id}", metadata: metadata)
           end
 

--- a/server/lib/realtime_web/channels/realtime_channel.ex
+++ b/server/lib/realtime_web/channels/realtime_channel.ex
@@ -45,36 +45,15 @@ defmodule RealtimeWeb.RealtimeChannel do
       if is_new_api do
         params["configs"]["realtime"]
         |> case do
-          [_ | _] = db_changes_params ->
-            Enum.map(db_changes_params, fn p ->
-              case p do
-                %{"schema" => schema, "table" => table, "filter" => filter} ->
-                  "#{schema}:#{table}:#{filter}"
-
-                %{"schema" => schema, "table" => table} ->
-                  "#{schema}:#{table}"
-
-                %{"schema" => schema} ->
-                  "#{schema}"
-              end
-            end)
-
-          _ ->
-            []
-        end
-        |> Enum.map(&String.downcase/1)
-        |> MapSet.new()
-        |> MapSet.to_list()
-        |> case do
           [_ | _] = params_list ->
             pg_change_params =
               params_list
-              |> Enum.map(fn subtopic ->
+              |> Enum.map(fn params ->
                 %{
                   id: Ecto.UUID.bingenerate(),
                   channel_pid: channel_pid,
                   claims: claims,
-                  topic: subtopic
+                  params: params
                 }
               end)
 
@@ -89,12 +68,24 @@ defmodule RealtimeWeb.RealtimeChannel do
             {:ok, []}
         end
       else
+        params =
+          case String.split(subtopic, ":", parts: 3) do
+            [schema] ->
+              %{"schema" => schema}
+
+            [schema, table] ->
+              %{"schema" => schema, "table" => table}
+
+            [schema, table, filter] ->
+              %{"schema" => schema, "table" => table, "filter" => filter}
+          end
+
         pg_change_params = [
           %{
             id: Ecto.UUID.bingenerate(),
             channel_pid: channel_pid,
             claims: claims,
-            topic: subtopic
+            params: params
           }
         ]
 
@@ -126,16 +117,22 @@ defmodule RealtimeWeb.RealtimeChannel do
 
           send(self(), :after_join)
 
-          {:ok,
-           assign(socket, %{
-             access_token: token,
-             ack_broadcast: !!params["configs"]["broadcast"]["ack"],
-             is_new_api: is_new_api,
-             pg_change_params: pg_change_params,
-             presence_key: presence_key,
-             self_broadcast: !!params["configs"]["broadcast"]["self"],
-             verify_token_ref: verify_token_ref
-           })}
+          {
+            :ok,
+            %{realtime: Enum.map(pg_change_params, &Map.fetch!(&1, :id))},
+            assign(
+              socket,
+              %{
+                access_token: token,
+                ack_broadcast: !!params["configs"]["broadcast"]["ack"],
+                is_new_api: is_new_api,
+                pg_change_params: pg_change_params,
+                presence_key: presence_key,
+                self_broadcast: !!params["configs"]["broadcast"]["self"],
+                verify_token_ref: verify_token_ref
+              }
+            )
+          }
 
         :error ->
           {:error, %{reason: "unable to insert topic subscriptions into database"}}

--- a/server/test/realtime/message_dispatcher_test.exs
+++ b/server/test/realtime/message_dispatcher_test.exs
@@ -5,55 +5,10 @@ defmodule Realtime.MessageDispatcherTest do
   alias Phoenix.Socket.V1.JSONSerializer
   alias Realtime.Adapters.Changes.NewRecord
 
-  @subscription_id <<187, 181, 30, 78, 243, 113, 68, 99, 191, 10, 175, 143, 86, 220, 154, 115>>
-
-  test "dispatch/3 for subscriber_fastlane when subscription_ids is empty" do
-    msg = msg([])
-
-    dispatch(
-      [{self(), {:subscriber_fastlane, self(), JSONSerializer, @subscription_id}}],
-      self(),
-      msg
-    )
-
-    expected = JSONSerializer.fastlane!(msg)
-    refute_received ^expected
-  end
+  @subscription_id "417e76fd-9bc5-4b3e-bd5d-a031389c4a6b"
 
   test "dispatch/3 for subscriber_fastlane when subscription_id in subscription_ids" do
-    msg = msg(MapSet.new([@subscription_id]))
-
-    dispatch(
-      [
-        {self(), {:subscriber_fastlane, self(), JSONSerializer, "realtime:public:todos", false}}
-      ],
-      self(),
-      msg
-    )
-
-    expected = JSONSerializer.fastlane!(msg)
-    assert_received ^expected
-  end
-
-  test "dispatch/3 for subscriber_fastlane when subscription_id not in subscription_ids" do
-    msg = msg(MapSet.new([@subscription_id]))
-
-    other_subscription_id =
-      <<160, 66, 132, 13, 21, 219, 69, 221, 164, 160, 40, 72, 156, 208, 114, 4>>
-
-    dispatch(
-      [{self(), {:subscriber_fastlane, self(), JSONSerializer, other_subscription_id}}],
-      self(),
-      msg
-    )
-
-    expected = JSONSerializer.fastlane!(msg)
-    refute_received ^expected
-  end
-
-  @spec msg(list) :: map()
-  defp msg(subscription_ids) do
-    %Broadcast{
+    msg = %Broadcast{
       event: "INSERT",
       payload: %NewRecord{
         columns: [
@@ -71,10 +26,20 @@ defmodule Realtime.MessageDispatcherTest do
           "id" => 32,
           "user_id" => 1
         },
-        subscription_ids: MapSet.new(subscription_ids),
         type: "INSERT"
       },
-      topic: "realtime:public:todos"
+      topic: "test"
     }
+
+    dispatch(
+      [
+        {self(), {:subscriber_fastlane, self(), JSONSerializer, @subscription_id, "test", false}}
+      ],
+      self(),
+      msg
+    )
+
+    expected = JSONSerializer.fastlane!(msg)
+    assert_received ^expected
   end
 end

--- a/server/test/realtime/message_dispatcher_test.exs
+++ b/server/test/realtime/message_dispatcher_test.exs
@@ -33,7 +33,8 @@ defmodule Realtime.MessageDispatcherTest do
 
     dispatch(
       [
-        {self(), {:subscriber_fastlane, self(), JSONSerializer, @subscription_id, "test", false}}
+        {self(),
+         {:subscriber_fastlane, self(), JSONSerializer, @subscription_id, "test", "*", false}}
       ],
       self(),
       msg

--- a/server/test/realtime/rls_subscriptions_test.exs
+++ b/server/test/realtime/rls_subscriptions_test.exs
@@ -1,46 +1,8 @@
 defmodule Realtime.RlsSubscriptionsTest do
   use ExUnit.Case
-  alias Realtime.RLS.Subscriptions
-
-  @id "bbb51e4e-f371-4463-bf0a-af8f56dc9a71"
-  @claims %{"role" => "authenticated"}
 
   setup_all do
     start_supervised(Realtime.RLS.Repo)
     :ok
-  end
-
-  test "create_topic_subscribers/1" do
-    params = %{topic: "topic_test", id: bin_id(), claims: @claims}
-
-    case Subscriptions.create_topic_subscribers([params]) do
-      {:ok, response} ->
-        esp = [Map.merge(params, %{entities: [], filters: [], claims_role: "authenticated"})]
-
-        assert response.enriched_subscription_params == esp
-        assert response.params_list == [params]
-
-        entities = [
-          {"*"},
-          {"public"},
-          {"realtime"},
-          {"public", "todos"},
-          {"realtime", "schema_migrations"},
-          {"realtime", "subscription"}
-        ]
-
-        Map.keys(response.publication_entities)
-        |> Enum.each(fn e ->
-          assert Enum.member?(entities, e)
-        end)
-
-      other ->
-        assert match?({:ok, _}, other)
-    end
-  end
-
-  defp bin_id() do
-    {_, bin} = Ecto.UUID.dump(@id)
-    bin
   end
 end

--- a/server/test/realtime/subscription_manager_test.exs
+++ b/server/test/realtime/subscription_manager_test.exs
@@ -50,7 +50,7 @@ defmodule Realtime.SubscriptionManagerTest do
       [
         %{
           channel_pid: self(),
-          topic: "test_topic",
+          params: %{"schema" => "*"},
           id: @subscription_id,
           claims: @claims
         }
@@ -64,14 +64,14 @@ defmodule Realtime.SubscriptionManagerTest do
        %{
          replication_mode: "RLS",
          subscription_params: %{
-           self() => %{
-             entities: [],
-             filters: [],
-             topic: "test_topic",
-             id: "bbb51e4e-f371-4463-bf0a-af8f56dc9a71",
-             claims: %{"role" => "authenticated"},
-             claims_role: "authenticated"
-           }
+           self() => [
+             %{
+               channel_pid: self(),
+               params: %{"schema" => "*"},
+               id: @subscription_id,
+               claims: @claims
+             }
+           ]
          }
        }}
 
@@ -86,7 +86,7 @@ defmodule Realtime.SubscriptionManagerTest do
       [
         %{
           channel_pid: self(),
-          topic: "test_topic",
+          params: %{"schema" => "public", "table" => "*"},
           id: bin,
           claims: @claims
         }
@@ -96,14 +96,14 @@ defmodule Realtime.SubscriptionManagerTest do
     state = %{
       replication_mode: "RLS",
       subscription_params: %{
-        self() => %{
-          entities: [],
-          filters: [],
-          topic: "test_topic",
-          id: bin,
-          claims: %{"role" => "authenticated"},
-          claims_role: "authenticated"
-        }
+        self() => [
+          %{
+            channel_pid: self(),
+            params: %{"schema" => "public", "table" => "*"},
+            id: bin,
+            claims: @claims
+          }
+        ]
       },
       sync_interval: 15_000,
       sync_ref: make_ref()
@@ -121,20 +121,21 @@ defmodule Realtime.SubscriptionManagerTest do
       [
         %{
           channel_pid: self(),
-          topic: "test_topic",
+          params: %{"schema" => "*"},
           id: bin,
           claims: @claims
         }
       ]
     }
 
-    prev_sub = %{
-      entities: [16537],
-      filters: [],
-      topic: "public:todos",
-      id: bin,
-      claims: @claims
-    }
+    prev_sub = [
+      %{
+        channel_pid: :some_prev_pid,
+        params: %{"schema" => "public"},
+        id: bin,
+        claims: @claims
+      }
+    ]
 
     state = %{
       replication_mode: "RLS",
@@ -152,14 +153,14 @@ defmodule Realtime.SubscriptionManagerTest do
         assert is_reference(new_state.sync_ref)
         assert sub_param.some_prev_pid == prev_sub
 
-        assert sub_param[self()] == %{
-                 entities: [],
-                 filters: [],
-                 topic: "test_topic",
-                 id: bin,
-                 claims: @claims,
-                 claims_role: "authenticated"
-               }
+        assert sub_param[self()] == [
+                 %{
+                   channel_pid: self(),
+                   params: %{"schema" => "*"},
+                   id: bin,
+                   claims: @claims
+                 }
+               ]
 
       other ->
         assert match?({:reply, :ok, _}, other)

--- a/server/test/realtime/subscription_manager_test.exs
+++ b/server/test/realtime/subscription_manager_test.exs
@@ -79,15 +79,13 @@ defmodule Realtime.SubscriptionManagerTest do
   end
 
   test "handle_call/track_topic_subscribers, when subscription_params is not empty" do
-    {_, bin} = Ecto.UUID.dump(@subscription_id)
-
     mess = {
       :track_topic_subscribers,
       [
         %{
           channel_pid: self(),
           params: %{"schema" => "public", "table" => "*"},
-          id: bin,
+          id: @subscription_id,
           claims: @claims
         }
       ]
@@ -100,7 +98,7 @@ defmodule Realtime.SubscriptionManagerTest do
           %{
             channel_pid: self(),
             params: %{"schema" => "public", "table" => "*"},
-            id: bin,
+            id: @subscription_id,
             claims: @claims
           }
         ]
@@ -114,15 +112,13 @@ defmodule Realtime.SubscriptionManagerTest do
   end
 
   test "handle_call/track_topic_subscribers, updated state" do
-    {_, bin} = Ecto.UUID.dump(@subscription_id)
-
     mess = {
       :track_topic_subscribers,
       [
         %{
           channel_pid: self(),
           params: %{"schema" => "*"},
-          id: bin,
+          id: @subscription_id,
           claims: @claims
         }
       ]
@@ -132,7 +128,7 @@ defmodule Realtime.SubscriptionManagerTest do
       %{
         channel_pid: :some_prev_pid,
         params: %{"schema" => "public"},
-        id: bin,
+        id: @subscription_id,
         claims: @claims
       }
     ]
@@ -157,7 +153,7 @@ defmodule Realtime.SubscriptionManagerTest do
                  %{
                    channel_pid: self(),
                    params: %{"schema" => "*"},
-                   id: bin,
+                   id: @subscription_id,
                    claims: @claims
                  }
                ]
@@ -198,7 +194,6 @@ defmodule Realtime.SubscriptionManagerTest do
 
   test "handle_info/sync_subscription, when subscription_params is not empty" do
     msg = {:DOWN, make_ref(), :process, self(), :any}
-    {_, bin} = Ecto.UUID.dump(@subscription_id)
 
     state = %{
       subscription_params: %{
@@ -206,7 +201,7 @@ defmodule Realtime.SubscriptionManagerTest do
           entities: [],
           filters: [],
           topic: "public:todos",
-          id: bin,
+          id: @subscription_id,
           claims: @claims
         }
       }
@@ -221,7 +216,6 @@ defmodule Realtime.SubscriptionManagerTest do
     with_mock Realtime.RLS.Subscriptions,
       delete_topic_subscriber: fn _ -> raise "" end do
       msg = {:DOWN, make_ref(), :process, self(), :any}
-      {_, bin} = Ecto.UUID.dump(@subscription_id)
 
       state = %{
         subscription_params: %{
@@ -229,7 +223,7 @@ defmodule Realtime.SubscriptionManagerTest do
             entities: [],
             filters: [],
             topic: "public:todos",
-            id: bin,
+            id: @subscription_id,
             claims: @claims
           }
         }

--- a/server/test/realtime_web/channels/realtime_channel_test.exs
+++ b/server/test/realtime_web/channels/realtime_channel_test.exs
@@ -33,8 +33,8 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     }
 
     broadcast_change(
-      "postgres_changes:#{Ecto.UUID.cast!(id)}",
-      Map.put(change, :subscription_ids, MapSet.new([id]))
+      "postgres_changes:#{id}",
+      change
     )
 
     assert_push("INSERT", ^change)
@@ -50,8 +50,8 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     }
 
     broadcast_change(
-      "postgres_changes:#{Ecto.UUID.cast!(id)}",
-      Map.put(change, :subscription_ids, MapSet.new([id]))
+      "postgres_changes:#{id}",
+      change
     )
 
     assert_push("UPDATE", ^change)
@@ -67,8 +67,8 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     }
 
     broadcast_change(
-      "postgres_changes:#{Ecto.UUID.cast!(id)}",
-      Map.put(change, :subscription_ids, MapSet.new([id]))
+      "postgres_changes:#{id}",
+      change
     )
 
     assert_push("DELETE", ^change)


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Update `Realtime.RLS.Subscriptions` to use a single query for inserting topic subscribers into `realtime.subscription`
