### PR TITLE
fix: Support apikey header for Tenant authorization

### DIFF
--- a/lib/realtime_web/plugs/auth_tenant.ex
+++ b/lib/realtime_web/plugs/auth_tenant.ex
@@ -26,9 +26,19 @@ defmodule RealtimeWeb.AuthTenant do
   def call(conn, _opts), do: unauthorized(conn)
 
   defp access_token(conn) do
-    case get_req_header(conn, "authorization") do
-      ["Bearer " <> token] -> token
-      _ -> nil
+    authorization = get_req_header(conn, "authorization")
+    apikey = get_req_header(conn, "apikey")
+
+    cond do
+      authorization != [] && match?(["Bearer " <> _], authorization) ->
+        ["Bearer " <> token] = authorization
+        token
+
+      apikey != [] ->
+        hd(apikey)
+
+      true ->
+        nil
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.0",
+      version: "2.22.1",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for apikey header for Tenant authorization due to the way we are routing requests in our api gateway
