### PR TITLE
fix: unit conversion for polling query metric

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -82,7 +82,7 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           measurement: :duration,
           description: "Duration of the logical replication slot polling query for Realtime RLS.",
           tags: [:tenant],
-          unit: {:native, :millisecond},
+          unit: {:microsecond, :millisecond},,
           reporter_options: [
             buckets: [125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000]
           ]

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -82,7 +82,7 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           measurement: :duration,
           description: "Duration of the logical replication slot polling query for Realtime RLS.",
           tags: [:tenant],
-          unit: {:microsecond, :millisecond},,
+          unit: {:microsecond, :millisecond},
           reporter_options: [
             buckets: [125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000]
           ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.9.0",
+      version: "2.9.1",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- Convert from `:native` doesn't work here use `:microsecond`