### PR TITLE
feat: support 100k connections

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,7 +18,11 @@ if config_env() == :prod do
     http: [
       port: String.to_integer(System.get_env("PORT") || "4000"),
       transport_options: [
-        max_connections: String.to_integer(System.get_env("MAX_CONNECTIONS") || "16384"),
+        # max_connection is per connection supervisor
+        # num_conns_sups defaults to num_acceptors
+        # total conns accepted here is max_connections * num_acceptors
+        # ref: https://ninenines.eu/docs/en/ranch/2.0/manual/ranch/
+        max_connections: String.to_integer(System.get_env("MAX_CONNECTIONS") || "1000"),
         num_acceptors: String.to_integer(System.get_env("NUM_ACCEPTORS") || "100"),
         # IMPORTANT: support IPv6 addresses
         socket_opts: [:inet6]

--- a/deploy/fly/prod.toml
+++ b/deploy/fly/prod.toml
@@ -24,9 +24,9 @@ processes = []
   protocol = "tcp"
   script_checks = []
   [services.concurrency]
-   # should match ranch.info
-    hard_limit = 16384
-    soft_limit = 16384
+   # should match :ranch.info max_connections * num_acceptors
+    hard_limit = 100000
+    soft_limit = 100000
     type = "connections"
 
   [[services.ports]]


### PR DESCRIPTION
We're getting close to 16k connections on one node when a node in a region is restarted.

This will give us some room for growth. 