### PR TITLE
fix: don't care if release was published

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -20,7 +20,6 @@ jobs:
 
   deploy:
     runs-on: ubuntu-20.04
-    if: needs.release.outputs.published == 'true'
     steps:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions@1.1


### PR DESCRIPTION
- keep the deploy from getting skipped