### PR TITLE
fix: Revert "chore: move ECTO_IPV6 and ERL_AFLAGS from Dockerfile to …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,3 +99,6 @@ COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/realtime ./
 USER nobody
 
 CMD ["/app/bin/server"]
+# Appended by flyctl
+ENV ECTO_IPV6 true
+ENV ERL_AFLAGS "-proto_dist inet6_tcp"

--- a/deploy/fly/prod.toml
+++ b/deploy/fly/prod.toml
@@ -9,8 +9,6 @@ processes = []
 
 [env]
   DNS_NODES = "realtime-prod.internal"
-  ECTO_IPV6 = true
-  ERL_AFLAGS = "-proto_dist inet6_tcp"
 
 [experimental]
   allowed_public_ports = []

--- a/deploy/fly/qa.toml
+++ b/deploy/fly/qa.toml
@@ -9,8 +9,6 @@ processes = []
 
 [env]
   DNS_NODES = "realtime-qa.internal"
-  ECTO_IPV6 = true
-  ERL_AFLAGS = "-proto_dist inet6_tcp"
 
 [experimental]
   allowed_public_ports = []

--- a/deploy/fly/staging.toml
+++ b/deploy/fly/staging.toml
@@ -9,8 +9,6 @@ processes = []
 
 [env]
   DNS_NODES = "realtime-staging.internal"
-  ECTO_IPV6 = true
-  ERL_AFLAGS = "-proto_dist inet6_tcp"
 
 [experimental]
   allowed_public_ports = []


### PR DESCRIPTION
…toml files"

This reverts commit f63de63dd0288abf139f611d832c8058824805a3.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Seeing `unable to connect to...`

## What is the new behavior?

Fly is able to connect to the nodes internally via IPv6.
