### PR TITLE
fix: set Logger external_id and project to id in SubscriptionManager

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscription_manager.ex
+++ b/lib/extensions/postgres_cdc_rls/subscription_manager.ex
@@ -61,6 +61,8 @@ defmodule Extensions.PostgresCdcRls.SubscriptionManager do
       "subs_pool_size" => subs_pool_size
     } = args
 
+    Logger.metadata(external_id: id, project: id)
+
     {:ok, conn} = H.connect_db(host, port, name, user, pass, socket_opts, 1)
     {:ok, conn_pub} = H.connect_db(host, port, name, user, pass, socket_opts, subs_pool_size)
     {:ok, _} = Subscriptions.maybe_delete_all(conn)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

None of the logs generated by SubscriptionManager are associated with `external_id` so hard to tell in Logflare.

## What is the new behavior?

All the logs generated by SubscriptionManager are associated with `external_id` so easy to tell in Logflare.
