### PR TITLE
fix: log :erlang.system_monitor messages

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -63,6 +63,7 @@ defmodule Realtime.Application do
 
     children =
       [
+        Realtime.ErlSysMon,
         Realtime.PromEx,
         {Cluster.Supervisor, [topologies, [name: Realtime.ClusterSupervisor]]},
         Realtime.Repo,

--- a/lib/realtime/monitoring/erl_sys_mon.ex
+++ b/lib/realtime/monitoring/erl_sys_mon.ex
@@ -1,0 +1,30 @@
+defmodule Realtime.ErlSysMon do
+  @moduledoc """
+  Logs Erlang System Monitor events.
+  """
+
+  use GenServer
+
+  require Logger
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(_args) do
+    :erlang.system_monitor(self(), [
+      :busy_dist_port,
+      :busy_port,
+      {:long_gc, 250},
+      {:long_schedule, 100}
+    ])
+
+    {:ok, []}
+  end
+
+  def handle_info(msg, state) do
+    Logger.warning("#{__MODULE__} message: " <> inspect(msg))
+
+    {:noreply, state}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.6",
+      version: "2.22.7",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Logs :erlang.system_monitor messages and gets us logs like:

<img width="1000" alt="Screenshot 2023-09-07 at 3 05 16 PM" src="https://github.com/supabase/realtime/assets/1019814/e1364d46-0465-4065-9091-0b180366c60b">
