### PR TITLE
Tag docker images with "latest"

### DIFF
--- a/.github/workflows/prod_build.yml
+++ b/.github/workflows/prod_build.yml
@@ -85,11 +85,11 @@ jobs:
             network=host
 
       - id: build
-        uses: docker/build-push-action@v3, latest_arm
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}, latest_${{ env.arch }}
           platforms: linux/${{ env.arch }}
           no-cache: true
 

--- a/.github/workflows/prod_build.yml
+++ b/.github/workflows/prod_build.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}, latest
           platforms: linux/${{ env.arch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -85,7 +85,7 @@ jobs:
             network=host
 
       - id: build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3, latest_arm
         with:
           context: .
           push: true


### PR DESCRIPTION
Tags the x86 and arm64 docker images with "latest" and "latest_arm" respectively.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Docker images are only tagged with the version number

## What is the new behavior?

In addition to the version tag, latest and latest_arm tags are added to the images.

## Additional context

I'm open to discussion as to what the tags should be. Maybe x86 and arm would be more appropriate?
Closes: https://github.com/supabase/realtime/issues/618
