### PR TITLE
fix: remove uniq_external_id index from tenants table

### DIFF
--- a/priv/repo/migrations/20221223010058_drop_tenants_uniq_external_id_index.exs
+++ b/priv/repo/migrations/20221223010058_drop_tenants_uniq_external_id_index.exs
@@ -1,0 +1,7 @@
+defmodule Realtime.Repo.Migrations.DropTenantsUniqExternalIdIndex do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER TABLE IF EXISTS tenants DROP CONSTRAINT IF EXISTS uniq_external_id")
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There are two unique indexes on the same column, `external_id`, in the `tenants` table: `tenants_external_id_index (external_id)` and `uniq_external_id (external_id)`.

## What is the new behavior?

There is one unique index on the `external_id` column in the `tenants` table: `tenants_external_id_index (external_id)`.
