### PR TITLE
feat: stop connection to a tenant's db if there are no connected user…

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscriptions_checker.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions_checker.ex
@@ -79,16 +79,7 @@ defmodule Extensions.PostgresCdcRls.SubscriptionsChecker do
       Subscriptions.delete_multi(state.conn, ids)
     end
 
-    new_ref =
-      if :ets.info(tid, :size) == 0 do
-        Logger.debug("Cancel check_active_pids")
-        Rls.handle_stop(state.id, 15_000)
-        nil
-      else
-        check_active_pids()
-      end
-
-    {:noreply, %{state | check_active_pids: new_ref}}
+    {:noreply, %{state | check_active_pids: check_active_pids()}}
   end
 
   ## Internal functions


### PR DESCRIPTION
Stop connection to a tenant's db if there are no connected users for 10 minutes.