### PR TITLE
fix: only delete tenant from database on tenant delete endpoint

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.12.4",
+      version: "2.12.5",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Tenant delete endpoint would return a `503` error, or take a long time, when it fails to stop all the processes related to `PostgresCdc`. 

## What is the new behavior?

Tenant delete endpoint deletes the tenant from Realtime database, and then creates an async process to stop all processes, so it'll take at most 15 seconds or so and won't return a `503`.
