### PR TITLE
fix: connect to tenant database with ssl set to true

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -319,7 +319,8 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
       parameters: [
         application_name: "realtime_rls"
       ],
-      socket_options: socket_opts
+      socket_options: socket_opts,
+      ssl: true
     )
   end
 

--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -52,7 +52,8 @@ defmodule Realtime.Helpers do
       parameters: [
         application_name: "supabase_realtime"
       ],
-      socket_options: socket_opts
+      socket_options: socket_opts,
+      ssl: true
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.18.0",
+      version: "2.18.1",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Realtime fails to connect to tenant database if database enforced SSL on incoming connections.

## What is the new behavior?

Realtime will connect to tenant database with ssl flag set to true and it'll work for database that is enforcing SSL or not.