### PR TITLE
chore: add ci job to mirror docker images to ecr

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,23 @@
+name: Mirror to ECR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Image tag"
+        required: true
+        type: string
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.PROD_ACCESS_KEY_ID }}
+          password: ${{ secrets.PROD_SECRET_ACCESS_KEY }}
+      - uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: docker.io/supabase/realtime:${{ inputs.version }}
+          dst: public.ecr.aws/t3w2s2c9/realtime:${{ inputs.version }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

GHA workflow

## What is the new behavior?

supports running one off action to mirror specific image tags: `v0.22.7` is [needed](https://github.com/supabase/cli/issues/429)
similar to https://github.com/supabase/postgres/blob/develop/.github/workflows/mirror.yml

## Additional context

Add any other context or screenshots.
