### PR TITLE
feat: Add hostname detection for AWS ECS Fargate

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -4,9 +4,16 @@
 # the one below (my_app@127.0.0.1), you need to also uncomment the
 # RELEASE_DISTRIBUTION variable below. Must be "sname", "name" or "none".
 
+# for Fly.io
 ip=$(grep fly-local-6pn /etc/hosts | cut -f 1)
-if [ -z $ip ]
-then
+
+# for AWS ECS Fargate
+if [ "$AWS_EXECUTION_ENV" = "AWS_ECS_FARGATE" ]; then
+  ip=$(grep $HOSTNAME /etc/hosts | cut -f 1 -d " ")
+fi
+
+# default to localhost
+if [ -z $ip ]; then
   ip=127.0.0.1
 fi
 export RELEASE_DISTRIBUTION=name


### PR DESCRIPTION
## What kind of change does this PR introduce?

The hostname will be detected correctly when running on AWS Fargate.

## What is the current behavior?

When running outside of fly.io, it is detected as `127.0.0.1`.

## What is the new behavior?

If the environment variable indicates that it is running on Fargate, it will detect its IP.

It is not cool to add code for each execution environment, but it is difficult to set IP as an environment variable.

## Additional context

N/A
