### PR TITLE
chore: remove compilers from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,6 @@ defmodule Realtime.MixProject do
       version: "2.0.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

remove unnecessary compilers due to upgrade to elixir v1.14

## Additional context

See: https://gist.github.com/chrismccord/00a6ea2a96bc57df0cce526bd20af8a7#remove-the-phoenix-and-gettext-compilers-from-your-mixexss-project0-compilers-configuration