### PR TITLE
chore: add sjc replica

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -9,7 +9,8 @@ for repo <- [
       Realtime.Repo,
       Realtime.Repo.Replica.FRA,
       Realtime.Repo.Replica.IAD,
-      Realtime.Repo.Replica.SIN
+      Realtime.Repo.Replica.SIN,
+      Realtime.Repo.Replica.SJC
     ] do
   config :realtime, repo,
     username: "postgres",

--- a/lib/realtime/repo.ex
+++ b/lib/realtime/repo.ex
@@ -4,7 +4,7 @@ defmodule Realtime.Repo do
     adapter: Ecto.Adapters.Postgres
 
   @replicas %{
-    "sjc" => Realtime.Repo.Replica.IAD,
+    "sjc" => Realtime.Repo.Replica.SJC,
     "gru" => Realtime.Repo.Replica.IAD,
     "iad" => Realtime.Repo.Replica.IAD,
     "sin" => Realtime.Repo.Replica.SIN,

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -116,7 +116,8 @@ defmodule RealtimeWeb.Router do
         Realtime.Repo,
         Realtime.Repo.Replica.FRA,
         Realtime.Repo.Replica.IAD,
-        Realtime.Repo.Replica.SIN
+        Realtime.Repo.Replica.SIN,
+        Realtime.Repo.Replica.SJC
       ],
       ecto_psql_extras_options: [long_running_queries: [threshold: "200 milliseconds"]],
       metrics: RealtimeWeb.Telemetry


### PR DESCRIPTION
Looks like we had a replica we weren't using. Let's use it!

⚠️ Set the env `DB_HOST_REPLICA_SJC` before release ⚠️