### PR TITLE
feat: enable Fly gru region nodes to read from closest db replica

### DIFF
--- a/lib/realtime/repo.ex
+++ b/lib/realtime/repo.ex
@@ -8,6 +8,7 @@ defmodule Realtime.Repo do
 
   @replicas %{
     "fra" => Realtime.Repo.Replica.FRA,
+    "gru" => Realtime.Repo.Replica.IAD,
     "iad" => Realtime.Repo.Replica.IAD,
     "sin" => Realtime.Repo.Replica.SIN
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Fly `gru` (São Paulo) nodes are reading from AWS ap-southeast database

## What is the new behavior?

Fly `gru` nodes are reading from AWS us-east database replica
