### PR TITLE
fix: don't count access_token socket interaction as an event

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -281,7 +281,6 @@ defmodule RealtimeWeb.RealtimeChannel do
           }
         } = socket
       ) do
-    socket = count(socket)
     cancel_timer(pg_sub_ref)
 
     args = Map.put(postgres_extension, "id", tenant)

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -254,7 +254,6 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   @impl true
   def handle_info(%{event: "postgres_cdc_down"}, socket) do
-    socket = count(socket)
     pg_sub_ref = postgres_subscribe()
 
     {:noreply, assign(socket, %{pg_sub_ref: pg_sub_ref})}

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -317,8 +317,6 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   @impl true
   def handle_info(:confirm_token, %{assigns: %{pg_change_params: pg_change_params}} = socket) do
-    socket = count(socket)
-
     case confirm_token(socket) do
       {:ok, claims, confirm_token_ref} ->
         pg_change_params = Enum.map(pg_change_params, &Map.put(&1, :claims, claims))
@@ -379,7 +377,7 @@ defmodule RealtimeWeb.RealtimeChannel do
         %{assigns: %{pg_sub_ref: pg_sub_ref, pg_change_params: pg_change_params}} = socket
       )
       when is_binary(refresh_token) do
-    socket = count(socket) |> assign(:access_token, refresh_token)
+    socket = socket |> assign(:access_token, refresh_token)
 
     case confirm_token(socket) do
       {:ok, claims, confirm_token_ref} ->


### PR DESCRIPTION
`access_token` interaction RealtimeChannel events are bloating event counts too much.

100 concurrent users connected throughout the whole month would be:
100 connected * 4 events per minute (2 up 2 down) * 60 minutes * 24 hours = 576_000 events per day

RealtimeChannel event count updates:
- [x] don't count `access_token` 
- [x] don't count `postgres_subscribe`
- [x] don't count `postgres_cdc_down`
- [x] don't count `confirm_token`