### PR TITLE
feat: includes tailscale for private connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,16 @@
 ARG ELIXIR_VERSION=1.14.0
 ARG OTP_VERSION=25.0.4
 ARG DEBIAN_VERSION=bullseye-20220801-slim
+ARG TAILSCALE_VERSION=1.32.2
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+FROM alpine:latest as tailscale
+WORKDIR /app
+ENV TSFILE=tailscale_${TAILSCALE_VERSION}_amd64.tgz
+RUN wget https://pkgs.tailscale.com/stable/${TSFILE} && tar xzf ${TSFILE} --strip-components=1
+COPY tailscale/wrapper.sh ./
 
 FROM ${BUILDER_IMAGE} as builder
 
@@ -96,9 +103,13 @@ ENV MIX_ENV="prod"
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/realtime ./
 
-USER nobody
+RUN mkdir /tailscale
+COPY --from=tailscale /app/wrapper.sh /tailscale/wrapper.sh
+COPY --from=tailscale /app/tailscaled /tailscale/tailscaled
+COPY --from=tailscale /app/tailscale /tailscale/tailscale
+RUN mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale
 
-CMD ["/app/bin/server"]
+CMD ["/tailscale/wrapper.sh"]
 # Appended by flyctl
 ENV ECTO_IPV6 true
 ENV ERL_AFLAGS "-proto_dist inet6_tcp"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,12 @@
 ARG ELIXIR_VERSION=1.14.0
 ARG OTP_VERSION=25.0.4
 ARG DEBIAN_VERSION=bullseye-20220801-slim
-ARG TAILSCALE_VERSION=1.32.2
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 
 FROM alpine:latest as tailscale
+ARG TAILSCALE_VERSION=1.32.2
 WORKDIR /app
 ENV TSFILE=tailscale_${TAILSCALE_VERSION}_amd64.tgz
 RUN wget https://pkgs.tailscale.com/stable/${TSFILE} && tar xzf ${TSFILE} --strip-components=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN mix release
 # the compiled release and other runtime necessities
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales \
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales iptables sudo \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale

--- a/tailscale/wrapper.sh
+++ b/tailscale/wrapper.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+
+set -x
+set -euo pipefail
 
 if [[ -n "${ENABLE_TAILSCALE}" ]]; then
     echo "Enabling Tailscale"
@@ -7,4 +10,5 @@ if [[ -n "${ENABLE_TAILSCALE}" ]]; then
     /tailscale/tailscale up --authkey=${TAILSCALE_AUTHKEY} --hostname="${TAILSCALE_APP_NAME}" --accept-routes=true
 fi
 
+echo "Starting Realtime"
 sudo -u nobody /app/bin/server

--- a/tailscale/wrapper.sh
+++ b/tailscale/wrapper.sh
@@ -11,4 +11,4 @@ if [[ -n "${ENABLE_TAILSCALE}" ]]; then
 fi
 
 echo "Starting Realtime"
-sudo -u nobody /app/bin/server
+sudo -E -u nobody /app/bin/server

--- a/tailscale/wrapper.sh
+++ b/tailscale/wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [[ -n "${ENABLE_TAILSCALE}" ]]; then
+    echo "Enabling Tailscale"
+    TAILSCALE_APP_NAME="${TAILSCALE_APP_NAME:-${FLY_APP_NAME}-${FLY_REGION}}-${FLY_ALLOC_ID:0:8}"
+    /tailscale/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
+    /tailscale/tailscale up --authkey=${TAILSCALE_AUTHKEY} --hostname="${TAILSCALE_APP_NAME}" --accept-routes=true
+fi
+
+sudo -u nobody /app/bin/server


### PR DESCRIPTION
Functionality is behind a ENABLE_TAILSCALE env var, without which we do not attempt to start tailscale. This should cater for self-hosted setups that don't require tailscale.
