### PR TITLE
Feat: cluster latency matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 dev:
-	MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name node@127.0.0.1 --cookie cookie  -S mix phx.server
+	PORT=4000 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name pink@127.0.0.1 --cookie cookie  -S mix phx.server
+
+dev.orange:
+	PORT=4001 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name orange@127.0.0.1 --cookie cookie  -S mix phx.server
 
 seed:
 	mix run priv/repo/seeds.exs

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,7 +15,7 @@ config :realtime,
   presence: presence
 
 config :realtime, RealtimeWeb.Endpoint,
-  http: [port: 4000],
+  http: [port: System.get_env("PORT", "4000")],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
@@ -81,3 +81,15 @@ config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
+
+config :libcluster,
+  topologies: [
+    dev: [
+      strategy: Cluster.Strategy.Epmd,
+      config: [
+        hosts: [:"orange@127.0.0.1", :"pink@127.0.0.1"]
+      ],
+      connect: {:net_kernel, :connect_node, []},
+      disconnect: {:net_kernel, :disconnect_node, []}
+    ]
+  ]

--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -66,7 +66,8 @@ defmodule Realtime.Application do
         Realtime.RateCounter.DynamicSupervisor,
         RealtimeWeb.Endpoint,
         RealtimeWeb.Presence,
-        {Task.Supervisor, name: Realtime.TaskSupervisor}
+        {Task.Supervisor, name: Realtime.TaskSupervisor},
+        Realtime.Latency
       ] ++ extensions_supervisors
 
     children =

--- a/lib/realtime/monitoring/latency.ex
+++ b/lib/realtime/monitoring/latency.ex
@@ -1,0 +1,108 @@
+defmodule Realtime.Latency do
+  @moduledoc """
+    Measures the latency of the cluster from each node and broadcasts it over PubSub.
+  """
+
+  use GenServer
+
+  require Logger
+
+  defmodule Payload do
+    @moduledoc false
+
+    @defstruct [
+      :from_node,
+      :node,
+      :latency,
+      :response
+    ]
+
+    #    @type t :: %__MODULE__{
+    #            node: atom(),
+    #            latency: integer(),
+    #            response: {:ok, :pong} | {:badrpc, any()}
+    #          }
+  end
+
+  @every 5_000
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
+  end
+
+  def init(_args) do
+    ping_after()
+
+    {:ok, []}
+  end
+
+  def hanle_info(:ping, state) do
+    # This bullshit is not getting called
+    ping()
+    ping_after()
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    # IO.inspect(msg, label: "BULLSHIT")
+    ping()
+    ping_after()
+    {:noreply, state}
+  end
+
+  @doc """
+  Pings all the nodes in the cluster one after another and returns with their responses.
+  There is a timeout for a single node rpc, and a timeout to yield_many which should really
+  never get hit because these pings happen async under the Realtime.TaskSupervisor.
+  """
+
+  @spec ping :: [{%Task{}, tuple()}]
+  def ping() do
+    for n <- Node.list() do
+      {latency, {status, _respose} = reply} =
+        :timer.tc(fn -> :rpc.call(n, __MODULE__, :pong, [], 5_000) end)
+
+      latency_ms = latency / 1_000
+
+      fly_region = Application.get_env(:realtime, :fly_region)
+
+      if status == :badrpc,
+        do: Logger.error("Network error: can't connect to node #{n} from #{fly_region}")
+
+      if latency_ms > 1_000,
+        do:
+          Logger.warn(
+            "Network warning: latency is > #{latency_ms} ms to node #{n} from #{fly_region}"
+          )
+
+      payload = %{
+        from_node: Node.self(),
+        node: n,
+        latency: latency_ms,
+        response: reply
+      }
+
+      RealtimeWeb.Endpoint.broadcast("admin:cluster", "pong", payload)
+
+      payload
+    end
+  end
+
+  @doc """
+  A noop function to call from a remote server.
+  """
+
+  @spec pong :: {:ok, :pong}
+  def pong() do
+    {:ok, :pong}
+  end
+
+  @spec pong(:infinity | non_neg_integer) :: {:ok, :pong}
+  def pong(latency) when is_integer(latency) do
+    Process.sleep(latency)
+    {:ok, :pong}
+  end
+
+  defp ping_after() do
+    Process.send_after(self(), :ping, @every)
+  end
+end

--- a/lib/realtime_web/live/page_live/index.html.heex
+++ b/lib/realtime_web/live/page_live/index.html.heex
@@ -6,6 +6,7 @@
 <h3 class="font-bold">Tools</h3>
 <ul>
     <li><%= live_redirect "🔎 Inspector", to: Routes.inspector_index_path(@socket, :new) %></li>
+    <li><%= live_redirect "🟢 Status", to: Routes.status_index_path(@socket, :index) %></li>
 </ul>
 </div>
 

--- a/lib/realtime_web/live/status_live/index.ex
+++ b/lib/realtime_web/live/status_live/index.ex
@@ -1,0 +1,44 @@
+defmodule RealtimeWeb.StatusLive.Index do
+  use RealtimeWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: RealtimeWeb.Endpoint.subscribe("admin:cluster")
+    {:ok, assign(socket, pings: default_pings(), nodes: Enum.count(all_nodes()))}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{payload: payload}, socket) do
+    payload = %{
+      payload.from_node => %{
+        node: payload.node,
+        latency: payload.latency,
+        response: payload.response
+      }
+    }
+
+    pings = Map.merge(socket.assigns.pings, payload)
+
+    {:noreply, assign(socket, pings: pings)}
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Status - Supabase Realtime")
+  end
+
+  defp all_nodes() do
+    [Node.self() | Node.list()]
+  end
+
+  defp default_pings() do
+    for n <- all_nodes(), f <- all_nodes(), into: %{} do
+      {n, %{from_node: f, latency: 0, node: "Loading..."}}
+    end
+  end
+end

--- a/lib/realtime_web/live/status_live/index.html.heex
+++ b/lib/realtime_web/live/status_live/index.html.heex
@@ -1,0 +1,15 @@
+<.h1>Supabase Realtime: Multiplayer Edition</.h1>
+<.h2>Cluster Status</.h2>
+<p>Understand the latency between nodes across the Realtime cluster.</p>
+
+<div class="my-5">
+    <div class="grid grid-cols-4 gap-12 py-4">
+    <%= for {from_node, p} <- @pings do %>
+        <div class="p-4 border-2 whitespace-nowrap overflow-hidden">
+            <div>From: <%= from_node %></div>
+            <div>To: <%= p.node %></div>
+            <div><%= p.latency %> ms</div>
+        </div>
+    <% end %>
+    </div>
+</div>

--- a/lib/realtime_web/live/status_live/index.html.heex
+++ b/lib/realtime_web/live/status_live/index.html.heex
@@ -4,11 +4,12 @@
 
 <div class="my-5">
     <div class="grid grid-cols-4 gap-12 py-4">
-    <%= for {from_node, p} <- @pings do %>
+    <%= for {_pair, p} <- @pings do %>
         <div class="p-4 border-2 whitespace-nowrap overflow-hidden">
-            <div>From: <%= from_node %></div>
+            <div>From: <%= p.from_node %></div>
             <div>To: <%= p.node %></div>
             <div><%= p.latency %> ms</div>
+            <div><%= p.timestamp %></div>
         </div>
     <% end %>
     </div>

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -39,6 +39,7 @@ defmodule RealtimeWeb.Router do
     live "/", PageLive.Index, :index
     live "/inspector", InspectorLive.Index, :index
     live "/inspector/new", InspectorLive.Index, :new
+    live "/status", StatusLive.Index, :index
   end
 
   scope "/admin", RealtimeWeb do

--- a/test/realtime/latency_test.exs
+++ b/test/realtime/latency_test.exs
@@ -1,0 +1,4 @@
+defmodule Realtime.LatencyTest do
+  use Realtime.DataCase, async: true
+  doctest Realtime.Latency
+end


### PR DESCRIPTION
Problem: 
It's difficult to understand when our host is having subtle networking issues.

Solution:
We now have a GenServer to ping each node in the cluster from each node every 5 seconds. 

It logs:
- when the rpc fails
- when the latency of the rpc is over a certain value

We also have a LiveView to see realtime latencies between all nodes on a matrix:

<img width="756" alt="Screen Shot 2022-12-07 at 12 42 10 PM" src="https://user-images.githubusercontent.com/1019814/206281565-a1ec4fd1-894b-4f10-bbfe-4cea1a8a54eb.png">
