### PR TITLE
chore!: split up qemu and buildx steps in Multi-Tenant prod workflow

### DIFF
--- a/.github/workflows/mt_prod.yml
+++ b/.github/workflows/mt_prod.yml
@@ -49,10 +49,11 @@ jobs:
           tags: |
             type=raw,value=v${{ needs.release.outputs.version }}
 
-      - uses: docker/setup-qemu-action@v2
-        with:
-          platforms: amd64,arm64
-      - uses: docker/setup-buildx-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v2


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the current behavior?

Upload docker image error due to segmentation fault.

## What is the new behavior?

Hopefully, both arm64 and amd64 are deployed.

## Additional context

- https://github.com/supabase/realtime/actions/runs/3432087293/jobs/5721071413
