### PR TITLE
feat: cache tenants

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -70,6 +70,7 @@ defmodule Realtime.Application do
         {Phoenix.PubSub, name: Realtime.PubSub, pool_size: 10},
         Realtime.GenCounter.DynamicSupervisor,
         {Cachex, name: Realtime.RateCounter},
+        Realtime.Tenants.Cache,
         Realtime.RateCounter.DynamicSupervisor,
         RealtimeWeb.Endpoint,
         RealtimeWeb.Presence,

--- a/lib/realtime/context_cache.ex
+++ b/lib/realtime/context_cache.ex
@@ -13,11 +13,9 @@ defmodule Realtime.ContextCache do
            {:commit, {:cached, apply(context, fun, args)}}
          end) do
       {:commit, {:cached, value}} ->
-        IO.inspect("MISS")
         value
 
       {:ok, {:cached, value}} ->
-        IO.inspect("HIT")
         value
     end
   end

--- a/lib/realtime/context_cache.ex
+++ b/lib/realtime/context_cache.ex
@@ -1,0 +1,28 @@
+defmodule Realtime.ContextCache do
+  @moduledoc """
+    Read through cache for hot database paths.
+  """
+
+  require Logger
+
+  def apply_fun(context, {fun, arity}, args) do
+    cache = cache_name(context)
+    cache_key = {{fun, arity}, args}
+
+    case Cachex.fetch(cache, cache_key, fn {{_fun, _arity}, args} ->
+           {:commit, {:cached, apply(context, fun, args)}}
+         end) do
+      {:commit, {:cached, value}} ->
+        IO.inspect("MISS")
+        value
+
+      {:ok, {:cached, value}} ->
+        IO.inspect("HIT")
+        value
+    end
+  end
+
+  defp cache_name(context) do
+    Module.concat(context, Cache)
+  end
+end

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -6,7 +6,6 @@ defmodule Realtime.PromEx.Plugins.Tenant do
   alias Realtime.Telemetry
   alias Realtime.Tenants
   alias Realtime.UsersCounter
-  alias Realtime.Api
 
   @impl true
   def polling_metrics(opts) do
@@ -54,7 +53,7 @@ defmodule Realtime.PromEx.Plugins.Tenant do
 
     for t <- tenants do
       count = UsersCounter.tenant_users(Node.self(), t)
-      tenant = Api.get_tenant_by_external_id(t)
+      tenant = Tenants.Cache.get_tenant_by_external_id(t)
 
       Telemetry.execute(
         [:realtime, :connections],

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -3,6 +3,9 @@ defmodule Realtime.Tenants do
   Everything to do with Tenants.
   """
 
+  require Logger
+
+  alias Realtime.Repo
   alias Realtime.Api.Tenant
 
   @doc """
@@ -54,5 +57,14 @@ defmodule Realtime.Tenants do
     end)
     |> Task.await_many()
     |> List.flatten()
+  end
+
+  @spec get_tenant_by_external_id(String.t()) :: Tenant.t() | nil
+  def get_tenant_by_external_id(external_id) do
+    repo_replica = Repo.replica()
+
+    Tenant
+    |> repo_replica.get_by(external_id: external_id)
+    |> repo_replica.preload(:extensions)
   end
 end

--- a/lib/realtime/tenants/cache.ex
+++ b/lib/realtime/tenants/cache.ex
@@ -1,6 +1,6 @@
 defmodule Realtime.Tenants.Cache do
   @moduledoc """
-  Cache for users.
+  Cache for Tenants.
   """
 
   require Cachex.Spec

--- a/lib/realtime/tenants/cache.ex
+++ b/lib/realtime/tenants/cache.ex
@@ -1,0 +1,23 @@
+defmodule Realtime.Tenants.Cache do
+  @moduledoc """
+  Cache for users.
+  """
+
+  require Cachex.Spec
+
+  alias Realtime.Tenants
+
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start:
+        {Cachex, :start_link, [__MODULE__, [expiration: Cachex.Spec.expiration(default: 30_000)]]}
+    }
+  end
+
+  def get_tenant_by_external_id(keyword), do: apply_repo_fun(__ENV__.function, [keyword])
+
+  defp apply_repo_fun(arg1, arg2) do
+    Realtime.ContextCache.apply_fun(Tenants, arg1, arg2)
+  end
+end

--- a/lib/realtime_web/channels/user_socket.ex
+++ b/lib/realtime_web/channels/user_socket.ex
@@ -5,6 +5,7 @@ defmodule RealtimeWeb.UserSocket do
 
   alias Realtime.{PostgresCdc, Api}
   alias Api.Tenant
+  alias Realtime.Tenants
   alias RealtimeWeb.ChannelsAuthorization
   alias RealtimeWeb.RealtimeChannel
   import Realtime.Helpers, only: [decrypt!: 2, get_external_id: 1]
@@ -44,7 +45,7 @@ defmodule RealtimeWeb.UserSocket do
              max_joins_per_second: max_joins_per_second,
              max_channels_per_client: max_channels_per_client,
              postgres_cdc_default: postgres_cdc_default
-           } <- Api.get_tenant_by_external_id(external_id),
+           } <- Tenants.Cache.get_tenant_by_external_id(external_id),
            token when is_binary(token) <- access_token(params, headers),
            jwt_secret_dec <- decrypt!(jwt_secret, secure_key),
            {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec),

--- a/test/realtime/tenants/cache_test.exs
+++ b/test/realtime/tenants/cache_test.exs
@@ -1,8 +1,6 @@
 defmodule Realtime.Tenants.CacheTest do
   use Realtime.DataCase
 
-  import Mock
-
   alias Realtime.Api
   alias Realtime.Tenants
 

--- a/test/realtime/tenants/cache_test.exs
+++ b/test/realtime/tenants/cache_test.exs
@@ -1,0 +1,55 @@
+defmodule Realtime.Tenants.CacheTest do
+  use Realtime.DataCase
+
+  import Mock
+
+  alias Realtime.Api
+  alias Realtime.Tenants
+
+  @db_conf Application.compile_env(:realtime, Realtime.Repo)
+
+  setup do
+    params = %{
+      external_id: "external_id",
+      name: "localhost",
+      extensions: [
+        %{
+          "type" => "postgres_cdc_rls",
+          "settings" => %{
+            "db_host" => @db_conf[:hostname],
+            "db_name" => @db_conf[:database],
+            "db_user" => @db_conf[:username],
+            "db_password" => @db_conf[:password],
+            "db_port" => "5432",
+            "poll_interval" => 100,
+            "poll_max_changes" => 100,
+            "poll_max_record_bytes" => 1_048_576,
+            "region" => "us-east-1"
+          }
+        }
+      ],
+      postgres_cdc_default: "postgres_cdc_rls",
+      jwt_secret: "new secret",
+      max_concurrent_users: 200,
+      max_events_per_second: 100
+    }
+
+    {:ok, tenant} = Api.create_tenant(params)
+
+    %{tenant: tenant}
+  end
+
+  describe "get_tenant_by_external_id/1" do
+    test "tenants cache returns a cached result", %{tenant: tenant} do
+      external_id = "external_id"
+
+      assert %Api.Tenant{name: "localhost"} = Tenants.Cache.get_tenant_by_external_id(external_id)
+
+      Api.update_tenant(tenant, %{name: "new name"})
+
+      assert %Api.Tenant{name: "new name"} = Tenants.get_tenant_by_external_id(external_id)
+
+      assert %Api.Tenant{name: "localhost"} = Tenants.Cache.get_tenant_by_external_id(external_id)
+    end
+  end
+end


### PR DESCRIPTION
- `Tenants.Cache` module provides read-through cache functionality for any functions in the module
- `Realtime.ContextCache` to easily build caches for other contexts
- Uses `Tenants.Cache` in `Tenant` metrics poller
- Uses `Tenants.Cache` in `UserSocket`
- `Tenants.Cache` ttl is set to expire in 30 seconds