### PR TITLE
fix: reference versions and modules to run tenant db migrations

### DIFF
--- a/.github/workflows/staging_linter.yml
+++ b/.github/workflows/staging_linter.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run main database migrations
         run: mix ecto.migrate --log-migrator-sql
       - name: Run database tenant migrations
-        run: mix ecto.migrate --migrations-path priv/repo/postgres/migrations
+        run: mix ecto.migrate --migrations-path lib/extensions/postgres_cdc_rls/repo/migrations
       - name: Run format check
         run: mix format --check-formatted
       - name: Credo checks

--- a/lib/extensions/postgres_cdc_rls/migrations.ex
+++ b/lib/extensions/postgres_cdc_rls/migrations.ex
@@ -1,9 +1,72 @@
 defmodule Extensions.PostgresCdcRls.Migrations do
-  @moduledoc false
+  @moduledoc """
+  Run Realtime database migrations for tenant's database.
+  """
+
   use GenServer
 
   alias Realtime.Repo
+
+  alias Realtime.Extensions.Rls.Repo.Migrations.{
+    CreateRealtimeSubscriptionTable,
+    CreateRealtimeCheckFiltersTrigger,
+    CreateRealtimeQuoteWal2jsonFunction,
+    CreateRealtimeCheckEqualityOpFunction,
+    CreateRealtimeBuildPreparedStatementSqlFunction,
+    CreateRealtimeCastFunction,
+    CreateRealtimeIsVisibleThroughFiltersFunction,
+    CreateRealtimeApplyRlsFunction,
+    GrantRealtimeUsageToAuthenticatedRole,
+    EnableRealtimeApplyRlsFunctionPostgrest9Compatibility,
+    UpdateRealtimeSubscriptionCheckFiltersFunctionSecurity,
+    UpdateRealtimeBuildPreparedStatementSqlFunctionForCompatibilityWithAllTypes,
+    EnableGenericSubscriptionClaims,
+    AddWalPayloadOnErrorsInApplyRlsFunction,
+    UpdateChangeTimestampToIso8601ZuluFormat,
+    UpdateSubscriptionCheckFiltersFunctionDynamicTableName,
+    UpdateApplyRlsFunctionToApplyIso8601,
+    AddQuotedRegtypesSupport,
+    AddOutputForDataLessThanEqual64BytesWhenPayloadTooLarge,
+    AddQuotedRegtypesBackwardCompatibilitySupport,
+    RecreateRealtimeBuildPreparedStatementSqlFunction,
+    NullPassesFiltersRecreateIsVisibleThroughFilters,
+    UpdateApplyRlsFunctionToPassThroughDeleteEventsOnFilter,
+    MillisecondPrecisionForWalrus,
+    AddInOpToFilters,
+    EnableFilteringOnDeleteRecord
+  }
+
   alias Realtime.Helpers, as: H
+
+  @migrations [
+    {20_211_116_024_918, CreateRealtimeSubscriptionTable},
+    {20_211_116_045_059, CreateRealtimeCheckFiltersTrigger},
+    {20_211_116_050_929, CreateRealtimeQuoteWal2jsonFunction},
+    {20_211_116_051_442, CreateRealtimeCheckEqualityOpFunction},
+    {20_211_116_212_300, CreateRealtimeBuildPreparedStatementSqlFunction},
+    {20_211_116_213_355, CreateRealtimeCastFunction},
+    {20_211_116_213_934, CreateRealtimeIsVisibleThroughFiltersFunction},
+    {20_211_116_214_523, CreateRealtimeApplyRlsFunction},
+    {20_211_122_062_447, GrantRealtimeUsageToAuthenticatedRole},
+    {20_211_124_070_109, EnableRealtimeApplyRlsFunctionPostgrest9Compatibility},
+    {20_211_202_204_204, UpdateRealtimeSubscriptionCheckFiltersFunctionSecurity},
+    {20_211_202_204_605,
+     UpdateRealtimeBuildPreparedStatementSqlFunctionForCompatibilityWithAllTypes},
+    {20_211_210_212_804, EnableGenericSubscriptionClaims},
+    {20_211_228_014_915, AddWalPayloadOnErrorsInApplyRlsFunction},
+    {20_220_107_221_237, UpdateChangeTimestampToIso8601ZuluFormat},
+    {20_220_228_202_821, UpdateSubscriptionCheckFiltersFunctionDynamicTableName},
+    {20_220_312_004_840, UpdateApplyRlsFunctionToApplyIso8601},
+    {20_220_603_231_003, AddQuotedRegtypesSupport},
+    {20_220_603_232_444, AddOutputForDataLessThanEqual64BytesWhenPayloadTooLarge},
+    {20_220_615_214_548, AddQuotedRegtypesBackwardCompatibilitySupport},
+    {20_220_712_093_339, RecreateRealtimeBuildPreparedStatementSqlFunction},
+    {20_220_908_172_859, NullPassesFiltersRecreateIsVisibleThroughFilters},
+    {20_220_916_233_421, UpdateApplyRlsFunctionToPassThroughDeleteEventsOnFilter},
+    {20_230_119_133_233, MillisecondPrecisionForWalrus},
+    {20_230_128_025_114, AddInOpToFilters},
+    {20_230_128_025_212, EnableFilteringOnDeleteRecord}
+  ]
 
   @spec start_link(GenServer.options()) :: GenServer.on_start()
   def start_link(opts) do
@@ -13,7 +76,8 @@ defmodule Extensions.PostgresCdcRls.Migrations do
   ## Callbacks
 
   @impl true
-  def init(args) do
+  def init(%{"id" => id} = args) do
+    Logger.metadata(external_id: id, project: id)
     # applying tenant's migrations
     apply_migrations(args)
     # need try to stop this PID
@@ -27,14 +91,23 @@ defmodule Extensions.PostgresCdcRls.Migrations do
   end
 
   @spec apply_migrations(map()) :: [integer()]
-  defp apply_migrations(args) do
+  defp apply_migrations(
+         %{
+           "db_host" => db_host,
+           "db_port" => db_port,
+           "db_name" => db_name,
+           "db_user" => db_user,
+           "db_password" => db_password,
+           "db_socket_opts" => db_socket_opts
+         } = _args
+       ) do
     {host, port, name, user, pass} =
       H.decrypt_creds(
-        args["db_host"],
-        args["db_port"],
-        args["db_name"],
-        args["db_user"],
-        args["db_password"]
+        db_host,
+        db_port,
+        db_name,
+        db_user,
+        db_password
       )
 
     Repo.with_dynamic_repo(
@@ -45,12 +118,12 @@ defmodule Extensions.PostgresCdcRls.Migrations do
         password: pass,
         username: user,
         pool_size: 2,
-        socket_options: args["db_socket_opts"]
+        socket_options: db_socket_opts
       ],
       fn repo ->
         Ecto.Migrator.run(
           Repo,
-          [Ecto.Migrator.migrations_path(Repo, "postgres/migrations")],
+          @migrations,
           :up,
           all: true,
           prefix: "realtime",

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211116024918_create_realtime_subscription_table.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211116024918_create_realtime_subscription_table.ex
@@ -1,18 +1,20 @@
-defmodule Realtime.Repo.Migrations.CreateRealtimeSubscriptionTable do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateRealtimeSubscriptionTable do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create type realtime.equality_op as enum(
+    execute("create type realtime.equality_op as enum(
       'eq', 'neq', 'lt', 'lte', 'gt', 'gte'
-    );"
+    );")
 
-    execute "create type realtime.user_defined_filter as (
+    execute("create type realtime.user_defined_filter as (
       column_name text,
       op realtime.equality_op,
       value text
-    );"
+    );")
 
-    execute "create table realtime.subscription (
+    execute("create table realtime.subscription (
       -- Tracks which users are subscribed to each table
       id bigint not null generated always as identity,
       user_id uuid not null,
@@ -24,8 +26,10 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeSubscriptionTable do
 
       constraint pk_subscription primary key (id),
       unique (entity, user_id, filters)
-    )"
+    )")
 
-    execute "create index ix_realtime_subscription_entity on realtime.subscription using hash (entity)"
+    execute(
+      "create index ix_realtime_subscription_entity on realtime.subscription using hash (entity)"
+    )
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211116050929_create_realtime_quote_wal2json_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211116050929_create_realtime_quote_wal2json_function.ex
@@ -1,8 +1,10 @@
-defmodule Realtime.Repo.Migrations.CreateRealtimeQuoteWal2jsonFunction do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateRealtimeQuoteWal2jsonFunction do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create function realtime.quote_wal2json(entity regclass)
+    execute("create function realtime.quote_wal2json(entity regclass)
       returns text
       language sql
       immutable
@@ -36,6 +38,6 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeQuoteWal2jsonFunction do
           on pc.relnamespace = nsp.oid
       where
         pc.oid = entity
-    $$;"
+    $$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211116051442_create_realtime_check_equality_op_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211116051442_create_realtime_check_equality_op_function.ex
@@ -1,8 +1,10 @@
-defmodule Realtime.Repo.Migrations.CreateRealtimeCheckEqualityOpFunction do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateRealtimeCheckEqualityOpFunction do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create function realtime.check_equality_op(
+    execute("create function realtime.check_equality_op(
       op realtime.equality_op,
       type_ regtype,
       val_1 text,
@@ -32,6 +34,6 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeCheckEqualityOpFunction do
       execute format('select %L::'|| type_::text || ' ' || op_symbol || ' %L::'|| type_::text, val_1, val_2) into res;
       return res;
     end;
-    $$;"
+    $$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211116212300_create_realtime_build_prepared_statement_sql_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211116212300_create_realtime_build_prepared_statement_sql_function.ex
@@ -1,8 +1,18 @@
-defmodule Realtime.Repo.Migrations.UpdateRealtimeBuildPreparedStatementSqlFunctionForCompatibilityWithAllTypes do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateRealtimeBuildPreparedStatementSqlFunction do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create or replace function realtime.build_prepared_statement_sql(
+    execute("create type realtime.wal_column as (
+      name text,
+      type text,
+      value jsonb,
+      is_pkey boolean,
+      is_selectable boolean
+    );")
+
+    execute("create function realtime.build_prepared_statement_sql(
       prepared_statement_name text,
       entity regclass,
       columns realtime.wal_column[]
@@ -26,7 +36,7 @@ defmodule Realtime.Repo.Migrations.UpdateRealtimeBuildPreparedStatementSqlFuncti
           from
             ' || entity || '
           where
-            ' || string_agg(quote_ident(pkc.name) || '=' || quote_nullable(pkc.value #>> '{}') , ' and ') || '
+            ' || string_agg(quote_ident(pkc.name) || '=' || quote_nullable(pkc.value) , ' and ') || '
         )'
       from
         unnest(columns) pkc
@@ -34,6 +44,6 @@ defmodule Realtime.Repo.Migrations.UpdateRealtimeBuildPreparedStatementSqlFuncti
         pkc.is_pkey
       group by
         entity
-    $$;"
+    $$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211116213355_create_realtime_cast_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211116213355_create_realtime_cast_function.ex
@@ -1,8 +1,10 @@
-defmodule Realtime.Repo.Migrations.CreateRealtimeCastFunction do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateRealtimeCastFunction do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create function realtime.cast(val text, type_ regtype)
+    execute("create function realtime.cast(val text, type_ regtype)
       returns jsonb
       immutable
       language plpgsql
@@ -13,6 +15,6 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeCastFunction do
       execute format('select to_jsonb(%L::'|| type_::text || ')', val)  into res;
       return res;
     end
-    $$;"
+    $$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211116213934_create_realtime_is_visible_through_filters_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211116213934_create_realtime_is_visible_through_filters_function.ex
@@ -1,8 +1,11 @@
-defmodule Realtime.Repo.Migrations.CreateRealtimeIsVisibleThroughFiltersFunction do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateRealtimeIsVisibleThroughFiltersFunction do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
+    execute(
+      "create function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
       returns bool
       language sql
       immutable
@@ -29,5 +32,6 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeIsVisibleThroughFiltersFunction
       join unnest(columns) col
           on f.column_name = col.name;
     $$;"
+    )
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211116214523_create_realtime_apply_rls_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211116214523_create_realtime_apply_rls_function.ex
@@ -1,8 +1,20 @@
-defmodule Realtime.Repo.Migrations.EnableRealtimeApplyRlsFunctionPostgrest9Compatibility do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateRealtimeApplyRlsFunction do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+    execute(
+      "create type realtime.action as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'ERROR');"
+    )
+
+    execute("create type realtime.wal_rls as (
+      wal jsonb,
+      is_rls_enabled boolean,
+      users uuid[],
+      errors text[]
+    );")
+    execute("create function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
       returns realtime.wal_rls
       language plpgsql
       volatile
@@ -147,7 +159,10 @@ defmodule Realtime.Repo.Migrations.EnableRealtimeApplyRlsFunctionPostgrest9Compa
       else
         -- If RLS is on and someone is subscribed to the table prep
         if is_rls_enabled and array_length(subscriptions, 1) > 0 then
-          perform set_config('role', 'authenticated', true);
+          perform
+            set_config('role', 'authenticated', true),
+            set_config('request.jwt.claim.role', 'authenticated', true);
+
           if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
             deallocate walrus_rls_stmt;
           end if;
@@ -172,15 +187,8 @@ defmodule Realtime.Repo.Migrations.EnableRealtimeApplyRlsFunctionPostgrest9Compa
             else
               -- Check if RLS allows the user to see the record
               perform
-                set_config(
-                  'request.jwt.claims',
-                  jsonb_build_object(
-                    'sub', user_id::text,
-                    'email', email::text,
-                    'role', 'authenticated'
-                  )::text,
-                  true
-                );
+                set_config('request.jwt.claim.sub', user_id::text, true),
+                set_config('request.jwt.claim.email', email::text, true);
               execute 'execute walrus_rls_stmt' into user_has_access;
 
               if user_has_access then
@@ -204,6 +212,6 @@ defmodule Realtime.Repo.Migrations.EnableRealtimeApplyRlsFunctionPostgrest9Compa
       errors
     )::realtime.wal_rls;
   end;
-  $$;"
+  $$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211122062447_grant_realtime_usage_to_authenticated_role.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211122062447_grant_realtime_usage_to_authenticated_role.ex
@@ -1,0 +1,9 @@
+defmodule Realtime.Extensions.Rls.Repo.Migrations.GrantRealtimeUsageToAuthenticatedRole do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    execute("grant usage on schema realtime to authenticated;")
+  end
+end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211124070109_enable_realtime_apply_rls_function_postgrest_9_compatibility.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211124070109_enable_realtime_apply_rls_function_postgrest_9_compatibility.ex
@@ -1,15 +1,11 @@
-defmodule Realtime.Repo.Migrations.CreateRealtimeApplyRlsFunction do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.EnableRealtimeApplyRlsFunctionPostgrest9Compatibility do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create type realtime.action as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'ERROR');"
-    execute "create type realtime.wal_rls as (
-      wal jsonb,
-      is_rls_enabled boolean,
-      users uuid[],
-      errors text[]
-    );"
-    execute "create function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+    execute(
+      "create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
       returns realtime.wal_rls
       language plpgsql
       volatile
@@ -154,10 +150,7 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeApplyRlsFunction do
       else
         -- If RLS is on and someone is subscribed to the table prep
         if is_rls_enabled and array_length(subscriptions, 1) > 0 then
-          perform
-            set_config('role', 'authenticated', true),
-            set_config('request.jwt.claim.role', 'authenticated', true);
-
+          perform set_config('role', 'authenticated', true);
           if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
             deallocate walrus_rls_stmt;
           end if;
@@ -182,8 +175,15 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeApplyRlsFunction do
             else
               -- Check if RLS allows the user to see the record
               perform
-                set_config('request.jwt.claim.sub', user_id::text, true),
-                set_config('request.jwt.claim.email', email::text, true);
+                set_config(
+                  'request.jwt.claims',
+                  jsonb_build_object(
+                    'sub', user_id::text,
+                    'email', email::text,
+                    'role', 'authenticated'
+                  )::text,
+                  true
+                );
               execute 'execute walrus_rls_stmt' into user_has_access;
 
               if user_has_access then
@@ -208,5 +208,6 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeApplyRlsFunction do
     )::realtime.wal_rls;
   end;
   $$;"
+    )
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211202204605_update_realtime_build_prepared_statement_sql_function_for_compatibility_with_all_types.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211202204605_update_realtime_build_prepared_statement_sql_function_for_compatibility_with_all_types.ex
@@ -1,16 +1,10 @@
-defmodule Realtime.Repo.Migrations.CreateRealtimeBuildPreparedStatementSqlFunction do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.UpdateRealtimeBuildPreparedStatementSqlFunctionForCompatibilityWithAllTypes do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create type realtime.wal_column as (
-      name text,
-      type text,
-      value jsonb,
-      is_pkey boolean,
-      is_selectable boolean
-    );"
-
-    execute "create function realtime.build_prepared_statement_sql(
+    execute("create or replace function realtime.build_prepared_statement_sql(
       prepared_statement_name text,
       entity regclass,
       columns realtime.wal_column[]
@@ -34,7 +28,7 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeBuildPreparedStatementSqlFuncti
           from
             ' || entity || '
           where
-            ' || string_agg(quote_ident(pkc.name) || '=' || quote_nullable(pkc.value) , ' and ') || '
+            ' || string_agg(quote_ident(pkc.name) || '=' || quote_nullable(pkc.value #>> '{}') , ' and ') || '
         )'
       from
         unnest(columns) pkc
@@ -42,6 +36,6 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeBuildPreparedStatementSqlFuncti
         pkc.is_pkey
       group by
         entity
-    $$;"
+    $$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211210212804_enable_generic_subscription_claims.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211210212804_enable_generic_subscription_claims.ex
@@ -1,8 +1,94 @@
-defmodule Realtime.Repo.Migrations.UpdateChangeTimestampToIso8601ZuluFormat do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.EnableGenericSubscriptionClaims do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+    execute("truncate table realtime.subscription restart identity")
+
+    execute("alter table realtime.subscription
+      drop constraint subscription_entity_user_id_filters_key cascade,
+      drop column email cascade,
+      drop column created_at cascade")
+
+    execute("alter table realtime.subscription rename user_id to subscription_id")
+
+    execute("create function realtime.to_regrole(role_name text)
+      returns regrole
+      immutable
+      language sql
+      -- required to allow use in generated clause
+      as $$ select role_name::regrole $$;")
+
+    execute("alter table realtime.subscription
+      add column claims jsonb not null,
+      add column claims_role regrole not null generated always as (realtime.to_regrole(claims ->> 'role')) stored,
+      add column created_at timestamp not null default timezone('utc', now())")
+
+    execute(
+      "create unique index subscription_subscription_id_entity_filters_key on realtime.subscription (subscription_id, entity, filters)"
+    )
+
+    execute("revoke usage on schema realtime from authenticated;")
+    execute("revoke all on realtime.subscription from authenticated;")
+
+    execute("create or replace function realtime.subscription_check_filters()
+      returns trigger
+      language plpgsql
+      as $$
+        /*
+          Validates that the user defined filters for a subscription:
+            - refer to valid columns that the claimed role may access
+            - values are coercable to the correct column type
+        */
+      declare
+        col_names text[] = coalesce(
+            array_agg(c.column_name order by c.ordinal_position),
+            '{}'::text[]
+          )
+          from
+            information_schema.columns c
+          where
+            format('%I.%I', c.table_schema, c.table_name)::regclass = new.entity
+            and pg_catalog.has_column_privilege((new.claims ->> 'role'), new.entity, c.column_name, 'SELECT');
+        filter realtime.user_defined_filter;
+        col_type regtype;
+      begin
+        for filter in select * from unnest(new.filters) loop
+          -- Filtered column is valid
+          if not filter.column_name = any(col_names) then
+            raise exception 'invalid column for filter %', filter.column_name;
+          end if;
+
+          -- Type is sanitized and safe for string interpolation
+          col_type = (
+            select atttypid::regtype
+            from pg_catalog.pg_attribute
+            where attrelid = new.entity
+              and attname = filter.column_name
+          );
+          if col_type is null then
+            raise exception 'failed to lookup type for column %', filter.column_name;
+          end if;
+          -- raises an exception if value is not coercable to type
+          perform realtime.cast(filter.value, col_type);
+        end loop;
+
+        -- Apply consistent order to filters so the unique constraint on
+        -- (subscription_id, entity, filters) can't be tricked by a different filter order
+        new.filters = coalesce(
+          array_agg(f order by f.column_name, f.op, f.value),
+          '{}'
+        ) from unnest(new.filters) f;
+
+        return new;
+      end;
+    $$;")
+
+    execute("alter type realtime.wal_rls rename attribute users to subscription_ids cascade;")
+
+    execute("drop function realtime.apply_rls(jsonb, integer);")
+    execute("create function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
       returns setof realtime.wal_rls
       language plpgsql
       volatile
@@ -138,10 +224,7 @@ defmodule Realtime.Repo.Migrations.UpdateChangeTimestampToIso8601ZuluFormat do
               'schema', wal ->> 'schema',
               'table', wal ->> 'table',
               'type', action,
-              'commit_timestamp', to_char(
-                (wal ->> 'timestamp')::timestamptz,
-                'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'
-              ),
+              'commit_timestamp', (wal ->> 'timestamp')::text::timestamp with time zone,
               'columns', (
                 select
                   jsonb_agg(
@@ -237,6 +320,6 @@ defmodule Realtime.Repo.Migrations.UpdateChangeTimestampToIso8601ZuluFormat do
 
         perform set_config('role', null, true);
       end;
-      $$;"
+      $$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20211228014915_add_wal_payload_on_errors_in_apply_rls_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20211228014915_add_wal_payload_on_errors_in_apply_rls_function.ex
@@ -1,8 +1,11 @@
-defmodule Realtime.Repo.Migrations.AddWalPayloadOnErrorsInApplyRlsFunction do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.AddWalPayloadOnErrorsInApplyRlsFunction do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+    execute(
+      "create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
       returns setof realtime.wal_rls
       language plpgsql
       volatile
@@ -243,5 +246,6 @@ defmodule Realtime.Repo.Migrations.AddWalPayloadOnErrorsInApplyRlsFunction do
     perform set_config('role', null, true);
   end;
   $$;"
+    )
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20220228202821_update_subscription_check_filters_function_dynamic_table_name.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20220228202821_update_subscription_check_filters_function_dynamic_table_name.ex
@@ -1,14 +1,16 @@
-defmodule Realtime.Repo.Migrations.CreateRealtimeCheckFiltersTrigger do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.UpdateSubscriptionCheckFiltersFunctionDynamicTableName do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create function realtime.subscription_check_filters()
+    execute("create or replace function realtime.subscription_check_filters()
       returns trigger
       language plpgsql
     as $$
     /*
     Validates that the user defined filters for a subscription:
-    - refer to valid columns that 'authenticated' may access
+    - refer to valid columns that the claimed role may access
     - values are coercable to the correct column type
     */
     declare
@@ -16,13 +18,18 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeCheckFiltersTrigger do
         array_agg(c.column_name order by c.ordinal_position),
         '{}'::text[]
       )
-        from
-          information_schema.columns c
-        where
-          (quote_ident(c.table_schema) || '.' || quote_ident(c.table_name))::regclass = new.entity
-          and pg_catalog.has_column_privilege('authenticated', new.entity, c.column_name, 'SELECT');
+      from
+        information_schema.columns c
+      where
+        format('%I.%I', c.table_schema, c.table_name)::regclass = new.entity
+        and pg_catalog.has_column_privilege(
+          (new.claims ->> 'role'),
+          format('%I.%I', c.table_schema, c.table_name)::regclass,
+          c.column_name,
+          'SELECT'
+        );
       filter realtime.user_defined_filter;
-      col_type text;
+      col_type regtype;
     begin
       for filter in select * from unnest(new.filters) loop
         -- Filtered column is valid
@@ -36,28 +43,23 @@ defmodule Realtime.Repo.Migrations.CreateRealtimeCheckFiltersTrigger do
           from pg_catalog.pg_attribute
           where attrelid = new.entity
             and attname = filter.column_name
-        )::text;
+        );
         if col_type is null then
           raise exception 'failed to lookup type for column %', filter.column_name;
         end if;
         -- raises an exception if value is not coercable to type
-        perform format('select %s::%I', filter.value, col_type);
+        perform realtime.cast(filter.value, col_type);
       end loop;
 
       -- Apply consistent order to filters so the unique constraint on
-      -- (user_id, entity, filters) can't be tricked by a different filter order
+      -- (subscription_id, entity, filters) can't be tricked by a different filter order
       new.filters = coalesce(
         array_agg(f order by f.column_name, f.op, f.value),
         '{}'
       ) from unnest(new.filters) f;
 
-      return new;
-    end;
-    $$;"
-
-    execute "create trigger tr_check_filters
-    before insert or update on realtime.subscription
-    for each row
-    execute function realtime.subscription_check_filters();"
+    return new;
+  end;
+  $$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20220312004840_update_apply_rls_function_to_apply_iso_8601.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20220312004840_update_apply_rls_function_to_apply_iso_8601.ex
@@ -1,8 +1,11 @@
-defmodule Realtime.Repo.Migrations.UpdateApplyRlsFunctionToApplyIso8601 do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.UpdateApplyRlsFunctionToApplyIso8601 do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+    execute(
+      "create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
       returns setof realtime.wal_rls
       language plpgsql
       volatile
@@ -238,5 +241,6 @@ defmodule Realtime.Repo.Migrations.UpdateApplyRlsFunctionToApplyIso8601 do
         perform set_config('role', null, true);
       end;
       $$;"
+    )
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20220603231003_add_quoted_regtypes_support.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20220603231003_add_quoted_regtypes_support.ex
@@ -1,4 +1,6 @@
-defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesSupport do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.AddQuotedRegtypesSupport do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20220615214548_add_quoted_regtypes_backward_compatibility_support.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20220615214548_add_quoted_regtypes_backward_compatibility_support.ex
@@ -1,9 +1,44 @@
-defmodule Realtime.RLS.Repo.Migrations.UpdateApplyRlsFunctionToPassThroughDeleteEventsOnFilter do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.AddQuotedRegtypesBackwardCompatibilitySupport do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
     execute("
-      create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+      create or replace function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
+            returns bool
+            language sql
+            immutable
+        as $$
+        /*
+        Should the record be visible (true) or filtered out (false) after *filters* are applied
+        */
+            select
+                -- Default to allowed when no filters present
+                coalesce(
+                    sum(
+                        realtime.check_equality_op(
+                            op:=f.op,
+                            type_:=coalesce(
+                                col.type_oid::regtype, -- null when wal2json version <= 2.4
+                                col.type_name::regtype
+                            ),
+                            -- cast jsonb to text
+                            val_1:=col.value #>> '{}',
+                            val_2:=f.value
+                        )::int
+                    ) = count(1),
+                    true
+                )
+            from
+                unnest(filters) f
+                join unnest(columns) col
+                    on f.column_name = col.name;
+        $$;
+    ")
+
+    execute("
+    create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
           returns setof realtime.wal_rls
           language plpgsql
           volatile
@@ -248,10 +283,7 @@ defmodule Realtime.RLS.Repo.Migrations.UpdateApplyRlsFunctionToPassThroughDelete
                           where
                               subs.entity = entity_
                               and subs.claims_role = working_role
-                              and (
-                                  realtime.is_visible_through_filters(columns, subs.filters)
-                                  or action = 'DELETE'
-                              )
+                              and realtime.is_visible_through_filters(columns, subs.filters)
                   ) loop
 
                       if not is_rls_enabled or action = 'DELETE' then
@@ -287,7 +319,7 @@ defmodule Realtime.RLS.Repo.Migrations.UpdateApplyRlsFunctionToPassThroughDelete
 
           perform set_config('role', null, true);
       end;
-      $$;
+    $$;
     ")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20220712093339_recreate_realtime_build_prepared_statement_sql_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20220712093339_recreate_realtime_build_prepared_statement_sql_function.ex
@@ -1,8 +1,10 @@
-defmodule Realtime.RLS.Repo.Migrations.RecreateRealtimeBuildPreparedStatementSqlFunction do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.RecreateRealtimeBuildPreparedStatementSqlFunction do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "
+    execute("
       create or replace function realtime.build_prepared_statement_sql(
           prepared_statement_name text,
           entity regclass,
@@ -35,6 +37,6 @@ defmodule Realtime.RLS.Repo.Migrations.RecreateRealtimeBuildPreparedStatementSql
           group by
               entity
       $$;
-    "
+    ")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20220908172859_null_passes_filters_recreate_is_visible_through_filters.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20220908172859_null_passes_filters_recreate_is_visible_through_filters.ex
@@ -1,8 +1,10 @@
-defmodule Realtime.RLS.Repo.Migrations.NullPassesFiltersRecreateIsVisibleThroughFilters do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.NullPassesFiltersRecreateIsVisibleThroughFilters do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
-    execute "
+    execute("
     create or replace function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
       returns bool
       language sql
@@ -35,6 +37,6 @@ defmodule Realtime.RLS.Repo.Migrations.NullPassesFiltersRecreateIsVisibleThrough
             join unnest(columns) col
                 on f.column_name = col.name;
     $$;
-    "
+    ")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20230119133233_millisecond_precision_for_walrus.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20230119133233_millisecond_precision_for_walrus.ex
@@ -1,42 +1,11 @@
-defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesBackwardCompatibilitySupport do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.MillisecondPrecisionForWalrus do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
     execute("
-      create or replace function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
-            returns bool
-            language sql
-            immutable
-        as $$
-        /*
-        Should the record be visible (true) or filtered out (false) after *filters* are applied
-        */
-            select
-                -- Default to allowed when no filters present
-                coalesce(
-                    sum(
-                        realtime.check_equality_op(
-                            op:=f.op,
-                            type_:=coalesce(
-                                col.type_oid::regtype, -- null when wal2json version <= 2.4
-                                col.type_name::regtype
-                            ),
-                            -- cast jsonb to text
-                            val_1:=col.value #>> '{}',
-                            val_2:=f.value
-                        )::int
-                    ) = count(1),
-                    true
-                )
-            from
-                unnest(filters) f
-                join unnest(columns) col
-                    on f.column_name = col.name;
-        $$;
-    ")
-
-    execute("
-    create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+      create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
           returns setof realtime.wal_rls
           language plpgsql
           volatile
@@ -198,7 +167,7 @@ defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesBackwardCompatibilitySup
                       'type', action,
                       'commit_timestamp', to_char(
                           (wal ->> 'timestamp')::timestamptz,
-                          'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'
+                          'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'
                       ),
                       'columns', (
                           select
@@ -222,43 +191,43 @@ defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesBackwardCompatibilitySup
                   -- Add \"record\" key for insert and update
                   || case
                       when action in ('INSERT', 'UPDATE') then
-                          case
-                              when error_record_exceeds_max_size then
-                                  jsonb_build_object(
-                                      'record',
-                                      (
-                                          select jsonb_object_agg((c).name, (c).value)
-                                          from unnest(columns) c
-                                          where (c).is_selectable and (octet_length((c).value::text) <= 64)
-                                      )
-                                  )
-                              else
-                                  jsonb_build_object(
-                                      'record',
-                                      (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
-                                  )
-                          end
+                          jsonb_build_object(
+                              'record',
+                              (
+                                  select jsonb_object_agg((c).name, (c).value)
+                                  from unnest(columns) c
+                                  where
+                                      (c).is_selectable
+                                      and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                              )
+                          )
                       else '{}'::jsonb
                   end
                   -- Add \"old_record\" key for update and delete
                   || case
-                      when action in ('UPDATE', 'DELETE') then
-                          case
-                              when error_record_exceeds_max_size then
-                                  jsonb_build_object(
-                                      'old_record',
-                                      (
-                                          select jsonb_object_agg((c).name, (c).value)
-                                          from unnest(old_columns) c
-                                          where (c).is_selectable and (octet_length((c).value::text) <= 64)
-                                      )
+                      when action = 'UPDATE' then
+                          jsonb_build_object(
+                                  'old_record',
+                                  (
+                                      select jsonb_object_agg((c).name, (c).value)
+                                      from unnest(old_columns) c
+                                      where
+                                          (c).is_selectable
+                                          and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
                                   )
-                              else
-                                  jsonb_build_object(
-                                      'old_record',
-                                      (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
-                                  )
-                          end
+                              )
+                      when action = 'DELETE' then
+                          jsonb_build_object(
+                              'old_record',
+                              (
+                                  select jsonb_object_agg((c).name, (c).value)
+                                  from unnest(old_columns) c
+                                  where
+                                      (c).is_selectable
+                                      and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                                      and ( not is_rls_enabled or (c).is_pkey ) -- if RLS enabled, we can't secure deletes so filter to pkey
+                              )
+                          )
                       else '{}'::jsonb
                   end;
 
@@ -281,7 +250,10 @@ defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesBackwardCompatibilitySup
                           where
                               subs.entity = entity_
                               and subs.claims_role = working_role
-                              and realtime.is_visible_through_filters(columns, subs.filters)
+                              and (
+                                  realtime.is_visible_through_filters(columns, subs.filters)
+                                  or action = 'DELETE'
+                              )
                   ) loop
 
                       if not is_rls_enabled or action = 'DELETE' then
@@ -317,7 +289,7 @@ defmodule Realtime.RLS.Repo.Migrations.AddQuotedRegtypesBackwardCompatibilitySup
 
           perform set_config('role', null, true);
       end;
-    $$;
+      $$;
     ")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20230128025114_add_in_op_to_filters.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20230128025114_add_in_op_to_filters.ex
@@ -1,4 +1,6 @@
-defmodule Realtime.RLS.Repo.Migrations.AddInOpToFilters do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.AddInOpToFilters do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20230128025212_enable_filtering_on_delete_record.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20230128025212_enable_filtering_on_delete_record.ex
@@ -1,4 +1,6 @@
-defmodule Realtime.RLS.Repo.Migrations.AddOutputForDataLessThanEqual64BytesWhenPayloadTooLarge do
+defmodule Realtime.Extensions.Rls.Repo.Migrations.EnableFilteringOnDeleteRecord do
+  @moduledoc false
+
   use Ecto.Migration
 
   def change do
@@ -11,6 +13,7 @@ defmodule Realtime.RLS.Repo.Migrations.AddOutputForDataLessThanEqual64BytesWhenP
       declare
           -- Regclass of the table e.g. public.notes
           entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
+
           -- I, U, D, T: insert, update ...
           action realtime.action = (
               case wal ->> 'action'
@@ -20,23 +23,29 @@ defmodule Realtime.RLS.Repo.Migrations.AddOutputForDataLessThanEqual64BytesWhenP
                   else 'ERROR'
               end
           );
+
           -- Is row level security enabled for the table
           is_rls_enabled bool = relrowsecurity from pg_class where oid = entity_;
+
           subscriptions realtime.subscription[] = array_agg(subs)
               from
                   realtime.subscription subs
               where
                   subs.entity = entity_;
+
           -- Subscription vars
           roles regrole[] = array_agg(distinct us.claims_role)
               from
                   unnest(subscriptions) us;
+
           working_role regrole;
           claimed_role regrole;
           claims jsonb;
+
           subscription_id uuid;
           subscription_has_access bool;
           visible_to_subscription_ids uuid[] = '{}';
+
           -- structured info for wal's columns
           columns realtime.wal_column[];
           -- previous identity values for update/delete
@@ -58,7 +67,10 @@ defmodule Realtime.RLS.Repo.Migrations.AddOutputForDataLessThanEqual64BytesWhenP
                       x->>'typeoid',
                       realtime.cast(
                           (x->'value') #>> '{}',
-                          (x->>'typeoid')::regtype
+                          coalesce(
+                              (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                              (x->>'type')::regtype
+                          )
                       ),
                       (pks ->> 'name') is not null,
                       true
@@ -77,7 +89,10 @@ defmodule Realtime.RLS.Repo.Migrations.AddOutputForDataLessThanEqual64BytesWhenP
                       x->>'typeoid',
                       realtime.cast(
                           (x->'value') #>> '{}',
-                          (x->>'typeoid')::regtype
+                          coalesce(
+                              (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                              (x->>'type')::regtype
+                          )
                       ),
                       (pks ->> 'name') is not null,
                       true
@@ -176,43 +191,43 @@ defmodule Realtime.RLS.Repo.Migrations.AddOutputForDataLessThanEqual64BytesWhenP
                   -- Add \"record\" key for insert and update
                   || case
                       when action in ('INSERT', 'UPDATE') then
-                          case
-                              when error_record_exceeds_max_size then
-                                  jsonb_build_object(
-                                      'record',
-                                      (
-                                          select jsonb_object_agg((c).name, (c).value)
-                                          from unnest(columns) c
-                                          where (c).is_selectable and (octet_length((c).value::text) <= 64)
-                                      )
-                                  )
-                              else
-                                  jsonb_build_object(
-                                      'record',
-                                      (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
-                                  )
-                          end
+                          jsonb_build_object(
+                              'record',
+                              (
+                                  select jsonb_object_agg((c).name, (c).value)
+                                  from unnest(columns) c
+                                  where
+                                      (c).is_selectable
+                                      and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                              )
+                          )
                       else '{}'::jsonb
                   end
                   -- Add \"old_record\" key for update and delete
                   || case
-                      when action in ('UPDATE', 'DELETE') then
-                          case
-                              when error_record_exceeds_max_size then
-                                  jsonb_build_object(
-                                      'old_record',
-                                      (
-                                          select jsonb_object_agg((c).name, (c).value)
-                                          from unnest(old_columns) c
-                                          where (c).is_selectable and (octet_length((c).value::text) <= 64)
-                                      )
+                      when action = 'UPDATE' then
+                          jsonb_build_object(
+                                  'old_record',
+                                  (
+                                      select jsonb_object_agg((c).name, (c).value)
+                                      from unnest(old_columns) c
+                                      where
+                                          (c).is_selectable
+                                          and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
                                   )
-                              else
-                                  jsonb_build_object(
-                                      'old_record',
-                                      (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
-                                  )
-                          end
+                              )
+                      when action = 'DELETE' then
+                          jsonb_build_object(
+                              'old_record',
+                              (
+                                  select jsonb_object_agg((c).name, (c).value)
+                                  from unnest(old_columns) c
+                                  where
+                                      (c).is_selectable
+                                      and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                                      and ( not is_rls_enabled or (c).is_pkey ) -- if RLS enabled, we can't secure deletes so filter to pkey
+                              )
+                          )
                       else '{}'::jsonb
                   end;
 
@@ -235,7 +250,10 @@ defmodule Realtime.RLS.Repo.Migrations.AddOutputForDataLessThanEqual64BytesWhenP
                           where
                               subs.entity = entity_
                               and subs.claims_role = working_role
-                              and realtime.is_visible_through_filters(columns, subs.filters)
+                              and (
+                                  realtime.is_visible_through_filters(columns, subs.filters)
+                                  or action = 'DELETE'
+                              )
                   ) loop
 
                       if not is_rls_enabled or action = 'DELETE' then

--- a/lib/extensions/postgres_cdc_rls/supervisor.ex
+++ b/lib/extensions/postgres_cdc_rls/supervisor.ex
@@ -13,6 +13,8 @@ defmodule Extensions.PostgresCdcRls.Supervisor do
 
   @impl true
   def init(_args) do
+    load_migrations_modules()
+
     :syn.set_event_handler(Rls.SynHandler)
     :syn.add_node_to_scopes([Rls])
 
@@ -27,5 +29,15 @@ defmodule Extensions.PostgresCdcRls.Supervisor do
     ]
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp load_migrations_modules() do
+    {:ok, modules} = :application.get_key(:realtime, :modules)
+
+    modules
+    |> Enum.filter(
+      &String.starts_with?(to_string(&1), "Elixir.Realtime.Extensions.Rls.Repo.Migrations")
+    )
+    |> Enum.each(&Code.ensure_loaded!/1)
   end
 end

--- a/priv/repo/postgres/migrations/20211122062447_grant_realtime_usage_to_authenticated_role.exs
+++ b/priv/repo/postgres/migrations/20211122062447_grant_realtime_usage_to_authenticated_role.exs
@@ -1,7 +1,0 @@
-defmodule Realtime.Repo.Migrations.GrantRealtimeUsageToAuthenticatedRole do
-  use Ecto.Migration
-
-  def change do
-    execute "grant usage on schema realtime to authenticated;"
-  end
-end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Running tenant database migrations eats up a lot of memory and causes OOM errors.

## What is the new behavior?

Moved the migrations modules to `/lib` where they will be compiled and, on application start, will be loaded once and used by all tenants wishing to run migrations.

## Additional Context

This strategy is recommended: https://github.com/elixir-ecto/ecto_sql/issues/152#issuecomment-536772953