### PR TITLE
fix: update in filter to work with non-text types

### DIFF
--- a/lib/extensions/postgres_cdc_rls/migrations.ex
+++ b/lib/extensions/postgres_cdc_rls/migrations.ex
@@ -33,7 +33,8 @@ defmodule Extensions.PostgresCdcRls.Migrations do
     UpdateApplyRlsFunctionToPassThroughDeleteEventsOnFilter,
     MillisecondPrecisionForWalrus,
     AddInOpToFilters,
-    EnableFilteringOnDeleteRecord
+    EnableFilteringOnDeleteRecord,
+    UpdateSubscriptionCheckFiltersForInFilterNonTextTypes
   }
 
   alias Realtime.Helpers, as: H
@@ -65,7 +66,8 @@ defmodule Extensions.PostgresCdcRls.Migrations do
     {20_220_916_233_421, UpdateApplyRlsFunctionToPassThroughDeleteEventsOnFilter},
     {20_230_119_133_233, MillisecondPrecisionForWalrus},
     {20_230_128_025_114, AddInOpToFilters},
-    {20_230_128_025_212, EnableFilteringOnDeleteRecord}
+    {20_230_128_025_212, EnableFilteringOnDeleteRecord},
+    {20_230_227_211_149, UpdateSubscriptionCheckFiltersForInFilterNonTextTypes}
   ]
 
   @spec start_link(GenServer.options()) :: GenServer.on_start()

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20230227211149_update_subscription_check_filters_for_in_filter_non_text_types.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20230227211149_update_subscription_check_filters_for_in_filter_non_text_types.ex
@@ -1,0 +1,79 @@
+defmodule Realtime.Extensions.Rls.Repo.Migrations.UpdateSubscriptionCheckFiltersForInFilterNonTextTypes do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    execute("
+    create or replace function realtime.subscription_check_filters()
+        returns trigger
+        language plpgsql
+    as $$
+    /*
+    Validates that the user defined filters for a subscription:
+    - refer to valid columns that the claimed role may access
+    - values are coercable to the correct column type
+    */
+    declare
+        col_names text[] = coalesce(
+                array_agg(c.column_name order by c.ordinal_position),
+                '{}'::text[]
+            )
+            from
+                information_schema.columns c
+            where
+                format('%I.%I', c.table_schema, c.table_name)::regclass = new.entity
+                and pg_catalog.has_column_privilege(
+                    (new.claims ->> 'role'),
+                    format('%I.%I', c.table_schema, c.table_name)::regclass,
+                    c.column_name,
+                    'SELECT'
+                );
+        filter realtime.user_defined_filter;
+        col_type regtype;
+
+        in_val jsonb;
+    begin
+        for filter in select * from unnest(new.filters) loop
+            -- Filtered column is valid
+            if not filter.column_name = any(col_names) then
+                raise exception 'invalid column for filter %', filter.column_name;
+            end if;
+
+            -- Type is sanitized and safe for string interpolation
+            col_type = (
+                select atttypid::regtype
+                from pg_catalog.pg_attribute
+                where attrelid = new.entity
+                      and attname = filter.column_name
+            );
+            if col_type is null then
+                raise exception 'failed to lookup type for column %', filter.column_name;
+            end if;
+
+            -- Set maximum number of entries for in filter
+            if filter.op = 'in'::realtime.equality_op then
+                in_val = realtime.cast(filter.value, (col_type::text || '[]')::regtype);
+                if coalesce(jsonb_array_length(in_val), 0) > 100 then
+                    raise exception 'too many values for `in` filter. Maximum 100';
+                end if;
+            else
+                -- raises an exception if value is not coercable to type
+                perform realtime.cast(filter.value, col_type);
+            end if;
+
+        end loop;
+
+        -- Apply consistent order to filters so the unique constraint on
+        -- (subscription_id, entity, filters) can't be tricked by a different filter order
+        new.filters = coalesce(
+            array_agg(f order by f.column_name, f.op, f.value),
+            '{}'
+        ) from unnest(new.filters) f;
+
+        return new;
+    end;
+    $$;
+    ")
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`in` filter only works with `text` types

## What is the new behavior?

`in` filter only works with `text` and non-`text` types

## Additional context

- Related: https://github.com/supabase/walrus/pull/71
- Fixes: https://github.com/supabase/realtime/issues/491
