### PR TITLE
feat: add hard coded limits to the db

### DIFF
--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -16,8 +16,8 @@ defmodule Realtime.Api.Tenant do
     field(:external_id, :string)
     field(:jwt_secret, :string)
     field(:postgres_cdc_default, :string)
-    field(:max_concurrent_users, :integer)
-    field(:max_events_per_second, :integer)
+    field(:max_concurrent_users, :integer, default: 200)
+    field(:max_events_per_second, :integer, default: 100)
     field(:events_per_second_rolling, :float, virtual: true)
     field(:events_per_second_now, :integer, virtual: true)
 

--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -18,6 +18,8 @@ defmodule Realtime.Api.Tenant do
     field(:postgres_cdc_default, :string)
     field(:max_concurrent_users, :integer, default: 200)
     field(:max_events_per_second, :integer, default: 100)
+    field(:max_bytes_per_second, :integer, default: 100_000)
+    field(:max_channels_per_client, :integer, default: 100)
     field(:events_per_second_rolling, :float, virtual: true)
     field(:events_per_second_now, :integer, virtual: true)
 
@@ -63,7 +65,9 @@ defmodule Realtime.Api.Tenant do
       :jwt_secret,
       :max_concurrent_users,
       :max_events_per_second,
-      :postgres_cdc_default
+      :postgres_cdc_default,
+      :max_bytes_per_second,
+      :max_channels_per_client
     ])
     |> validate_required([
       :external_id,

--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -20,6 +20,7 @@ defmodule Realtime.Api.Tenant do
     field(:max_events_per_second, :integer, default: 100)
     field(:max_bytes_per_second, :integer, default: 100_000)
     field(:max_channels_per_client, :integer, default: 100)
+    field(:max_joins_per_second, :integer, default: 500)
     field(:events_per_second_rolling, :float, virtual: true)
     field(:events_per_second_now, :integer, virtual: true)
 
@@ -67,7 +68,8 @@ defmodule Realtime.Api.Tenant do
       :max_events_per_second,
       :postgres_cdc_default,
       :max_bytes_per_second,
-      :max_channels_per_client
+      :max_channels_per_client,
+      :max_joins_per_second
     ])
     |> validate_required([
       :external_id,

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -36,7 +36,13 @@ defmodule RealtimeWeb.RealtimeChannel do
             tenant: String.t(),
             log_level: atom(),
             rate_counter: RateCounter.t(),
-            limits: %{max_events_per_second: integer(), max_concurrent_users: integer()},
+            limits: %{
+              max_events_per_second: integer(),
+              max_concurrent_users: integer(),
+              max_bytes_per_second: integer(),
+              max_channels_per_client: integer(),
+              max_joins_per_second: integer()
+            },
             tenant_topic: String.t(),
             pg_sub_ref: reference() | nil,
             pg_change_params: map(),
@@ -50,8 +56,6 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   @confirm_token_ms_interval 1_000 * 60 * 5
-  @max_join_rate 500
-  @max_user_channels 100
 
   @impl true
   def join(
@@ -490,7 +494,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     wait
   end
 
-  def limit_joins(%{assigns: %{tenant: tenant}}) do
+  def limit_joins(%{assigns: %{tenant: tenant, limits: limits}}) do
     id = {:limit, :channel_joins, tenant}
     GenCounter.new(id)
     RateCounter.new(id, idle_shutdown: :infinity)
@@ -498,7 +502,7 @@ defmodule RealtimeWeb.RealtimeChannel do
 
     case RateCounter.get(id) do
       {:ok, %{avg: avg}} ->
-        if avg < @max_join_rate do
+        if avg < limits.max_joins_per_second do
           :ok
         else
           {:error, :too_many_joins}
@@ -510,10 +514,10 @@ defmodule RealtimeWeb.RealtimeChannel do
     end
   end
 
-  def limit_channels(%{assigns: %{tenant: tenant}, transport_pid: pid}) do
+  def limit_channels(%{assigns: %{tenant: tenant, limits: limits}, transport_pid: pid}) do
     key = limit_channels_key(tenant)
 
-    if Registry.count_match(Realtime.Registry, key, pid) > @max_user_channels do
+    if Registry.count_match(Realtime.Registry, key, pid) > limits.max_channels_per_client do
       {:error, :too_many_channels}
     else
       Registry.register(Realtime.Registry, limit_channels_key(tenant), pid)

--- a/lib/realtime_web/channels/user_socket.ex
+++ b/lib/realtime_web/channels/user_socket.ex
@@ -40,6 +40,9 @@ defmodule RealtimeWeb.UserSocket do
              jwt_secret: jwt_secret,
              max_concurrent_users: max_conn_users,
              max_events_per_second: max_events_per_second,
+             max_bytes_per_second: max_bytes_per_second,
+             max_joins_per_second: max_joins_per_second,
+             max_channels_per_client: max_channels_per_client,
              postgres_cdc_default: postgres_cdc_default
            } <- Api.get_tenant_by_external_id(external_id),
            token when is_binary(token) <- access_token(params, headers),
@@ -52,7 +55,10 @@ defmodule RealtimeWeb.UserSocket do
             jwt_secret: jwt_secret,
             limits: %{
               max_concurrent_users: max_conn_users,
-              max_events_per_second: max_events_per_second
+              max_events_per_second: max_events_per_second,
+              max_bytes_per_second: max_bytes_per_second,
+              max_joins_per_second: max_joins_per_second,
+              max_channels_per_client: max_channels_per_client
             },
             postgres_extension: PostgresCdc.filter_settings(postgres_cdc_default, extensions),
             postgres_cdc_module: postgres_cdc_module,

--- a/priv/repo/migrations/20230110180046_add_limits_fields_to_tenants.exs
+++ b/priv/repo/migrations/20230110180046_add_limits_fields_to_tenants.exs
@@ -1,0 +1,10 @@
+defmodule Realtime.Repo.Migrations.AddLimitsFieldsToTenants do
+  use Ecto.Migration
+
+  def change do
+    alter table("tenants") do
+      add(:max_bytes_per_second, :integer, default: 100_000, null: false)
+      add(:max_channels_per_client, :integer, default: 100, null: false)
+    end
+  end
+end

--- a/priv/repo/migrations/20230110180046_add_limits_fields_to_tenants.exs
+++ b/priv/repo/migrations/20230110180046_add_limits_fields_to_tenants.exs
@@ -5,6 +5,7 @@ defmodule Realtime.Repo.Migrations.AddLimitsFieldsToTenants do
     alter table("tenants") do
       add(:max_bytes_per_second, :integer, default: 100_000, null: false)
       add(:max_channels_per_client, :integer, default: 100, null: false)
+      add(:max_joins_per_second, :integer, default: 500, null: false)
     end
   end
 end

--- a/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
+++ b/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
@@ -29,7 +29,10 @@ defmodule Realtime.Extensions.CdcRlsTest do
       claims: %{},
       limits: %{
         max_concurrent_users: 1,
-        max_events_per_second: 100
+        max_events_per_second: 100,
+        max_joins_per_second: 500,
+        max_channels_per_client: 100,
+        max_bytes_per_second: 100_000
       },
       is_new_api: false,
       log_level: :info


### PR DESCRIPTION
- Adds `max_channels_per_client`, `max_bytes_per_second` and `max_joins_per_second` to the db
- Updates the `UserSocket` and `RealtimeChannel` to use these db limits
- Updates tests

Notes
- I chose to use an `integer` type for the the `max_bytes_per_second` field so technically the db supports almost 2 gigabytes per second (probably enough) rate limit because of the largest supported integer of `2147483647`
- I'm thinking this will make it easy to call `:erlang.external_size` which returns bytes and we won't have to do any conversion.
- This PR does not implement limiting for `max_bytes_per_second` yet