### PR TITLE
fix: error on memory usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 .PHONY: dev dev.orange seed prod bench.% dev_db start start.% stop stop.% rebuild rebuild.%
 
 dev:
-	SLOT_NAME_SUFFIX=some_sha PORT=4000 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name pink@127.0.0.1 --cookie cookie  -S mix phx.server
+	ELIXIR_ERL_OPTIONS="+hmax 1000000000" SLOT_NAME_SUFFIX=some_sha PORT=4000 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name pink@127.0.0.1 --cookie cookie  -S mix phx.server
 
 dev.orange:
-	SLOT_NAME_SUFFIX=some_sha PORT=4001 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name orange@127.0.0.1 --cookie cookie  -S mix phx.server
+	ELIXIR_ERL_OPTIONS="+hmax 1000000000" SLOT_NAME_SUFFIX=some_sha PORT=4001 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" iex --name orange@127.0.0.1 --cookie cookie  -S mix phx.server
 
 seed:
 	mix run priv/repo/seeds.exs
 
 prod:
-	SLOT_NAME_SUFFIX=some_sha MIX_ENV=prod FLY_APP_NAME=realtime-local API_KEY=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" SECRET_KEY_BASE=M+55t7f6L9VWyhH03R5N7cIhrdRlZaMDfTE6Udz0eZS7gCbnoLQ8PImxwhEyao6D DASHBOARD_USER=realtime_local DASHBOARD_PASSWORD=password ERL_AFLAGS="-kernel shell_history enabled" iex -S mix phx.server
+	ELIXIR_ERL_OPTIONS="+hmax 1000000000" SLOT_NAME_SUFFIX=some_sha MIX_ENV=prod FLY_APP_NAME=realtime-local API_KEY=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" SECRET_KEY_BASE=M+55t7f6L9VWyhH03R5N7cIhrdRlZaMDfTE6Udz0eZS7gCbnoLQ8PImxwhEyao6D DASHBOARD_USER=realtime_local DASHBOARD_PASSWORD=password ERL_AFLAGS="-kernel shell_history enabled" iex -S mix phx.server
 
 bench.%:
-	SLOT_NAME_SUFFIX=some_sha MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" mix run bench/$*
+	ELIXIR_ERL_OPTIONS="+hmax 1000000000" SLOT_NAME_SUFFIX=some_sha MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" ERL_AFLAGS="-kernel shell_history enabled" mix run bench/$*
 
 dev_db:
 	docker-compose -f docker-compose.dbs.yml up -d && mix ecto.migrate --log-migrator-sql

--- a/lib/realtime/monitoring/os_metrics.ex
+++ b/lib/realtime/monitoring/os_metrics.ex
@@ -6,7 +6,8 @@ defmodule Realtime.OsMetrics do
   @spec ram_usage() :: float()
   def ram_usage() do
     mem = :memsup.get_system_memory_data()
-    100 - mem[:free_memory] / mem[:total_memory] * 100
+    free_mem = if Mix.env() == :dev, do: mem[:free_memory], else: mem[:available_memory]
+    100 - free_mem / mem[:total_memory] * 100
   end
 
   @spec cpu_la() :: %{avg1: float(), avg5: float(), avg15: float()}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.12.5",
+      version: "2.12.6",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -9,3 +9,6 @@
 
 ## Tweak GC to run more often
 ##-env ERL_FULLSWEEP_AFTER 10
+
+## Limit process heap for all procs to 1000 MB
++hmax 1000000000


### PR DESCRIPTION
Still not getting crash dumps on oom's.

I thought about monitoring `:memsup.get_system_memory_data()` and then using `erlang:halt/1` to trigger a crash dump when memory usage gets low but looking at our metrics memsup doesn't seem to be reporting what our host is reporting for memory usage.

So this attempt consists of:
- [x] using `:memsup.get_system_memory_data()[:available_memory]` on prod to see if that reflects actual memory better
- [x] setting the `+hmax 1000000000` vm argument so no one process can use over 1000mb of heap

Now if a process does accumulate a lot of heap it will be killed and we should at least see the error log for it.