### PR TITLE
fix: token refresh

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -345,6 +345,15 @@ defmodule RealtimeWeb.RealtimeChannel do
   def handle_in(
         "access_token",
         %{"access_token" => refresh_token},
+        %{access_token: access_token} = socket
+      )
+      when refresh_token == access_token do
+    {:noreply, socket}
+  end
+
+  def handle_in(
+        "access_token",
+        %{"access_token" => refresh_token},
         %{assigns: %{pg_sub_ref: pg_sub_ref, pg_change_params: pg_change_params}} = socket
       )
       when is_binary(refresh_token) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.13.0",
+      version: "2.13.1",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Problem
Clients can send over a new "access_token" which causes us to resubscribe to Postgres. Some clients seem to do this even if the access_token has not changed. With lots of clients connected this can cause extreme thrashing on the realtime.subscription table. 

## Solution
If the access_token in the socket is the same as the one they are trying to send over, don't do anything. 