### PR TITLE
chore: upgrade supabase/postgres image version to 14.1.0.77

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   db:
-    image: supabase/postgres:14.1.0.34
+    image: supabase/postgres:14.1.0.77
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - db
   db:
-    image: supabase/postgres:14.1.0.34
+    image: supabase/postgres:14.1.0.77
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.rls.dev.yml
+++ b/docker-compose.rls.dev.yml
@@ -25,7 +25,7 @@ services:
       bash -c "./prod/rel/realtime/bin/realtime eval Realtime.Release.migrate
       && ./prod/rel/realtime/bin/realtime start"
   db:
-    image: supabase/postgres:14.1.0.34
+    image: supabase/postgres:14.1.0.77
     ports:
       - 5432:5432
     volumes:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the new behavior?

`supabase/postgres` docker image is bumped up to 14.1.0.77.