### PR TITLE
feat: show latency on db events on inspector

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -71,16 +71,14 @@ Hooks.payload = {
   this.channel.on("postgres_changes", { event: "*", schema: schema, table: table }, payload => {
     let ts = new Date();
     let payload_ts = Date.parse(payload.commit_timestamp)
-    let latency = ts.getTime() - payload_ts
-    console.log(ts.getTime())
-    console.log(payload_ts)
+    let latency = (ts.getTime() / 1000) - (payload_ts / 1000)
     let line = 
       `<tr class="bg-white border-b hover:bg-gray-50">
         <td class="py-4 px-6">POSTGRES</td>
         <td class="py-4 px-6">${ts.toISOString()}</td>
         <td class="py-4 px-6">
           <div class="pb-3">${JSON.stringify(payload)}</div>
-          <div class="pt-3 border-t hover:bg-gray-50">Latency: ${latency} ms</div>
+          <div class="pt-3 border-t hover:bg-gray-50">Latency: ${Math.round(latency)} sec</div>
         </td>
       </tr>`
     let list = document.querySelector("#plist")

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,10 +27,11 @@ Hooks.payload = {
     if (payload.extension === 'postgres_changes' && payload.status === 'ok') {
           this.pushEventTo("#conn_info", "postgres_subscribed", {})
         }
-
+    let ts = new Date();    
     let line = 
     `<tr class="bg-white border-b hover:bg-gray-50">
       <td class="py-4 px-6">SYSTEM</td>
+      <td class="py-4 px-6">${ts.toISOString()}</td>
       <td class="py-4 px-6">${JSON.stringify(payload)}</td>
     </tr>`
     let list = document.querySelector("#plist")
@@ -41,9 +42,11 @@ Hooks.payload = {
   // The event name can by anything
   // Match on specific event names to filter for only those types of events and do something with them
   this.channel.on("broadcast", { event: "*" }, payload => {
+    let ts = new Date();
     let line = 
       `<tr class="bg-white border-b hover:bg-gray-50">
         <td class="py-4 px-6">BROADCAST</td>
+        <td class="py-4 px-6">${ts.toISOString()}</td>
         <td class="py-4 px-6">${JSON.stringify(payload)}</td>
       </tr>`
     let list = document.querySelector("#plist")
@@ -53,9 +56,11 @@ Hooks.payload = {
   // Listen for all (`*`) `presence` events
   this.channel.on("presence", { event: "*" }, payload => {
     this.pushEventTo("#conn_info", "presence_subscribed", {})
-    let line = 
+    let ts = new Date();
+    let line =
       `<tr class="bg-white border-b hover:bg-gray-50">
         <td class="py-4 px-6">PRESENCE</td>
+        <td class="py-4 px-6">${ts.toISOString()}</td>
         <td class="py-4 px-6">${JSON.stringify(payload)}</td>
       </tr>`
     let list = document.querySelector("#plist")
@@ -64,10 +69,19 @@ Hooks.payload = {
 
   // Listen for all (`*`) `postgres_changes` events on tables in the `public` schema
   this.channel.on("postgres_changes", { event: "*", schema: schema, table: table }, payload => {
+    let ts = new Date();
+    let payload_ts = Date.parse(payload.commit_timestamp)
+    let latency = ts.getTime() - payload_ts
+    console.log(ts.getTime())
+    console.log(payload_ts)
     let line = 
       `<tr class="bg-white border-b hover:bg-gray-50">
         <td class="py-4 px-6">POSTGRES</td>
-        <td class="py-4 px-6">${JSON.stringify(payload)}</td>
+        <td class="py-4 px-6">${ts.toISOString()}</td>
+        <td class="py-4 px-6">
+          <div class="pb-3">${JSON.stringify(payload)}</div>
+          <div class="pt-3 border-t hover:bg-gray-50">Latency: ${latency} ms</div>
+        </td>
       </tr>`
     let list = document.querySelector("#plist")
     list.innerHTML = line + list.innerHTML;

--- a/lib/realtime_web/live/inspector_live/index.html.heex
+++ b/lib/realtime_web/live/inspector_live/index.html.heex
@@ -20,7 +20,7 @@
             />
         </.modal>
     <% end %>
-    
+
     <div id="conn_info" class="mb-5">
         <%= if @broadcast_subscribed do %>
             <p>Connected to <code><%= @connected_to %></code></p>
@@ -59,10 +59,10 @@
     <aside class="w-full sm:w-1/3 md:w-1/4 pr-2 mb-8">
         <.h3>Broadcast an Event</.h3>
         <div class="mb-6">
-            <.form 
+            <.form
                 id="message_form"
-                :let={m} 
-                for={@changeset} 
+                :let={m}
+                for={@changeset}
                 class="bg-white rounded mt-4"
                 phx-submit="send_message"
                 >
@@ -109,7 +109,8 @@
             <table class="table-fixed w-full text-md text-left text-gray-700">
                 <thead class="text-xs text-gray-700 uppercase bg-gray-50">
                     <tr>
-                        <th scope="col" class="w-36 py-3 px-6">Extension</th>
+                        <th scope="col" class="w-32 py-3 px-6">Extension</th>
+                        <th scope="col" class="w-64 py-3 px-6">Timestamp</th>
                         <th scope="col" class="py-3 px-6">Payload</th>
                     </tr>
                 </thead>


### PR DESCRIPTION
Shows the database latency on the database events on the inspector.

However, I need subsecond `commit_timestamp`s for it to be accurate.

https://user-images.githubusercontent.com/1019814/213325827-7eab2398-d2ea-4976-a055-7d2d6e22f8a7.mp4

