### PR TITLE
feat: support `in` filter when parsing subscription params

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -7,7 +7,7 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
 
   @type conn() :: Postgrex.conn()
 
-  @filter_types ["eq", "neq", "lt", "lte", "gt", "gte"]
+  @filter_types ["eq", "neq", "lt", "lte", "gt", "gte", "in"]
 
   @spec create(conn(), String.t(), list(map())) ::
           {:ok, Postgrex.Result.t()}
@@ -140,7 +140,7 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
   @doc """
   Parses subscription filter parameters into something we can pass into our `create_subscription` query.
 
-  We currently support the following filters: 'eq', 'neq', 'lt', 'lte', 'gt', 'gte`
+  We currently support the following filters: 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'in'
 
   ## Examples
 
@@ -148,11 +148,17 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
       {:ok, ["public", "messages", [{"subject", "eq", "hey"}]]}
 
+  `in` filter:
+
+      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=in.[hidee, ho]"}
+      iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
+      {:ok, ["public", "messages", [{"subject", "eq", "[hidee, ho]"}]]}
+
   An unsupported filter will respond with an error tuple:
 
-      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=in.hey"}
+      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=like.hey"}
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
-      {:error, ~s(Error parsing `filter` params: ["in", "hey"])}
+      {:error, ~s(Error parsing `filter` params: ["like", "hey"])}
 
   Catch `undefined` filters:
 

--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -150,9 +150,9 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
 
   `in` filter:
 
-      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=in.[hidee, ho]"}
+      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=in.(hidee,ho)"}
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
-      {:ok, ["public", "messages", [{"subject", "eq", "[hidee, ho]"}]]}
+      {:ok, ["public", "messages", [{"subject", "eq", "(hidee,ho)"}]]}
 
   An unsupported filter will respond with an error tuple:
 

--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -156,9 +156,9 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
 
   An unsupported filter will respond with an error tuple:
 
-      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=bad.hey"}
+      iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=like.hey"}
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
-      {:error, ~s(Error parsing `filter` params: ["bad", "hey"])}
+      {:error, ~s(Error parsing `filter` params: ["like", "hey"])}
 
   Catch `undefined` filters:
 

--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -152,7 +152,7 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
 
       iex> params = %{"schema" => "public", "table" => "messages", "filter" => "subject=in.(hidee,ho)"}
       iex> Extensions.PostgresCdcRls.Subscriptions.parse_subscription_params(params)
-      {:ok, ["public", "messages", [{"subject", "eq", "(hidee,ho)"}]]}
+      {:ok, ["public", "messages", [{"subject", "in", "(hidee,ho)"}]]}
 
   An unsupported filter will respond with an error tuple:
 


### PR DESCRIPTION
When the `filter` is `"subject=in.(hidee,ho)"`
 - see the [PostgREST syntax](https://postgrest.org/en/stable/api.html#operators)