### PR TITLE
feat: add in op for filter and enable filter on delete records

### DIFF
--- a/priv/repo/migrations/20230128025114_add_in_op_to_filters.exs
+++ b/priv/repo/migrations/20230128025114_add_in_op_to_filters.exs
@@ -1,0 +1,121 @@
+defmodule Realtime.Repo.Migrations.AddInOpToFilters do
+  use Ecto.Migration
+
+  def change do
+    execute("alter type realtime.equality_op add value 'in';")
+
+    execute("
+      create or replace function realtime.check_equality_op(
+          op realtime.equality_op,
+          type_ regtype,
+          val_1 text,
+          val_2 text
+      )
+          returns bool
+          immutable
+          language plpgsql
+      as $$
+      /*
+      Casts *val_1* and *val_2* as type *type_* and check the *op* condition for truthiness
+      */
+      declare
+          op_symbol text = (
+              case
+                  when op = 'eq' then '='
+                  when op = 'neq' then '!='
+                  when op = 'lt' then '<'
+                  when op = 'lte' then '<='
+                  when op = 'gt' then '>'
+                  when op = 'gte' then '>='
+                  when op = 'in' then '= any'
+                  else 'UNKNOWN OP'
+              end
+          );
+          res boolean;
+      begin
+          execute format(
+              'select %L::'|| type_::text || ' ' || op_symbol
+              || ' ( %L::'
+              || (
+                  case
+                      when op = 'in' then type_::text || '[]'
+                      else type_::text end
+              )
+              || ')', val_1, val_2) into res;
+          return res;
+      end;
+      $$;
+    ")
+
+    execute("
+      create or replace function realtime.subscription_check_filters()
+          returns trigger
+          language plpgsql
+      as $$
+      /*
+      Validates that the user defined filters for a subscription:
+      - refer to valid columns that the claimed role may access
+      - values are coercable to the correct column type
+      */
+      declare
+          col_names text[] = coalesce(
+                  array_agg(c.column_name order by c.ordinal_position),
+                  '{}'::text[]
+              )
+              from
+                  information_schema.columns c
+              where
+                  format('%I.%I', c.table_schema, c.table_name)::regclass = new.entity
+                  and pg_catalog.has_column_privilege(
+                      (new.claims ->> 'role'),
+                      format('%I.%I', c.table_schema, c.table_name)::regclass,
+                      c.column_name,
+                      'SELECT'
+                  );
+          filter realtime.user_defined_filter;
+          col_type regtype;
+
+          in_val jsonb;
+      begin
+          for filter in select * from unnest(new.filters) loop
+              -- Filtered column is valid
+              if not filter.column_name = any(col_names) then
+                  raise exception 'invalid column for filter %', filter.column_name;
+              end if;
+
+              -- Type is sanitized and safe for string interpolation
+              col_type = (
+                  select atttypid::regtype
+                  from pg_catalog.pg_attribute
+                  where attrelid = new.entity
+                        and attname = filter.column_name
+              );
+              if col_type is null then
+                  raise exception 'failed to lookup type for column %', filter.column_name;
+              end if;
+
+              -- Set maximum number of entries for in filter
+              if filter.op = 'in'::realtime.equality_op then
+                  in_val = realtime.cast(filter.value, (col_type::text || '[]')::regtype);
+                  if coalesce(jsonb_array_length(in_val), 0) > 100 then
+                      raise exception 'too many values for `in` filter. Maximum 100';
+                  end if;
+              end if;
+
+              -- raises an exception if value is not coercable to type
+              perform realtime.cast(filter.value, col_type);
+          end loop;
+
+          -- Apply consistent order to filters so the unique constraint on
+          -- (subscription_id, entity, filters) can't be tricked by a different filter order
+          new.filters = coalesce(
+              array_agg(f order by f.column_name, f.op, f.value),
+              '{}'
+          ) from unnest(new.filters) f;
+
+          return new;
+      end;
+      $$;
+    ")
+  end
+end

--- a/priv/repo/postgres/migrations/20230128025114_add_in_op_to_filters.exs
+++ b/priv/repo/postgres/migrations/20230128025114_add_in_op_to_filters.exs
@@ -1,4 +1,4 @@
-defmodule Realtime.Repo.Migrations.AddInOpToFilters do
+defmodule Realtime.RLS.Repo.Migrations.AddInOpToFilters do
   use Ecto.Migration
 
   def change do

--- a/priv/repo/postgres/migrations/20230128025212_enable_filtering_on_delete_record.exs
+++ b/priv/repo/postgres/migrations/20230128025212_enable_filtering_on_delete_record.exs
@@ -1,0 +1,293 @@
+defmodule Realtime.RLS.Repo.Migrations.EnableFilteringOnDeleteRecord do
+  use Ecto.Migration
+
+  def change do
+    execute("
+      create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+          returns setof realtime.wal_rls
+          language plpgsql
+          volatile
+      as $$
+      declare
+          -- Regclass of the table e.g. public.notes
+          entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
+
+          -- I, U, D, T: insert, update ...
+          action realtime.action = (
+              case wal ->> 'action'
+                  when 'I' then 'INSERT'
+                  when 'U' then 'UPDATE'
+                  when 'D' then 'DELETE'
+                  else 'ERROR'
+              end
+          );
+
+          -- Is row level security enabled for the table
+          is_rls_enabled bool = relrowsecurity from pg_class where oid = entity_;
+
+          subscriptions realtime.subscription[] = array_agg(subs)
+              from
+                  realtime.subscription subs
+              where
+                  subs.entity = entity_;
+
+          -- Subscription vars
+          roles regrole[] = array_agg(distinct us.claims_role)
+              from
+                  unnest(subscriptions) us;
+
+          working_role regrole;
+          claimed_role regrole;
+          claims jsonb;
+
+          subscription_id uuid;
+          subscription_has_access bool;
+          visible_to_subscription_ids uuid[] = '{}';
+
+          -- structured info for wal's columns
+          columns realtime.wal_column[];
+          -- previous identity values for update/delete
+          old_columns realtime.wal_column[];
+
+          error_record_exceeds_max_size boolean = octet_length(wal::text) > max_record_bytes;
+
+          -- Primary jsonb output for record
+          output jsonb;
+
+      begin
+          perform set_config('role', null, true);
+
+          columns =
+              array_agg(
+                  (
+                      x->>'name',
+                      x->>'type',
+                      x->>'typeoid',
+                      realtime.cast(
+                          (x->'value') #>> '{}',
+                          coalesce(
+                              (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                              (x->>'type')::regtype
+                          )
+                      ),
+                      (pks ->> 'name') is not null,
+                      true
+                  )::realtime.wal_column
+              )
+              from
+                  jsonb_array_elements(wal -> 'columns') x
+                  left join jsonb_array_elements(wal -> 'pk') pks
+                      on (x ->> 'name') = (pks ->> 'name');
+
+          old_columns =
+              array_agg(
+                  (
+                      x->>'name',
+                      x->>'type',
+                      x->>'typeoid',
+                      realtime.cast(
+                          (x->'value') #>> '{}',
+                          coalesce(
+                              (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                              (x->>'type')::regtype
+                          )
+                      ),
+                      (pks ->> 'name') is not null,
+                      true
+                  )::realtime.wal_column
+              )
+              from
+                  jsonb_array_elements(wal -> 'identity') x
+                  left join jsonb_array_elements(wal -> 'pk') pks
+                      on (x ->> 'name') = (pks ->> 'name');
+
+          for working_role in select * from unnest(roles) loop
+
+              -- Update `is_selectable` for columns and old_columns
+              columns =
+                  array_agg(
+                      (
+                          c.name,
+                          c.type_name,
+                          c.type_oid,
+                          c.value,
+                          c.is_pkey,
+                          pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                      )::realtime.wal_column
+                  )
+                  from
+                      unnest(columns) c;
+
+              old_columns =
+                      array_agg(
+                          (
+                              c.name,
+                              c.type_name,
+                              c.type_oid,
+                              c.value,
+                              c.is_pkey,
+                              pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                          )::realtime.wal_column
+                      )
+                      from
+                          unnest(old_columns) c;
+
+              if action <> 'DELETE' and count(1) = 0 from unnest(columns) c where c.is_pkey then
+                  return next (
+                      jsonb_build_object(
+                          'schema', wal ->> 'schema',
+                          'table', wal ->> 'table',
+                          'type', action
+                      ),
+                      is_rls_enabled,
+                      -- subscriptions is already filtered by entity
+                      (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                      array['Error 400: Bad Request, no primary key']
+                  )::realtime.wal_rls;
+
+              -- The claims role does not have SELECT permission to the primary key of entity
+              elsif action <> 'DELETE' and sum(c.is_selectable::int) <> count(1) from unnest(columns) c where c.is_pkey then
+                  return next (
+                      jsonb_build_object(
+                          'schema', wal ->> 'schema',
+                          'table', wal ->> 'table',
+                          'type', action
+                      ),
+                      is_rls_enabled,
+                      (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                      array['Error 401: Unauthorized']
+                  )::realtime.wal_rls;
+
+              else
+                  output = jsonb_build_object(
+                      'schema', wal ->> 'schema',
+                      'table', wal ->> 'table',
+                      'type', action,
+                      'commit_timestamp', to_char(
+                          (wal ->> 'timestamp')::timestamptz,
+                          'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'
+                      ),
+                      'columns', (
+                          select
+                              jsonb_agg(
+                                  jsonb_build_object(
+                                      'name', pa.attname,
+                                      'type', pt.typname
+                                  )
+                                  order by pa.attnum asc
+                              )
+                          from
+                              pg_attribute pa
+                              join pg_type pt
+                                  on pa.atttypid = pt.oid
+                          where
+                              attrelid = entity_
+                              and attnum > 0
+                              and pg_catalog.has_column_privilege(working_role, entity_, pa.attname, 'SELECT')
+                      )
+                  )
+                  -- Add \"record\" key for insert and update
+                  || case
+                      when action in ('INSERT', 'UPDATE') then
+                          jsonb_build_object(
+                              'record',
+                              (
+                                  select jsonb_object_agg((c).name, (c).value)
+                                  from unnest(columns) c
+                                  where
+                                      (c).is_selectable
+                                      and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                              )
+                          )
+                      else '{}'::jsonb
+                  end
+                  -- Add \"old_record\" key for update and delete
+                  || case
+                      when action = 'UPDATE' then
+                          jsonb_build_object(
+                                  'old_record',
+                                  (
+                                      select jsonb_object_agg((c).name, (c).value)
+                                      from unnest(old_columns) c
+                                      where
+                                          (c).is_selectable
+                                          and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                                  )
+                              )
+                      when action = 'DELETE' then
+                          jsonb_build_object(
+                              'old_record',
+                              (
+                                  select jsonb_object_agg((c).name, (c).value)
+                                  from unnest(old_columns) c
+                                  where
+                                      (c).is_selectable
+                                      and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                                      and ( not is_rls_enabled or (c).is_pkey ) -- if RLS enabled, we can't secure deletes so filter to pkey
+                              )
+                          )
+                      else '{}'::jsonb
+                  end;
+
+                  -- Create the prepared statement
+                  if is_rls_enabled and action <> 'DELETE' then
+                      if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
+                          deallocate walrus_rls_stmt;
+                      end if;
+                      execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+                  end if;
+
+                  visible_to_subscription_ids = '{}';
+
+                  for subscription_id, claims in (
+                          select
+                              subs.subscription_id,
+                              subs.claims
+                          from
+                              unnest(subscriptions) subs
+                          where
+                              subs.entity = entity_
+                              and subs.claims_role = working_role
+                              and (
+                                  realtime.is_visible_through_filters(columns, subs.filters)
+                                  or action = 'DELETE'
+                              )
+                  ) loop
+
+                      if not is_rls_enabled or action = 'DELETE' then
+                          visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                      else
+                          -- Check if RLS allows the role to see the record
+                          perform
+                              set_config('role', working_role::text, true),
+                              set_config('request.jwt.claims', claims::text, true);
+
+                          execute 'execute walrus_rls_stmt' into subscription_has_access;
+
+                          if subscription_has_access then
+                              visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                          end if;
+                      end if;
+                  end loop;
+
+                  perform set_config('role', null, true);
+
+                  return next (
+                      output,
+                      is_rls_enabled,
+                      visible_to_subscription_ids,
+                      case
+                          when error_record_exceeds_max_size then array['Error 413: Payload Too Large']
+                          else '{}'
+                      end
+                  )::realtime.wal_rls;
+
+              end if;
+          end loop;
+
+          perform set_config('role', null, true);
+      end;
+      $$;
+    ")
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

- Use the `in` op when listening to filters (https://github.com/supabase/walrus/blob/master/sql/walrus_migration_0004_in_op.sql)
- Use filters when listening to delete records (https://github.com/supabase/walrus/blob/master/sql/walrus_migration_0005_delete_old_record_rls.sql)
