### PR TITLE
Feat: validate subscription params a bit more

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -148,11 +148,17 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
       {:ok, ["public", "messages", [{"subject", "eq", "hey"}]]}
 
-  A not supported filter will response with:
+  An unsupported filter will response with an error tuple:
 
       iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=in.hey"}
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
       {:error, ~s(Error parsing `filter` params: ["in", "hey"])}
+
+  Catch `undefined` filters:
+
+      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "undefined"}
+      iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
+      {:error, ~s(Error parsing `filter` params: ["undefined"])}
 
   """
 

--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -135,8 +135,19 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
     end
   end
 
-  defp parse_subscription_params(params) do
-    # filter example "body=eq.hey"
+  @doc """
+  Parses subscription filter parameters into something we can pass into our `create_subscription` query.
+
+  ## Examples
+
+      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=eq.hey"}
+      iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
+      ["public", "messages", [{"subject", "eq", "hey"}]]
+
+  """
+
+  @spec parse_subscription_params(map()) :: list
+  def parse_subscription_params(params) do
     case params do
       %{"schema" => schema, "table" => table, "filter" => filter} ->
         with [col, rest] <- String.split(filter, "=", parts: 2),

--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -148,7 +148,7 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
       {:ok, ["public", "messages", [{"subject", "eq", "hey"}]]}
 
-  An unsupported filter will response with an error tuple:
+  An unsupported filter will respond with an error tuple:
 
       iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=in.hey"}
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -1,5 +1,7 @@
 defmodule Realtime.Extensions.CdcRlsSubscriptionsTest do
   use RealtimeWeb.ChannelCase
+  doctest Extensions.PostgresCdcRls.Subscriptions
+
   alias Extensions.PostgresCdcRls.Subscriptions, as: S
   alias Postgrex, as: P
 

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -59,7 +59,8 @@ defmodule Realtime.Extensions.CdcRlsSubscriptionsTest do
       }
     ]
 
-    assert {:error, :malformed_subscription_params} =
+    assert {:error,
+            "No subscription params provided. Please provide at least a `schema` or `table` to subscribe to."} =
              S.create(conn, "supabase_realtime_test", params_list)
 
     %Postgrex.Result{rows: [[num]]} =


### PR DESCRIPTION
Problem: 

It was hard to tell which subscription params we supported.

Solution:

Tests, and being more explicit about what is failing when we parse subscription params.