### PR TITLE
fix: sort region nodes by node name

### DIFF
--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -68,7 +68,7 @@ defmodule Extensions.PostgresCdcRls do
 
   def start_distributed(%{"region" => region, "id" => tenant} = args) do
     fly_region = PostgresCdc.aws_to_fly(region)
-    launch_node = launch_node(tenant, fly_region, node())
+    launch_node = PostgresCdc.launch_node(tenant, fly_region, node())
 
     Logger.warning(
       "Starting distributed postgres extension #{inspect(lauch_node: launch_node, region: region, fly_region: fly_region)}"
@@ -133,20 +133,6 @@ defmodule Extensions.PostgresCdcRls do
 
       _ ->
         nil
-    end
-  end
-
-  def launch_node(tenant, fly_region, default) do
-    case PostgresCdc.region_nodes(fly_region) do
-      [_ | _] = regions_nodes ->
-        member_count = Enum.count(regions_nodes)
-        index = :erlang.phash2(tenant, member_count)
-        {_, [node: launch_node]} = Enum.at(regions_nodes, index)
-        launch_node
-
-      _ ->
-        Logger.warning("Didn't find launch_node, return default #{inspect(default)}")
-        default
     end
   end
 

--- a/lib/extensions/postgres_cdc_stream/cdc_stream.ex
+++ b/lib/extensions/postgres_cdc_stream/cdc_stream.ex
@@ -57,7 +57,7 @@ defmodule Extensions.PostgresCdcStream do
 
   def start_distributed(%{"region" => region, "id" => tenant} = args) do
     fly_region = PostgresCdc.aws_to_fly(region)
-    launch_node = launch_node(tenant, fly_region, node())
+    launch_node = PostgresCdc.launch_node(tenant, fly_region, node())
 
     Logger.warning(
       "Starting distributed postgres extension #{inspect(lauch_node: launch_node, region: region, fly_region: fly_region)}"
@@ -74,20 +74,6 @@ defmodule Extensions.PostgresCdcStream do
       error ->
         Logger.error("Error starting Postgres Extention: #{inspect(error, pretty: true)}")
         error
-    end
-  end
-
-  def launch_node(tenant, fly_region, default) do
-    case PostgresCdc.region_nodes(fly_region) do
-      [_ | _] = regions_nodes ->
-        member_count = Enum.count(regions_nodes)
-        index = :erlang.phash2(tenant, member_count)
-        {_, [node: launch_node]} = Enum.at(regions_nodes, index)
-        launch_node
-
-      _ ->
-        Logger.warning("Didn't find launch_node, return default #{inspect(default)}")
-        default
     end
   end
 

--- a/lib/realtime/postgres_cdc.ex
+++ b/lib/realtime/postgres_cdc.ex
@@ -78,6 +78,11 @@ defmodule Realtime.PostgresCdc do
     end
   end
 
+  @doc """
+  Lists the nodes in a region. Sorts by node name in case the list order
+  is unstable.
+  """
+
   @spec region_nodes(String.t()) :: [{pid(), [node: atom()]}]
   def region_nodes(region) when is_binary(region) do
     :syn.members(RegionNodes, region)

--- a/lib/realtime/postgres_cdc.ex
+++ b/lib/realtime/postgres_cdc.ex
@@ -78,9 +78,10 @@ defmodule Realtime.PostgresCdc do
     end
   end
 
-  @spec region_nodes(String.t()) :: [{pid, any}]
+  @spec region_nodes(String.t()) :: [{pid(), [node: atom()]}]
   def region_nodes(region) when is_binary(region) do
     :syn.members(RegionNodes, region)
+    |> Enum.sort_by(fn {_pid, [node: node]} -> node end)
   end
 
   @callback handle_connect(any()) :: {:ok, pid()} | {:error, any()}


### PR DESCRIPTION
Sorts region nodes by node name in case the node list order is unstable. 