### PR TITLE
chore: Adapt script for AWS to use a IPV6 address

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.2",
+      version: "2.22.3",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -9,7 +9,7 @@ ip=$(grep fly-local-6pn /etc/hosts | cut -f 1)
 
 # for AWS ECS Fargate
 if [ "$AWS_EXECUTION_ENV" = "AWS_ECS_FARGATE" ]; then
-  ip=$(grep $HOSTNAME /etc/hosts | cut -f 1 -d " ")
+  ip=$(hostname -I | awk '{print $3}')
 fi
 
 # default to localhost
@@ -17,7 +17,7 @@ if [ -z $ip ]; then
   ip=127.0.0.1
 fi
 
-# assign the value of NODE_NAME if it exists, else assign the value of FLY_APP_NAME, 
+# assign the value of NODE_NAME if it exists, else assign the value of FLY_APP_NAME,
 # and if that doesn't exist either, assign "realtime" to node_name
 node_name="${NODE_NAME:=${FLY_APP_NAME:=realtime}}"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Due to the way we're setting up AWS deployment, we need to properly set the node long name.