### PR TITLE
fix: filter out table names with spaces when polling replication

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replications.ex
+++ b/lib/extensions/postgres_cdc_rls/replications.ex
@@ -84,7 +84,7 @@ defmodule Extensions.PostgresCdcRls.Replications do
             string_agg(
               realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass),
               ','
-            ) filter (where ppt.tablename is not null),
+            ) filter (where ppt.tablename is not null and ppt.tablename not like '% %'),
             ''
           ) w2j_add_tables
         from

--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -126,6 +126,10 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
     case query(conn, sql, [publication]) do
       {:ok, %{columns: ["schemaname", "tablename", "oid"], rows: rows}} ->
         Enum.reduce(rows, %{}, fn [schema, table, oid], acc ->
+          if String.contains?(table, " ") do
+            Logger.error("Publication table name contains spaces: \"#{schema}\".\"#{table}\"")
+          end
+
           Map.put(acc, {schema, table}, [oid])
           |> Map.update({schema}, [oid], &[oid | &1])
           |> Map.update({"*"}, [oid], &[oid | &1])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Polling replication breaks if there's any table names with spaces in the name.

## What is the new behavior?

Polling replication filters out table names with spaces so it'll continue working for other valid table names in the publication.
