### PR TITLE
fix: Update openapi docs to have tenant as a param of the URL

### DIFF
--- a/lib/realtime_web/api_spec.ex
+++ b/lib/realtime_web/api_spec.ex
@@ -1,8 +1,15 @@
 defmodule RealtimeWeb.ApiSpec do
   @moduledoc false
 
-  alias OpenApiSpex.{Components, Info, OpenApi, Paths, SecurityScheme, Server}
-  alias RealtimeWeb.{Endpoint, Router}
+  alias OpenApiSpex.Components
+  alias OpenApiSpex.Info
+  alias OpenApiSpex.OpenApi
+  alias OpenApiSpex.Paths
+  alias OpenApiSpex.SecurityScheme
+  alias OpenApiSpex.Server
+  alias OpenApiSpex.ServerVariable
+
+  alias RealtimeWeb.Router
 
   @behaviour OpenApi
 
@@ -10,7 +17,10 @@ defmodule RealtimeWeb.ApiSpec do
   def spec do
     %OpenApi{
       servers: [
-        Server.from_endpoint(Endpoint)
+        %Server{
+          url: "https://{tenant}.supabase.co/realtime/v1",
+          variables: %{"tenant" => %ServerVariable{default: "tenant"}}
+        }
       ],
       info: %Info{
         title: to_string(Application.spec(:realtime, :description)),

--- a/lib/realtime_web/api_spec.ex
+++ b/lib/realtime_web/api_spec.ex
@@ -15,10 +15,16 @@ defmodule RealtimeWeb.ApiSpec do
 
   @impl OpenApi
   def spec do
+    url =
+      case Mix.env() do
+        :prod -> "https://{tenant}.supabase.co/realtime/v1"
+        _ -> "http://{tenant}.localhost:4000/"
+      end
+
     %OpenApi{
       servers: [
         %Server{
-          url: "https://{tenant}.supabase.co/realtime/v1",
+          url: url,
           variables: %{"tenant" => %ServerVariable{default: "tenant"}}
         }
       ],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.1",
+      version: "2.22.2",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update openapi docs to have tenant as a param of the URL

## Additional context

<img width="232" alt="Screenshot 2023-08-23 at 23 42 26" src="https://github.com/supabase/realtime/assets/1697301/e58643a2-8a10-43d2-8f5c-46a1a541cd54">
<img width="536" alt="Screenshot 2023-08-23 at 23 42 03" src="https://github.com/supabase/realtime/assets/1697301/6f48dee9-8faf-49ff-a562-0141cee090c9">

