### PR TITLE
fix: make rlimit configurable by env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ COPY --from=tailscale /app/tailscaled /tailscale/tailscaled
 COPY --from=tailscale /app/tailscale /tailscale/tailscale
 RUN mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale
 
+ENV RLIMIT_NOFILE 100000
 COPY limits.sh /app/limits.sh
 ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--", "/app/limits.sh"]
 

--- a/limits.sh
+++ b/limits.sh
@@ -1,5 +1,9 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 
-set -e
-ulimit -n 100000
+if [ ! -z "$RLIMIT_NOFILE" ]; then
+    echo "Setting RLIMIT_NOFILE to ${RLIMIT_NOFILE}"
+    ulimit -n "$RLIMIT_NOFILE"
+fi
+
 exec "$@"

--- a/tailscale/wrapper.sh
+++ b/tailscale/wrapper.sh
@@ -3,7 +3,7 @@
 set -x
 set -euo pipefail
 
-if [ "${ENABLE_TAILSCALE}" = true ]; then
+if [ "${ENABLE_TAILSCALE-}" = true ]; then
     echo "Enabling Tailscale"
     TAILSCALE_APP_NAME="${TAILSCALE_APP_NAME:-${FLY_APP_NAME}-${FLY_REGION}}-${FLY_ALLOC_ID:0:8}"
     /tailscale/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

rlimit is always set to 100k, causing problem when ran in docker rootless mode

## What is the new behavior?

- uses system default if `RLIMIT_NOFILE` is unset (empty string)
- naming follows linux convention https://man7.org/linux/man-pages/man2/getrlimit.2.html

## Additional context

Add any other context or screenshots.
