### PR TITLE
feat: Add broadcast endpoint

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -128,4 +128,12 @@ defmodule Realtime.Tenants do
     |> repo_replica.get_by(external_id: external_id)
     |> repo_replica.preload(:extensions)
   end
+
+  @doc """
+  Builds a PubSub topic from a tenant and a sub-topic.
+  """
+  @spec tenant_topic(Tenant.t(), String.t()) :: String.t()
+  def tenant_topic(%Tenant{external_id: external_id}, sub_topic) do
+    "#{external_id}:#{sub_topic}"
+  end
 end

--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -1,0 +1,26 @@
+defmodule Realtime.Tenants.BatchBroadcast do
+  @moduledoc """
+  Virtual schema with a representation of a batched broadcast.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  embedded_schema do
+    embeds_many :messages, Message do
+      field(:topic, :string)
+      field(:payload, :map)
+    end
+  end
+
+  def changeset(payload, attrs) do
+    payload
+    |> cast(attrs, [])
+    |> cast_embed(:messages, required: true, with: &message_changeset/2)
+  end
+
+  def message_changeset(message, attrs) do
+    message
+    |> cast(attrs, [:topic, :payload])
+    |> validate_required([:topic, :payload])
+  end
+end

--- a/lib/realtime_web/channels/auth/channels_authorization.ex
+++ b/lib/realtime_web/channels/auth/channels_authorization.ex
@@ -20,7 +20,7 @@ defmodule RealtimeWeb.ChannelsAuthorization do
     case authorize(token, secret) do
       {:ok, claims} ->
         required = MapSet.new(["role", "exp"])
-        claims_keys = Map.keys(claims) |> MapSet.new()
+        claims_keys = claims |> Map.keys() |> MapSet.new()
 
         if MapSet.subset?(required, claims_keys) do
           {:ok, claims}

--- a/lib/realtime_web/controllers/broadcast_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_controller.ex
@@ -1,0 +1,46 @@
+defmodule RealtimeWeb.BroadcastController do
+  use RealtimeWeb, :controller
+  alias RealtimeWeb.Endpoint
+
+  action_fallback(RealtimeWeb.FallbackController)
+
+  defmodule Payload do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    embedded_schema do
+      embeds_many :messages, Message do
+        field(:topic, :string)
+        field(:payload, :map)
+      end
+    end
+
+    def changeset(payload, attrs) do
+      payload
+      |> cast(attrs, [])
+      |> cast_embed(:messages, required: true, with: &message_changeset/2)
+    end
+
+    def message_changeset(message, attrs) do
+      message
+      |> cast(attrs, [:topic, :payload])
+      |> validate_required([:topic, :payload])
+    end
+  end
+
+  def broadcast(%{assigns: %{tenant: %{external_id: tenant}}} = conn, attrs) do
+    with %Ecto.Changeset{valid?: true} = changeset <- Payload.changeset(%Payload{}, attrs),
+         %Ecto.Changeset{changes: %{messages: messages}} <- changeset do
+      for %{changes: %{topic: sub_topic, payload: payload}} <- messages do
+        Task.Supervisor.async(Realtime.TaskSupervisor, fn ->
+          tenant_topic = "#{tenant}:#{sub_topic}"
+          Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
+        end)
+      end
+
+      conn
+      |> put_status(202)
+      |> text("")
+    end
+  end
+end

--- a/lib/realtime_web/controllers/fallback_controller.ex
+++ b/lib/realtime_web/controllers/fallback_controller.ex
@@ -21,4 +21,11 @@ defmodule RealtimeWeb.FallbackController do
     |> put_view(RealtimeWeb.ErrorView)
     |> render(:"404")
   end
+
+  def call(conn, %Ecto.Changeset{valid?: false} = changeset) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(RealtimeWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
 end

--- a/lib/realtime_web/open_api_schemas.ex
+++ b/lib/realtime_web/open_api_schemas.ex
@@ -5,6 +5,29 @@ defmodule RealtimeWeb.OpenApiSchemas do
 
   alias OpenApiSpex.Schema
 
+  defmodule TenantBatchParams do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        messages: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              topic: %Schema{type: :string},
+              payload: %Schema{type: :object}
+            }
+          }
+        }
+      }
+    })
+
+    def params(), do: {"Tenant Batch Params", "application/json", __MODULE__}
+  end
+
   defmodule TenantParams do
     @moduledoc false
     require OpenApiSpex
@@ -228,5 +251,27 @@ defmodule RealtimeWeb.OpenApiSchemas do
     })
 
     def response(), do: {"Not Found", "application/json", __MODULE__}
+  end
+
+  defmodule UnprocessableEntityResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        error: %Schema{
+          type: :object,
+          properties: %{
+            messages: %Schema{
+              type: :array,
+              items: %Schema{type: :object}
+            }
+          }
+        }
+      }
+    })
+
+    def response(), do: {"Unprocessable Entity", "application/json", __MODULE__}
   end
 end

--- a/lib/realtime_web/plugs/auth_tenant.ex
+++ b/lib/realtime_web/plugs/auth_tenant.ex
@@ -1,0 +1,41 @@
+defmodule RealtimeWeb.AuthTenant do
+  import Plug.Conn
+  import Realtime.Helpers
+
+  alias Realtime.Api.Tenant
+  alias RealtimeWeb.ChannelsAuthorization
+
+  def init(opts), do: opts
+
+  def call(%{assigns: %{tenant: tenant}} = conn, _opts) do
+    secure_key = Application.get_env(:realtime, :db_enc_key)
+
+    with %Tenant{jwt_secret: jwt_secret} <- tenant,
+         token when is_binary(token) <- access_token(conn),
+         jwt_secret_dec <- decrypt!(jwt_secret, secure_key),
+         {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec) do
+      conn
+    else
+      _ -> unauthorized(conn)
+    end
+  end
+
+  def call(conn, _opts), do: unauthorized(conn)
+
+  defp access_token(conn) do
+    case get_req_header(conn, "x-api-key") do
+      [] -> fetch_api_key_param(conn)
+      [token] -> token
+      _ -> nil
+    end
+  end
+
+  defp fetch_api_key_param(conn) do
+    conn
+    |> Plug.Conn.fetch_query_params()
+    |> then(& &1.query_params)
+    |> Map.get("apikey")
+  end
+
+  defp unauthorized(conn), do: conn |> put_status(401) |> halt()
+end

--- a/lib/realtime_web/plugs/auth_tenant.ex
+++ b/lib/realtime_web/plugs/auth_tenant.ex
@@ -1,4 +1,7 @@
 defmodule RealtimeWeb.AuthTenant do
+  @moduledoc """
+  Authorization plug to ensure that only authorized clients can connect to the their tenant's endpoints.
+  """
   import Plug.Conn
   import Realtime.Helpers
 
@@ -13,7 +16,7 @@ defmodule RealtimeWeb.AuthTenant do
     with %Tenant{jwt_secret: jwt_secret} <- tenant,
          token when is_binary(token) <- access_token(conn),
          jwt_secret_dec <- decrypt!(jwt_secret, secure_key),
-         {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec) do
+         {:ok, _claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec) do
       conn
     else
       _ -> unauthorized(conn)
@@ -23,18 +26,10 @@ defmodule RealtimeWeb.AuthTenant do
   def call(conn, _opts), do: unauthorized(conn)
 
   defp access_token(conn) do
-    case get_req_header(conn, "x-api-key") do
-      [] -> fetch_api_key_param(conn)
-      [token] -> token
+    case get_req_header(conn, "authorization") do
+      ["Bearer " <> token] -> token
       _ -> nil
     end
-  end
-
-  defp fetch_api_key_param(conn) do
-    conn
-    |> Plug.Conn.fetch_query_params()
-    |> then(& &1.query_params)
-    |> Map.get("apikey")
   end
 
   defp unauthorized(conn), do: conn |> put_status(401) |> halt()

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -85,6 +85,7 @@ defmodule RealtimeWeb.Router do
     pipe_through :tenant_api
 
     get "/ping", PingController, :ping
+    post "/broadcast", BroadcastController, :broadcast
   end
 
   # Enables LiveDashboard only for development

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -25,6 +25,10 @@ defmodule RealtimeWeb.Router do
     plug RealtimeWeb.Plugs.RateLimiter
   end
 
+  pipeline :secure_tenant_api do
+    plug RealtimeWeb.AuthTenant
+  end
+
   pipeline :dashboard_admin do
     plug :dashboard_basic_auth
   end
@@ -85,6 +89,11 @@ defmodule RealtimeWeb.Router do
     pipe_through :tenant_api
 
     get "/ping", PingController, :ping
+  end
+
+  scope "/api", RealtimeWeb do
+    pipe_through [:tenant_api, :secure_tenant_api]
+
     post "/broadcast", BroadcastController, :broadcast
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.20.4",
+      version: "2.21.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -2,11 +2,18 @@ defmodule RealtimeWeb.BroadcastControllerTest do
   use RealtimeWeb.ConnCase, async: false
 
   import Mock
-  alias RealtimeWeb.JwtVerification
+
+  alias Realtime.RateCounter
+  alias Realtime.Tenants
   alias RealtimeWeb.Endpoint
+  alias RealtimeWeb.JwtVerification
+
   setup [:create_tenant]
 
   setup %{conn: conn, tenant: tenant} do
+    start_supervised(Realtime.RateCounter.DynamicSupervisor)
+    start_supervised(Realtime.GenCounter.DynamicSupervisor)
+
     new_conn =
       conn
       |> put_req_header("accept", "application/json")
@@ -51,11 +58,19 @@ defmodule RealtimeWeb.BroadcastControllerTest do
         assert_called(Endpoint.broadcast_from(:_, topic_2, "broadcast", payload_2))
 
         assert conn.status == 202
+
+        # Wait for counters to increment
+        :timer.sleep(1000)
+        {:ok, rate_counter} = RateCounter.get(Tenants.requests_per_second_key(tenant))
+        assert rate_counter.avg != 0.0
       end
     end
 
     test "returns 422 when batch of messages includes badly formed messages", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mocks [
+        {JwtVerification, [], verify: fn _token, _secret -> {:ok, %{}} end},
+        {Endpoint, [:passthrough], broadcast_from: fn _, _, _, _ -> :ok end}
+      ] do
         conn =
           post(conn, Routes.broadcast_path(conn, :broadcast), %{
             "messages" => [
@@ -81,6 +96,8 @@ defmodule RealtimeWeb.BroadcastControllerTest do
                    ]
                  }
                }
+
+        assert_not_called(Endpoint.broadcast_from(:_, :_, :_, :_))
 
         assert conn.status == 422
       end

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -1,0 +1,93 @@
+defmodule RealtimeWeb.BroadcastControllerTest do
+  use RealtimeWeb.ConnCase, async: false
+
+  import Mock
+  alias RealtimeWeb.JwtVerification
+  alias RealtimeWeb.Endpoint
+  setup [:create_tenant]
+
+  setup %{conn: conn, tenant: tenant} do
+    new_conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header(
+        "authorization",
+        "Bearer auth_token"
+      )
+      |> then(&%{&1 | host: "#{tenant.external_id}.supabase.com"})
+
+    {:ok, conn: new_conn}
+  end
+
+  describe "broadcast" do
+    test "returns 202 when batch of messages is broadcasted", %{conn: conn, tenant: tenant} do
+      with_mocks [
+        {JwtVerification, [], verify: fn _token, _secret -> {:ok, %{}} end},
+        {Endpoint, [:passthrough], broadcast_from: fn _, _, _, _ -> :ok end}
+      ] do
+        sub_topic_1 = "sub_topic"
+        sub_topic_2 = "sub_topic"
+        topic_1 = tenant.external_id <> ":" <> sub_topic_1
+        topic_2 = tenant.external_id <> ":" <> sub_topic_2
+
+        payload_1 = %{"data" => "data"}
+        payload_2 = %{"data" => "data"}
+
+        conn =
+          post(conn, Routes.broadcast_path(conn, :broadcast), %{
+            "messages" => [
+              %{
+                "topic" => sub_topic_1,
+                "payload" => payload_2
+              },
+              %{
+                "topic" => sub_topic_2,
+                "payload" => payload_2
+              }
+            ]
+          })
+
+        assert_called(Endpoint.broadcast_from(:_, topic_1, "broadcast", payload_1))
+        assert_called(Endpoint.broadcast_from(:_, topic_2, "broadcast", payload_2))
+
+        assert conn.status == 202
+      end
+    end
+
+    test "returns 422 when batch of messages includes badly formed messages", %{conn: conn} do
+      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+        conn =
+          post(conn, Routes.broadcast_path(conn, :broadcast), %{
+            "messages" => [
+              %{
+                "topic" => "topic"
+              },
+              %{
+                "payload" => %{"data" => "data"}
+              },
+              %{
+                "topic" => "topic",
+                "payload" => %{"data" => "data"}
+              }
+            ]
+          })
+
+        assert Jason.decode!(conn.resp_body) == %{
+                 "errors" => %{
+                   "messages" => [
+                     %{"payload" => ["can't be blank"]},
+                     %{"topic" => ["can't be blank"]},
+                     %{}
+                   ]
+                 }
+               }
+
+        assert conn.status == 422
+      end
+    end
+  end
+
+  defp create_tenant(_context) do
+    %{tenant: tenant_fixture()}
+  end
+end

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -154,7 +154,6 @@ defmodule RealtimeWeb.TenantControllerTest do
   end
 
   defp create_tenant(_) do
-    tenant = RealtimeWeb.ConnCase.tenant_fixture()
-    %{tenant: tenant}
+    %{tenant: tenant_fixture()}
   end
 end

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -8,9 +8,14 @@ defmodule RealtimeWeb.TenantControllerTest do
   alias Realtime.Api.Tenant
   alias RealtimeWeb.{ChannelsAuthorization, JwtVerification}
 
-  @external_id "test_external_id"
+  @update_attrs %{
+    jwt_secret: "some updated jwt_secret",
+    name: "some updated name",
+    max_concurrent_users: 200
+  }
 
-  @create_attrs %{
+  @default_tenant_attrs %{
+    "external_id" => "external_id",
     "name" => "localhost",
     "extensions" => [
       %{
@@ -32,21 +37,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     "jwt_secret" => "new secret"
   }
 
-  @update_attrs %{
-    jwt_secret: "some updated jwt_secret",
-    name: "some updated name",
-    max_concurrent_users: 200
-  }
-
   @invalid_attrs %{external_id: nil, jwt_secret: nil, extensions: [], name: nil}
-
-  def fixture(:tenant) do
-    {:ok, tenant} =
-      Map.put(@create_attrs, "external_id", @external_id)
-      |> Api.create_tenant()
-
-    tenant
-  end
 
   setup %{conn: conn} do
     Application.put_env(:realtime, :db_enc_key, "1234567890123456")
@@ -65,8 +56,8 @@ defmodule RealtimeWeb.TenantControllerTest do
   describe "create tenant" do
     test "renders tenant when data is valid", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
-        ext_id = @external_id
-        conn = put(conn, Routes.tenant_path(conn, :update, ext_id), tenant: @create_attrs)
+        ext_id = @default_tenant_attrs["external_id"]
+        conn = put(conn, Routes.tenant_path(conn, :update, ext_id), tenant: @default_tenant_attrs)
         assert %{"id" => _id, "external_id" => ^ext_id} = json_response(conn, 201)["data"]
         conn = get(conn, Routes.tenant_path(conn, :show, ext_id))
         assert ^ext_id = json_response(conn, 200)["data"]["external_id"]
@@ -76,8 +67,8 @@ defmodule RealtimeWeb.TenantControllerTest do
 
     test "encrypt creds", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
-        ext_id = @external_id
-        conn = put(conn, Routes.tenant_path(conn, :update, ext_id), tenant: @create_attrs)
+        ext_id = @default_tenant_attrs["external_id"]
+        conn = put(conn, Routes.tenant_path(conn, :update, ext_id), tenant: @default_tenant_attrs)
         [%{"settings" => settings}] = json_response(conn, 201)["data"]["extensions"]
         sec_key = Application.get_env(:realtime, :db_enc_key)
         assert encrypt!("127.0.0.1", sec_key) == settings["db_host"]
@@ -147,23 +138,23 @@ defmodule RealtimeWeb.TenantControllerTest do
         {ChannelsAuthorization, [], authorize: fn _, _ -> {:ok, %{}} end},
         {Api, [], get_tenant_by_external_id: fn _ -> %Tenant{} end}
       ] do
-        Routes.tenant_path(conn, :reload, @external_id)
-        %{status: status} = post(conn, Routes.tenant_path(conn, :reload, @external_id))
+        Routes.tenant_path(conn, :reload, "external_id")
+        %{status: status} = post(conn, Routes.tenant_path(conn, :reload, "external_id"))
         assert status == 204
       end
     end
 
     test "reload when tenant does not exist", %{conn: conn} do
       with_mock ChannelsAuthorization, authorize: fn _, _ -> {:ok, %{}} end do
-        Routes.tenant_path(conn, :reload, @external_id)
-        %{status: status} = post(conn, Routes.tenant_path(conn, :reload, @external_id))
+        Routes.tenant_path(conn, :reload, "wrong_external_id")
+        %{status: status} = post(conn, Routes.tenant_path(conn, :reload, "wrong_external_id"))
         assert status == 404
       end
     end
   end
 
   defp create_tenant(_) do
-    tenant = fixture(:tenant)
+    tenant = RealtimeWeb.ConnCase.tenant_fixture()
     %{tenant: tenant}
   end
 end

--- a/test/realtime_web/plugs/auth_tenant_test.exs
+++ b/test/realtime_web/plugs/auth_tenant_test.exs
@@ -17,48 +17,29 @@ defmodule RealtimeWeb.AuthTenantTest do
   describe "with tenant" do
     setup %{conn: conn} = context do
       start_supervised!(RealtimeWeb.Joken.CurrentTime.Mock)
-      api_key = Map.get(context, :api_key, nil)
-      api_key_value = Map.get(context, :api_key_value)
+      api_key = Map.get(context, :api_key)
 
       conn =
-        case api_key do
-          :header -> put_req_header(conn, "x-api-key", api_key_value)
-          :param -> build_conn(:get, "/", %{"apikey" => api_key_value})
-          _ -> conn
-        end
+        if api_key, do: put_req_header(conn, "authorization", "Bearer #{api_key}"), else: conn
 
       conn = assign(conn, :tenant, tenant_fixture())
       %{conn: conn}
     end
 
-    test "returns 401 if token isn't present in header or param", %{conn: conn} do
+    test "returns 401 if token isn't present in header", %{conn: conn} do
       conn = AuthTenant.call(conn, %{})
       assert conn.status == 401
       assert conn.halted
     end
 
-    @tag api_key: :header, api_key_value: "invalid"
+    @tag api_key: "invalid"
     test "returns 401 if token in header isn't valid", %{conn: conn} do
       conn = AuthTenant.call(conn, %{})
       assert conn.status == 401
       assert conn.halted
     end
 
-    @tag api_key: :param, api_key_value: "invalid"
-    test "returns 401 if token in params isn't valid", %{conn: conn} do
-      conn = AuthTenant.call(conn, %{})
-      assert conn.status == 401
-      assert conn.halted
-    end
-
-    @tag api_key: :param, api_key_value: @token
-    test "returns non halted and null status if token in params is valid", %{conn: conn} do
-      conn = AuthTenant.call(conn, %{})
-      refute conn.status
-      refute conn.halted
-    end
-
-    @tag api_key: :header, api_key_value: @token
+    @tag api_key: @token
     test "returns non halted and null status if token in header is valid", %{conn: conn} do
       conn = AuthTenant.call(conn, %{})
       refute conn.status

--- a/test/realtime_web/plugs/auth_tenant_test.exs
+++ b/test/realtime_web/plugs/auth_tenant_test.exs
@@ -1,0 +1,68 @@
+defmodule RealtimeWeb.AuthTenantTest do
+  use RealtimeWeb.ConnCase
+
+  import Plug.Conn
+
+  alias RealtimeWeb.AuthTenant
+
+  @token "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsInJvbGUiOiJmb28iLCJleHAiOiJiYXIifQ.Ret2CevUozCsPhpgW2FMeFL7RooLgoOvfQzNpLBj5ak"
+  describe "without tenant" do
+    test "returns 401", %{conn: conn} do
+      conn = AuthTenant.call(conn, %{})
+      assert conn.status == 401
+      assert conn.halted
+    end
+  end
+
+  describe "with tenant" do
+    setup %{conn: conn} = context do
+      start_supervised!(RealtimeWeb.Joken.CurrentTime.Mock)
+      api_key = Map.get(context, :api_key, nil)
+      api_key_value = Map.get(context, :api_key_value)
+
+      conn =
+        case api_key do
+          :header -> put_req_header(conn, "x-api-key", api_key_value)
+          :param -> build_conn(:get, "/", %{"apikey" => api_key_value})
+          _ -> conn
+        end
+
+      conn = assign(conn, :tenant, tenant_fixture())
+      %{conn: conn}
+    end
+
+    test "returns 401 if token isn't present in header or param", %{conn: conn} do
+      conn = AuthTenant.call(conn, %{})
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    @tag api_key: :header, api_key_value: "invalid"
+    test "returns 401 if token in header isn't valid", %{conn: conn} do
+      conn = AuthTenant.call(conn, %{})
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    @tag api_key: :param, api_key_value: "invalid"
+    test "returns 401 if token in params isn't valid", %{conn: conn} do
+      conn = AuthTenant.call(conn, %{})
+      assert conn.status == 401
+      assert conn.halted
+    end
+
+    @tag api_key: :param, api_key_value: @token
+    test "returns non halted and null status if token in params is valid", %{conn: conn} do
+      conn = AuthTenant.call(conn, %{})
+      refute conn.status
+      refute conn.halted
+    end
+
+    @tag api_key: :header, api_key_value: @token
+    test "returns non halted and null status if token in header is valid", %{conn: conn} do
+      conn = AuthTenant.call(conn, %{})
+      refute conn.status
+      refute conn.halted
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -21,7 +21,7 @@ defmodule RealtimeWeb.ConnCase do
   defmodule Generators do
     def tenant_fixture(override \\ %{}) do
       create_attrs = %{
-        "external_id" => "external_id",
+        "external_id" => rand_string(),
         "name" => "localhost",
         "extensions" => [
           %{

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -18,11 +18,52 @@ defmodule RealtimeWeb.ConnCase do
   use ExUnit.CaseTemplate
   alias Ecto.Adapters.SQL.Sandbox
 
+  defmodule Generators do
+    def tenant_fixture(override \\ %{}) do
+      create_attrs = %{
+        "external_id" => "external_id",
+        "name" => "localhost",
+        "extensions" => [
+          %{
+            "type" => "postgres_cdc_rls",
+            "settings" => %{
+              "db_host" => "127.0.0.1",
+              "db_name" => "postgres",
+              "db_user" => "postgres",
+              "db_password" => "postgres",
+              "db_port" => "6432",
+              "poll_interval" => 100,
+              "poll_max_changes" => 100,
+              "poll_max_record_bytes" => 1_048_576,
+              "region" => "us-east-1"
+            }
+          }
+        ],
+        "postgres_cdc_default" => "postgres_cdc_rls",
+        "jwt_secret" => "new secret"
+      }
+
+      {:ok, tenant} =
+        create_attrs
+        |> Map.merge(override)
+        |> Realtime.Api.create_tenant()
+
+      tenant
+    end
+
+    def rand_string(length \\ 10) do
+      length
+      |> :crypto.strong_rand_bytes()
+      |> Base.encode32()
+    end
+  end
+
   using do
     quote do
       # Import conveniences for testing with connections
       import Plug.Conn
       import Phoenix.ConnTest
+      import Generators
       alias RealtimeWeb.Router.Helpers, as: Routes
 
       use RealtimeWeb, :verified_routes


### PR DESCRIPTION

## What kind of change does this PR introduce?

Adds a batch broadcast endpoint so users can push multiple messages into multiple topics

## What is the new behavior?

New endpoint:
POST `/api` where a user can send:
```
{"messages": [ {"topic": "topic", "payload": "payload"} ]}
```
