### PR TITLE
fix: Fixes flaky test on SubscriptionsCheckerTest

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.19.4",
+      version: "2.19.5",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/extensions/cdc_rls/subscriptions_checker_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_checker_test.exs
@@ -55,10 +55,9 @@ defmodule SubscriptionsCheckerTest do
 
       :ets.insert(tid, test_data)
 
-      assert Checker.pop_not_alive_pids([:pid1], tid) == [
-               UUID.string_to_binary!(uuid1),
-               UUID.string_to_binary!(uuid2)
-             ]
+      not_alive = Enum.sort(Checker.pop_not_alive_pids([:pid1], tid))
+      expected = Enum.sort([UUID.string_to_binary!(uuid1), UUID.string_to_binary!(uuid2)])
+      assert not_alive == expected
 
       assert :ets.tab2list(tid) == [{:pid2, "uuid", :ref, :node2}]
     end


### PR DESCRIPTION

## What kind of change does this PR introduce?

Tests for our SubscriptionChecker were flaky because of the way we checked the elements in the array.

## What is the current behavior?
Flaky test due to order of lists
<img width="1010" alt="Screenshot 2023-08-17 at 15 53 03" src="https://github.com/supabase/realtime/assets/1697301/b7f9972b-b794-4776-99f9-094c1716b62e">
