### PR TITLE
fix: Migration error for Cloud SQL

### DIFF
--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20230328144023_create_list_changes_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20230328144023_create_list_changes_function.ex
@@ -4,68 +4,261 @@ defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateListChangesFunction do
   use Ecto.Migration
 
   def change do
-    execute(
-      "create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
-      returns setof realtime.wal_rls
-      language sql
-      set log_min_messages to 'fatal'
-    as $$
-      with pub as (
-        select
-          concat_ws(
-            ',',
-            case when bool_or(pubinsert) then 'insert' else null end,
-            case when bool_or(pubupdate) then 'update' else null end,
-            case when bool_or(pubdelete) then 'delete' else null end
-          ) as w2j_actions,
-          coalesce(
-            string_agg(
-              realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass),
-              ','
-            ) filter (where ppt.tablename is not null and ppt.tablename not like '% %'),
-            ''
-          ) w2j_add_tables
-        from
-          pg_publication pp
-          left join pg_publication_tables ppt
-            on pp.pubname = ppt.pubname
-        where
-          pp.pubname = publication
-        group by
-          pp.pubname
-        limit 1
-      ),
-      w2j as (
-        select
-          x.*, pub.w2j_add_tables
-        from
-          pub,
-          pg_logical_slot_get_changes(
-            slot_name, null, max_changes,
-            'include-pk', 'true',
-            'include-transaction', 'false',
-            'include-timestamp', 'true',
-            'include-type-oids', 'true',
-            'format-version', '2',
-            'actions', pub.w2j_actions,
-            'add-tables', pub.w2j_add_tables
-          ) x
-      )
-      select
-        xyz.wal,
-        xyz.is_rls_enabled,
-        xyz.subscription_ids,
-        xyz.errors
-      from
-        w2j,
-        realtime.apply_rls(
-          wal := w2j.data::jsonb,
-          max_record_bytes := max_record_bytes
-        ) xyz(wal, is_rls_enabled, subscription_ids, errors)
-      where
-        w2j.w2j_add_tables <> ''
-        and xyz.subscription_ids[1] is not null
-    $$;"
+    execute("DO $dyn$
+    BEGIN
+    IF (SELECT rolsuper FROM pg_roles WHERE rolname = current_user) THEN
+        EXECUTE 'create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
+          returns setof realtime.wal_rls
+          language sql
+          set log_min_messages to ''fatal''
+        as $$
+          with pub as (
+            select
+              concat_ws(
+                '','',
+                case when bool_or(pubinsert) then ''insert'' else null end,
+                case when bool_or(pubupdate) then ''update'' else null end,
+                case when bool_or(pubdelete) then ''delete'' else null end
+              ) as w2j_actions,
+              coalesce(
+                string_agg(
+                  realtime.quote_wal2json(format(''%I.%I'', schemaname, tablename)::regclass),
+                  '',''
+                ) filter (where ppt.tablename is not null and ppt.tablename not like ''% %''),
+                ''''
+              ) w2j_add_tables
+            from
+              pg_publication pp
+              left join pg_publication_tables ppt
+                on pp.pubname = ppt.pubname
+            where
+              pp.pubname = publication
+            group by
+              pp.pubname
+            limit 1
+          ),
+          w2j as (
+            select
+              x.*, pub.w2j_add_tables
+            from
+              pub,
+              pg_logical_slot_get_changes(
+                slot_name, null, max_changes,
+                ''include-pk'', ''true'',
+                ''include-transaction'', ''false'',
+                ''include-timestamp'', ''true'',
+                ''include-type-oids'', ''true'',
+                ''format-version'', ''2'',
+                ''actions'', pub.w2j_actions,
+                ''add-tables'', pub.w2j_add_tables
+              ) x
+          )
+          select
+            xyz.wal,
+            xyz.is_rls_enabled,
+            xyz.subscription_ids,
+            xyz.errors
+          from
+            w2j,
+            realtime.apply_rls(
+              wal := w2j.data::jsonb,
+              max_record_bytes := max_record_bytes
+            ) xyz(wal, is_rls_enabled, subscription_ids, errors)
+          where
+            w2j.w2j_add_tables <> ''''
+            and xyz.subscription_ids[1] is not null
+        $$;';
+    ELSE
+        EXECUTE 'create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
+          returns setof realtime.wal_rls
+          language sql
+        as $$
+          with pub as (
+            select
+              concat_ws(
+                '','',
+                case when bool_or(pubinsert) then ''insert'' else null end,
+                case when bool_or(pubupdate) then ''update'' else null end,
+                case when bool_or(pubdelete) then ''delete'' else null end
+              ) as w2j_actions,
+              coalesce(
+                string_agg(
+                  realtime.quote_wal2json(format(''%I.%I'', schemaname, tablename)::regclass),
+                  '',''
+                ) filter (where ppt.tablename is not null and ppt.tablename not like ''% %''),
+                ''''
+              ) w2j_add_tables
+            from
+              pg_publication pp
+              left join pg_publication_tables ppt
+                on pp.pubname = ppt.pubname
+            where
+              pp.pubname = publication
+            group by
+              pp.pubname
+            limit 1
+          ),
+          w2j as (
+            select
+              x.*, pub.w2j_add_tables
+            from
+              pub,
+              pg_logical_slot_get_changes(
+                slot_name, null, max_changes,
+                ''include-pk'', ''true'',
+                ''include-transaction'', ''false'',
+                ''include-timestamp'', ''true'',
+                ''include-type-oids'', ''true'',
+                ''format-version'', ''2'',
+                ''actions'', pub.w2j_actions,
+                ''add-tables'', pub.w2j_add_tables
+              ) x
+          )
+          select
+            xyz.wal,
+            xyz.is_rls_enabled,
+            xyz.subscription_ids,
+            xyz.errors
+          from
+            w2j,
+            realtime.apply_rls(
+              wal := w2j.data::jsonb,
+              max_record_bytes := max_record_bytes
+            ) xyz(wal, is_rls_enabled, subscription_ids, errors)
+          where
+            w2j.w2j_add_tables <> ''''
+            and xyz.subscription_ids[1] is not null
+        $$;';
+    END IF;
+END $dyn$;
+
+DO $dyn$
+BEGIN
+    IF (SELECT rolsuper FROM pg_roles WHERE rolname = current_user) THEN
+        EXECUTE 'create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
+          returns setof realtime.wal_rls
+          language sql
+          set log_min_messages to ''fatal''
+        as $$
+          with pub as (
+            select
+              concat_ws(
+                '','',
+                case when bool_or(pubinsert) then ''insert'' else null end,
+                case when bool_or(pubupdate) then ''update'' else null end,
+                case when bool_or(pubdelete) then ''delete'' else null end
+              ) as w2j_actions,
+              coalesce(
+                string_agg(
+                  realtime.quote_wal2json(format(''%I.%I'', schemaname, tablename)::regclass),
+                  '',''
+                ) filter (where ppt.tablename is not null and ppt.tablename not like ''% %''),
+                ''''
+              ) w2j_add_tables
+            from
+              pg_publication pp
+              left join pg_publication_tables ppt
+                on pp.pubname = ppt.pubname
+            where
+              pp.pubname = publication
+            group by
+              pp.pubname
+            limit 1
+          ),
+          w2j as (
+            select
+              x.*, pub.w2j_add_tables
+            from
+              pub,
+              pg_logical_slot_get_changes(
+                slot_name, null, max_changes,
+                ''include-pk'', ''true'',
+                ''include-transaction'', ''false'',
+                ''include-timestamp'', ''true'',
+                ''include-type-oids'', ''true'',
+                ''format-version'', ''2'',
+                ''actions'', pub.w2j_actions,
+                ''add-tables'', pub.w2j_add_tables
+              ) x
+          )
+          select
+            xyz.wal,
+            xyz.is_rls_enabled,
+            xyz.subscription_ids,
+            xyz.errors
+          from
+            w2j,
+            realtime.apply_rls(
+              wal := w2j.data::jsonb,
+              max_record_bytes := max_record_bytes
+            ) xyz(wal, is_rls_enabled, subscription_ids, errors)
+          where
+            w2j.w2j_add_tables <> ''''
+            and xyz.subscription_ids[1] is not null
+        $$;';
+    ELSE
+        EXECUTE 'create function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
+          returns setof realtime.wal_rls
+          language sql
+        as $$
+          with pub as (
+            select
+              concat_ws(
+                '','',
+                case when bool_or(pubinsert) then ''insert'' else null end,
+                case when bool_or(pubupdate) then ''update'' else null end,
+                case when bool_or(pubdelete) then ''delete'' else null end
+              ) as w2j_actions,
+              coalesce(
+                string_agg(
+                  realtime.quote_wal2json(format(''%I.%I'', schemaname, tablename)::regclass),
+                  '',''
+                ) filter (where ppt.tablename is not null and ppt.tablename not like ''% %''),
+                ''''
+              ) w2j_add_tables
+            from
+              pg_publication pp
+              left join pg_publication_tables ppt
+                on pp.pubname = ppt.pubname
+            where
+              pp.pubname = publication
+            group by
+              pp.pubname
+            limit 1
+          ),
+          w2j as (
+            select
+              x.*, pub.w2j_add_tables
+            from
+              pub,
+              pg_logical_slot_get_changes(
+                slot_name, null, max_changes,
+                ''include-pk'', ''true'',
+                ''include-transaction'', ''false'',
+                ''include-timestamp'', ''true'',
+                ''include-type-oids'', ''true'',
+                ''format-version'', ''2'',
+                ''actions'', pub.w2j_actions,
+                ''add-tables'', pub.w2j_add_tables
+              ) x
+          )
+          select
+            xyz.wal,
+            xyz.is_rls_enabled,
+            xyz.subscription_ids,
+            xyz.errors
+          from
+            w2j,
+            realtime.apply_rls(
+              wal := w2j.data::jsonb,
+              max_record_bytes := max_record_bytes
+            ) xyz(wal, is_rls_enabled, subscription_ids, errors)
+          where
+            w2j.w2j_add_tables <> ''''
+            and xyz.subscription_ids[1] is not null
+        $$;';
+    END IF;
+END $dyn$;"
     )
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20230328144023_create_list_changes_function.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20230328144023_create_list_changes_function.ex
@@ -5,134 +5,6 @@ defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateListChangesFunction do
 
   def change do
     execute("DO $dyn$
-    BEGIN
-    IF (SELECT rolsuper FROM pg_roles WHERE rolname = current_user) THEN
-        EXECUTE 'create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
-          returns setof realtime.wal_rls
-          language sql
-          set log_min_messages to ''fatal''
-        as $$
-          with pub as (
-            select
-              concat_ws(
-                '','',
-                case when bool_or(pubinsert) then ''insert'' else null end,
-                case when bool_or(pubupdate) then ''update'' else null end,
-                case when bool_or(pubdelete) then ''delete'' else null end
-              ) as w2j_actions,
-              coalesce(
-                string_agg(
-                  realtime.quote_wal2json(format(''%I.%I'', schemaname, tablename)::regclass),
-                  '',''
-                ) filter (where ppt.tablename is not null and ppt.tablename not like ''% %''),
-                ''''
-              ) w2j_add_tables
-            from
-              pg_publication pp
-              left join pg_publication_tables ppt
-                on pp.pubname = ppt.pubname
-            where
-              pp.pubname = publication
-            group by
-              pp.pubname
-            limit 1
-          ),
-          w2j as (
-            select
-              x.*, pub.w2j_add_tables
-            from
-              pub,
-              pg_logical_slot_get_changes(
-                slot_name, null, max_changes,
-                ''include-pk'', ''true'',
-                ''include-transaction'', ''false'',
-                ''include-timestamp'', ''true'',
-                ''include-type-oids'', ''true'',
-                ''format-version'', ''2'',
-                ''actions'', pub.w2j_actions,
-                ''add-tables'', pub.w2j_add_tables
-              ) x
-          )
-          select
-            xyz.wal,
-            xyz.is_rls_enabled,
-            xyz.subscription_ids,
-            xyz.errors
-          from
-            w2j,
-            realtime.apply_rls(
-              wal := w2j.data::jsonb,
-              max_record_bytes := max_record_bytes
-            ) xyz(wal, is_rls_enabled, subscription_ids, errors)
-          where
-            w2j.w2j_add_tables <> ''''
-            and xyz.subscription_ids[1] is not null
-        $$;';
-    ELSE
-        EXECUTE 'create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
-          returns setof realtime.wal_rls
-          language sql
-        as $$
-          with pub as (
-            select
-              concat_ws(
-                '','',
-                case when bool_or(pubinsert) then ''insert'' else null end,
-                case when bool_or(pubupdate) then ''update'' else null end,
-                case when bool_or(pubdelete) then ''delete'' else null end
-              ) as w2j_actions,
-              coalesce(
-                string_agg(
-                  realtime.quote_wal2json(format(''%I.%I'', schemaname, tablename)::regclass),
-                  '',''
-                ) filter (where ppt.tablename is not null and ppt.tablename not like ''% %''),
-                ''''
-              ) w2j_add_tables
-            from
-              pg_publication pp
-              left join pg_publication_tables ppt
-                on pp.pubname = ppt.pubname
-            where
-              pp.pubname = publication
-            group by
-              pp.pubname
-            limit 1
-          ),
-          w2j as (
-            select
-              x.*, pub.w2j_add_tables
-            from
-              pub,
-              pg_logical_slot_get_changes(
-                slot_name, null, max_changes,
-                ''include-pk'', ''true'',
-                ''include-transaction'', ''false'',
-                ''include-timestamp'', ''true'',
-                ''include-type-oids'', ''true'',
-                ''format-version'', ''2'',
-                ''actions'', pub.w2j_actions,
-                ''add-tables'', pub.w2j_add_tables
-              ) x
-          )
-          select
-            xyz.wal,
-            xyz.is_rls_enabled,
-            xyz.subscription_ids,
-            xyz.errors
-          from
-            w2j,
-            realtime.apply_rls(
-              wal := w2j.data::jsonb,
-              max_record_bytes := max_record_bytes
-            ) xyz(wal, is_rls_enabled, subscription_ids, errors)
-          where
-            w2j.w2j_add_tables <> ''''
-            and xyz.subscription_ids[1] is not null
-        $$;';
-    END IF;
-END $dyn$;
-
-DO $dyn$
 BEGIN
     IF (SELECT rolsuper FROM pg_roles WHERE rolname = current_user) THEN
         EXECUTE 'create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
@@ -197,7 +69,7 @@ BEGIN
             and xyz.subscription_ids[1] is not null
         $$;';
     ELSE
-        EXECUTE 'create function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
+        EXECUTE 'create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
           returns setof realtime.wal_rls
           language sql
         as $$
@@ -258,7 +130,6 @@ BEGIN
             and xyz.subscription_ids[1] is not null
         $$;';
     END IF;
-END $dyn$;"
-    )
+END $dyn$;")
   end
 end

--- a/lib/extensions/postgres_cdc_rls/repo/migrations/20230708112632_create_list_changes_function_non_superuser.ex
+++ b/lib/extensions/postgres_cdc_rls/repo/migrations/20230708112632_create_list_changes_function_non_superuser.ex
@@ -7,10 +7,10 @@ defmodule Realtime.Extensions.Rls.Repo.Migrations.CreateListChangesFunction do
     execute("DO $dyn$
 BEGIN
     IF (SELECT rolsuper FROM pg_roles WHERE rolname = current_user) THEN
+    ELSE
         EXECUTE 'create or replace function realtime.list_changes(publication name, slot_name name, max_changes int, max_record_bytes int)
           returns setof realtime.wal_rls
           language sql
-          set log_min_messages to ''fatal''
         as $$
           with pub as (
             select
@@ -68,7 +68,6 @@ BEGIN
             w2j.w2j_add_tables <> ''''
             and xyz.subscription_ids[1] is not null
         $$;';
-    ELSE
     END IF;
 END $dyn$;")
   end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/Chore. 

## What is the current behavior?

The function realtime.list_changes is created, and sets the log_min_messages to 'fatal' for each session it runs.

## What is the new behavior?

The function realtime.list_changes is created, and if the your permissions are not a super use, it does not set the log_min_messages to 'fatal', but relies on the admin of the DB to set this at the appropriate level

## Additional context

This allows the migration to proceed for Cloud SQL setups that do not allow you to have a super user.
