### PR TITLE
feat: add polling query metric

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -111,14 +111,14 @@ defmodule Realtime.PromEx.Plugins.Tenant do
         ),
         sum(
           [:realtime, :channel, :joins],
-          event_name: [:realtime, :rate_counter, :channel, :events],
+          event_name: [:realtime, :rate_counter, :channel, :joins],
           measurement: :sum,
           description: "Sum of Realtime Channel joins.",
           tags: [:tenant]
         ),
         last_value(
           [:realtime, :channel, :joins, :limit_per_second],
-          event_name: [:realtime, :rate_counter, :channel, :events],
+          event_name: [:realtime, :rate_counter, :channel, :joins],
           measurement: :limit,
           description: "Rate limit of joins per second on a Realtime Channel.",
           tags: [:tenant]

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -20,7 +20,8 @@ defmodule Realtime.PromEx.Plugins.Tenant do
   def event_metrics(_opts) do
     # Event metrics definitions
     [
-      channel_events()
+      channel_events(),
+      replication_metrics()
     ]
   end
 
@@ -71,9 +72,28 @@ defmodule Realtime.PromEx.Plugins.Tenant do
     end
   end
 
+  defp replication_metrics() do
+    Event.build(
+      :realtime_tenant_replication_event_metrics,
+      [
+        distribution(
+          [:realtime, :replication, :poller, :query, :duration],
+          event_name: [:realtime, :replication, :poller, :query, :stop],
+          measurement: :duration,
+          description: "Duration of the logical replication slot polling query for Realtime RLS.",
+          tags: [:tenant],
+          unit: {:native, :millisecond},
+          reporter_options: [
+            buckets: [125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000]
+          ]
+        )
+      ]
+    )
+  end
+
   defp channel_events() do
     Event.build(
-      :realtime_tenant_events,
+      :realtime_tenant_channel_event_metrics,
       [
         sum(
           [:realtime, :channel, :events],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.8.2",
+      version: "2.9.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- [x] times the replication polling query and exposes a histogram metric for it per tenant