### PR TITLE
Updated Broken Images & Specifying the theme with prefers-color-scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <br />
 <p align="center">
   <a href="https://supabase.io">
-    <img src="https://raw.githubusercontent.com/supabase/supabase/master/web/static/supabase-light-rounded-corner-background.svg" alt="Supabase Logo" width="300">
+        <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/supabase-logo-wordmark--light.svg">
+      <img alt="Supabase Logo" width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/packages/common/assets/images/logo-preview.jpg">
+    </picture>
   </a>
 
   <h1 align="center">Supabase Realtime</h1>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed the Broken Image In README.md.

Updated specifying images based on the theme with new method  by using the HTML `<picture>` element in combination with the prefers-color-scheme media feature.

The old method of specifying images based on the theme, by using a fragment appended to the URL (#gh-dark-mode-only or #gh-light-mode-only), is deprecated and will be removed in favor of the new method described above.

[Source](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to)

## What is the current behavior?
![image](https://user-images.githubusercontent.com/53650724/190866221-7dcdf2f4-9347-4a9c-933c-df8d9fdbbb73.png)
Broken Image In README.md.

## What is the new behavior?
Updated Broken Images & Specifying the theme with prefers-color-scheme
![image](https://user-images.githubusercontent.com/53650724/190866290-629b27b6-27d6-4922-8626-e418718fa09b.png)

Feel free to include screenshots if it includes visual changes.