### PR TITLE
Fix: do not block a registration process

### DIFF
--- a/lib/extensions/postgres_cdc_rls/syn_handler.ex
+++ b/lib/extensions/postgres_cdc_rls/syn_handler.ex
@@ -1,4 +1,7 @@
 defmodule Extensions.PostgresCdcRls.SynHandler do
+  @moduledoc """
+  Custom defined Syn's callbacks
+  """
   require Logger
   alias RealtimeWeb.Endpoint
 

--- a/lib/extensions/postgres_cdc_rls/syn_handler.ex
+++ b/lib/extensions/postgres_cdc_rls/syn_handler.ex
@@ -44,8 +44,14 @@ defmodule Extensions.PostgresCdcRls.SynHandler do
       end
 
     target = node(stop)
-    Logger.warn("Resolving #{name} conflict, target: #{inspect(target)}")
-    :rpc.call(target, DynamicSupervisor, :stop, [stop, :normal, 15_000])
+
+    Logger.warn(
+      "Resolving #{name} conflict, stop pid #{inspect(stop)} on the node #{inspect(target)}"
+    )
+
+    spawn(fn ->
+      DynamicSupervisor.stop(stop, :shutdown, 15_000)
+    end)
 
     keep
   end

--- a/lib/extensions/postgres_cdc_rls/syn_handler.ex
+++ b/lib/extensions/postgres_cdc_rls/syn_handler.ex
@@ -43,15 +43,13 @@ defmodule Extensions.PostgresCdcRls.SynHandler do
           end
       end
 
-    target = node(stop)
-
-    Logger.warn(
-      "Resolving #{name} conflict, stop pid #{inspect(stop)} on the node #{inspect(target)}"
-    )
-
-    spawn(fn ->
-      DynamicSupervisor.stop(stop, :shutdown, 15_000)
-    end)
+    if node() == node(stop) do
+      resp = DynamicSupervisor.stop(stop, :shutdown, 4_000)
+      "Resolving #{name} conflict, stop local pid: #{inspect(stop)}, response: #{inspect(resp)}"
+    else
+      "Resolving #{name} conflict, remote pid: #{inspect(stop)}"
+    end
+    |> Logger.warn()
 
     keep
   end


### PR DESCRIPTION
The conflict is resolved in the same process as registration. This PR tries to stop the supervisor tree in the background to avoid a timeout on the `register_or_update_on_node` message.