### PR TITLE
feat: logs handle_in messages as info

### DIFF
--- a/lib/realtime_web.ex
+++ b/lib/realtime_web.ex
@@ -84,7 +84,7 @@ defmodule RealtimeWeb do
 
   def channel do
     quote do
-      use Phoenix.Channel
+      use Phoenix.Channel, log_join: :info, log_handle_in: :info
       import RealtimeWeb.Gettext
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.18.1",
+      version: "2.19.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This logs handle_in messages as `info` level so now if users connect to the socket with the `log_level=info` param the actual socket messages will be visible in their logs.

<img width="899" alt="Screenshot 2023-07-21 at 1 52 41 PM" src="https://github.com/supabase/realtime/assets/1019814/b8b608cd-6b7e-4434-936b-29965d59a735">
