### PR TITLE
Feat: append short commit sha to slot name

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "-c deploy/fly/prod.toml deploy"
+          args: "-c deploy/fly/prod.toml deploy —-build-arg COMMIT=$(git rev-parse --short HEAD)"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "-c deploy/fly/prod.toml deploy —-build-arg COMMIT=$(git rev-parse --short HEAD)"
+          args: "-c deploy/fly/prod.toml deploy --build-arg SLOT_NAME_SUFFIX=$(git rev-parse --short HEAD)"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "-c deploy/fly/staging.toml deploy"
+          args: "-c deploy/fly/staging.toml deploy —-build-arg COMMIT=$(git rev-parse --short HEAD)"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "-c deploy/fly/staging.toml deploy —-build-arg COMMIT=$(git rev-parse --short HEAD)"
+          args: "-c deploy/fly/staging.toml deploy --build-arg SLOT_NAME_SUFFIX=$(git rev-parse --short HEAD)"

--- a/.github/workflows/staging_supabench.yml
+++ b/.github/workflows/staging_supabench.yml
@@ -16,7 +16,7 @@ jobs:
           args: "-c deploy/fly/qa.toml scale count 1"
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "-c deploy/fly/qa.toml deploy"
+          args: "-c deploy/fly/qa.toml deploy —-build-arg COMMIT=$(git rev-parse --short HEAD)"
       - uses: superfly/flyctl-actions@1.1
         if: always()
         with:

--- a/.github/workflows/staging_supabench.yml
+++ b/.github/workflows/staging_supabench.yml
@@ -16,7 +16,7 @@ jobs:
           args: "-c deploy/fly/qa.toml scale count 1"
       - uses: superfly/flyctl-actions@1.1
         with:
-          args: "-c deploy/fly/qa.toml deploy —-build-arg COMMIT=$(git rev-parse --short HEAD)"
+          args: "-c deploy/fly/qa.toml deploy --build-arg SLOT_NAME_SUFFIX=$(git rev-parse --short HEAD)"
       - uses: superfly/flyctl-actions@1.1
         if: always()
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /app
 
 # install hex + rebar
 RUN mix local.hex --force && \
-    mix local.rebar --force
+  mix local.rebar --force
 
 # set build ENV
 ENV MIX_ENV="prod"
@@ -99,6 +99,11 @@ RUN chown nobody /app
 
 # set runner ENV
 ENV MIX_ENV="prod"
+
+# put commit sha
+# deploy with `flyctl deploy --build-arg COMMIT=$(git rev-parse --short HEAD)`
+ARG COMMIT
+ENV COMMIT_SHA="${COMMIT}"
 
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/realtime ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,9 +101,9 @@ RUN chown nobody /app
 ENV MIX_ENV="prod"
 
 # put commit sha
-# deploy with `flyctl deploy --build-arg COMMIT=$(git rev-parse --short HEAD)`
-ARG COMMIT
-ENV COMMIT_SHA="${COMMIT}"
+# deploy with `flyctl deploy --build-arg SLOT_NAME_SUFFIX=$(git rev-parse --short HEAD)`
+ARG SLOT_NAME_SUFFIX
+ENV SLOT_NAME_SUFFIX="${SLOT_NAME_SUFFIX}"
 
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/realtime ./

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 dev:
-	PORT=4000 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name pink@127.0.0.1 --cookie cookie  -S mix phx.server
+	COMMIT_SHA=some_sha PORT=4000 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name pink@127.0.0.1 --cookie cookie  -S mix phx.server
 
 dev.orange:
-	PORT=4001 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name orange@127.0.0.1 --cookie cookie  -S mix phx.server
+	COMMIT_SHA=some_sha PORT=4001 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name orange@127.0.0.1 --cookie cookie  -S mix phx.server
 
 seed:
 	mix run priv/repo/seeds.exs
 
 prod:
-	MIX_ENV=prod FLY_APP_NAME=realtime-local SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" SECRET_KEY_BASE=M+55t7f6L9VWyhH03R5N7cIhrdRlZaMDfTE6Udz0eZS7gCbnoLQ8PImxwhEyao6D DASHBOARD_USER=realtime_local DASHBOARD_PASSWORD=password ERL_AFLAGS="-kernel shell_history enabled" iex -S mix phx.server
+	COMMIT_SHA=some_sha MIX_ENV=prod FLY_APP_NAME=realtime-local SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" SECRET_KEY_BASE=M+55t7f6L9VWyhH03R5N7cIhrdRlZaMDfTE6Udz0eZS7gCbnoLQ8PImxwhEyao6D DASHBOARD_USER=realtime_local DASHBOARD_PASSWORD=password ERL_AFLAGS="-kernel shell_history enabled" iex -S mix phx.server
 
 swagger:
 	mix phx.swagger.generate
 
 bench.%:
-	MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" mix run bench/$*
+	COMMIT_SHA=some_sha MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" mix run bench/$*
 
 dev_db:
 	docker-compose -f docker-compose.dbs.yml up -d && mix ecto.migrate --log-migrator-sql

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 dev:
-	COMMIT_SHA=some_sha PORT=4000 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name pink@127.0.0.1 --cookie cookie  -S mix phx.server
+	SLOT_NAME_SUFFIX=some_sha PORT=4000 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name pink@127.0.0.1 --cookie cookie  -S mix phx.server
 
 dev.orange:
-	COMMIT_SHA=some_sha PORT=4001 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name orange@127.0.0.1 --cookie cookie  -S mix phx.server
+	SLOT_NAME_SUFFIX=some_sha PORT=4001 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name orange@127.0.0.1 --cookie cookie  -S mix phx.server
 
 seed:
 	mix run priv/repo/seeds.exs
 
 prod:
-	COMMIT_SHA=some_sha MIX_ENV=prod FLY_APP_NAME=realtime-local SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" SECRET_KEY_BASE=M+55t7f6L9VWyhH03R5N7cIhrdRlZaMDfTE6Udz0eZS7gCbnoLQ8PImxwhEyao6D DASHBOARD_USER=realtime_local DASHBOARD_PASSWORD=password ERL_AFLAGS="-kernel shell_history enabled" iex -S mix phx.server
+	SLOT_NAME_SUFFIX=some_sha MIX_ENV=prod FLY_APP_NAME=realtime-local API_KEY=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" SECRET_KEY_BASE=M+55t7f6L9VWyhH03R5N7cIhrdRlZaMDfTE6Udz0eZS7gCbnoLQ8PImxwhEyao6D DASHBOARD_USER=realtime_local DASHBOARD_PASSWORD=password ERL_AFLAGS="-kernel shell_history enabled" iex -S mix phx.server
 
 swagger:
 	mix phx.swagger.generate
 
 bench.%:
-	COMMIT_SHA=some_sha MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" mix run bench/$*
+	SLOT_NAME_SUFFIX=some_sha MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" mix run bench/$*
 
 dev_db:
 	docker-compose -f docker-compose.dbs.yml up -d && mix ecto.migrate --log-migrator-sql

--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -58,7 +58,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
       poll_interval_ms: args["poll_interval_ms"],
       poll_ref: make_ref(),
       publication: args["publication"],
-      slot_name: args["slot_name"] <> "_" <> commit_sha(),
+      slot_name: args["slot_name"] <> slot_name_suffix(),
       tenant: args["id"]
     }
 
@@ -269,7 +269,14 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
     )
   end
 
-  defp commit_sha() do
-    System.get_env("COMMIT_SHA", "unknown_sha")
+  def slot_name_suffix() do
+    case System.get_env("SLOT_NAME_SUFFIX") do
+      nil ->
+        ""
+
+      value ->
+        Logger.debug("Using slot name suffix: " <> value)
+        "_" <> value
+    end
   end
 end

--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -58,7 +58,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
       poll_interval_ms: args["poll_interval_ms"],
       poll_ref: make_ref(),
       publication: args["publication"],
-      slot_name: args["slot_name"],
+      slot_name: args["slot_name"] <> "_" <> commit_sha(),
       tenant: args["id"]
     }
 
@@ -267,5 +267,9 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
       ],
       socket_options: socket_opts
     )
+  end
+
+  defp commit_sha() do
+    System.get_env("COMMIT_SHA", "unknown_sha")
   end
 end

--- a/test/realtime/extensions/cdc_rls/replication_poller_test.exs
+++ b/test/realtime/extensions/cdc_rls/replication_poller_test.exs
@@ -1,7 +1,8 @@
 defmodule ReplicationPollerTest do
   use ExUnit.Case
 
-  import Extensions.PostgresCdcRls.ReplicationPoller, only: [generate_record: 1]
+  alias Extensions.PostgresCdcRls.ReplicationPoller, as: Poller
+  import Poller, only: [generate_record: 1]
 
   alias Realtime.Adapters.Changes.{
     DeletedRecord,
@@ -283,5 +284,17 @@ defmodule ReplicationPollerTest do
     }
 
     assert expected == generate_record(record)
+  end
+
+  describe "slot_name_suffix" do
+    test "when no SLOT_NAME_SUFFIX" do
+      System.delete_env("SLOT_NAME_SUFFIX")
+      assert Poller.slot_name_suffix() == ""
+    end
+
+    test "when SLOT_NAME_SUFFIX defined" do
+      System.put_env("SLOT_NAME_SUFFIX", "some_val")
+      assert Poller.slot_name_suffix() == "_some_val"
+    end
   end
 end


### PR DESCRIPTION
Problem:
Sometimes during deployment two nodes try to connect to the same replication slot.

Solution:
Let's append the short git sha to the slot name. Now every new deployment will create an additional replication slot. And since we use temporary replication slots when nothing is connected to the old slot it should kill itself. 