### PR TITLE
fix: footnote for latency

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -78,9 +78,8 @@ Hooks.payload = {
         <td class="py-4 px-6">${ts.toISOString()}</td>
         <td class="py-4 px-6">
           <div class="pb-3">${JSON.stringify(payload)}</div>
-          <div class="pt-3 border-t hover:bg-gray-50">Latency: ${Math.round(latency)} sec</div>
-        </td> 
-        </td>
+          <div class="pt-3 border-t hover:bg-gray-50"><a href="#footnote">*</a>Latency: ${Math.round(latency)} sec</div>
+        </td>   
       </tr>`
     let list = document.querySelector("#plist")
     list.innerHTML = line + list.innerHTML;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -78,7 +78,7 @@ Hooks.payload = {
         <td class="py-4 px-6">${ts.toISOString()}</td>
         <td class="py-4 px-6">
           <div class="pb-3">${JSON.stringify(payload)}</div>
-          <div class="pt-3 border-t hover:bg-gray-50"><a href="#footnote">*</a>Latency: ${Math.round(latency)} sec</div>
+          <div class="pt-3 border-t hover:bg-gray-50">Latency: ${Math.round(latency)} sec<a href="#footnote">*</a></div>
         </td>   
       </tr>`
     let list = document.querySelector("#plist")

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -78,7 +78,8 @@ Hooks.payload = {
         <td class="py-4 px-6">${ts.toISOString()}</td>
         <td class="py-4 px-6">
           <div class="pb-3">${JSON.stringify(payload)}</div>
-          <div class="pt-3 border-t hover:bg-gray-50">Latency: ~${Math.round(latency)} sec</div>
+          <div class="pt-3 border-t hover:bg-gray-50">Latency: ${Math.round(latency)} sec</div>
+        </td> 
         </td>
       </tr>`
     let list = document.querySelector("#plist")

--- a/lib/realtime_web/live/inspector_live/index.html.heex
+++ b/lib/realtime_web/live/inspector_live/index.html.heex
@@ -117,6 +117,9 @@
                 <tbody id="plist">
                 </tbody>
             </table>
+            <div class="my-4" id="footnote">
+                <small>*Latency reported in Postgres change payloads is rounded to the second because the `commit_timestamp` is reported in seconds.</small>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Adds a footnote for latency for Postgres change payloads to explain why it's reported in seconds.

Styling seems to vary quite a bit. I followed Chicago style footnotes using an asterisks. When not using numbers for footnotes you use an astrisks (*) then a dagger (†) and then a double dagger (‡).

<img width="972" alt="Screen Shot 2023-01-19 at 6 23 40 AM" src="https://user-images.githubusercontent.com/1019814/213454539-8ce43d7c-52fa-4f10-9f3d-59f735fbb358.png">
