### PR TITLE
fix: Support AWS regions

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,15 +43,18 @@ if config_env() == :prod do
 end
 
 if config_env() != :test do
+  platform = if System.get_env("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE", do: :aws, else: :fly
+
   config :realtime,
     secure_channels: System.get_env("SECURE_CHANNELS", "true") == "true",
     jwt_claim_validators: System.get_env("JWT_CLAIM_VALIDATORS", "{}"),
     api_jwt_secret: System.get_env("API_JWT_SECRET"),
     metrics_jwt_secret: System.get_env("METRICS_JWT_SECRET"),
     db_enc_key: System.get_env("DB_ENC_KEY"),
-    fly_region: System.get_env("FLY_REGION"),
+    region: System.get_env("FLY_REGION") || System.get_env("REGION"),
     fly_alloc_id: System.get_env("FLY_ALLOC_ID", ""),
-    prom_poll_rate: System.get_env("PROM_POLL_RATE", "5000") |> String.to_integer()
+    prom_poll_rate: System.get_env("PROM_POLL_RATE", "5000") |> String.to_integer(),
+    platform: platform
 
   queue_target = System.get_env("DB_QUEUE_TARGET", "5000") |> String.to_integer()
   queue_interval = System.get_env("DB_QUEUE_INTERVAL", "5000") |> String.to_integer()
@@ -80,7 +83,16 @@ if config_env() != :test do
     Realtime.Repo.Replica.FRA => System.get_env("DB_HOST_REPLICA_FRA", default_db_host),
     Realtime.Repo.Replica.IAD => System.get_env("DB_HOST_REPLICA_IAD", default_db_host),
     Realtime.Repo.Replica.SIN => System.get_env("DB_HOST_REPLICA_SIN", default_db_host),
-    Realtime.Repo.Replica.SJC => System.get_env("DB_HOST_REPLICA_SJC", default_db_host)
+    Realtime.Repo.Replica.SJC => System.get_env("DB_HOST_REPLICA_SJC", default_db_host),
+    Realtime.Repo.Replica.Singapore =>
+      System.get_env("DB_HOST_REPLICA_AP_SOUTH_EAST_1", default_db_host),
+    Realtime.Repo.Replica.Sydney =>
+      System.get_env("DB_HOST_REPLICA_AP_SOUTH_EAST_2", default_db_host),
+    Realtime.Repo.Replica.Ireland => System.get_env("DB_HOST_REPLICA_EU_WEST_1", default_db_host),
+    Realtime.Repo.Replica.London => System.get_env("DB_HOST_REPLICA_EU_WEST_1", default_db_host),
+    Realtime.Repo.Replica.NorthVirginia =>
+      System.get_env("DB_HOST_REPLICA_AP_EAST_1", default_db_host),
+    Realtime.Repo.Replica.Local => default_db_host
   }
 
   # username, password, database, and port must match primary credentials

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -84,14 +84,10 @@ if config_env() != :test do
     Realtime.Repo.Replica.IAD => System.get_env("DB_HOST_REPLICA_IAD", default_db_host),
     Realtime.Repo.Replica.SIN => System.get_env("DB_HOST_REPLICA_SIN", default_db_host),
     Realtime.Repo.Replica.SJC => System.get_env("DB_HOST_REPLICA_SJC", default_db_host),
-    Realtime.Repo.Replica.Singapore =>
-      System.get_env("DB_HOST_REPLICA_AP_SOUTH_EAST_1", default_db_host),
-    Realtime.Repo.Replica.Sydney =>
-      System.get_env("DB_HOST_REPLICA_AP_SOUTH_EAST_2", default_db_host),
-    Realtime.Repo.Replica.Ireland => System.get_env("DB_HOST_REPLICA_EU_WEST_1", default_db_host),
-    Realtime.Repo.Replica.London => System.get_env("DB_HOST_REPLICA_EU_WEST_1", default_db_host),
-    Realtime.Repo.Replica.NorthVirginia =>
-      System.get_env("DB_HOST_REPLICA_AP_EAST_1", default_db_host),
+    Realtime.Repo.Replica.Singapore => System.get_env("DB_HOST_REPLICA_SIN", default_db_host),
+    Realtime.Repo.Replica.London => System.get_env("DB_HOST_REPLICA_FRA", default_db_host),
+    Realtime.Repo.Replica.NorthVirginia => System.get_env("DB_HOST_REPLICA_IAD", default_db_host),
+    Realtime.Repo.Replica.Oregon => System.get_env("DB_HOST_REPLICA_SJC", default_db_host),
     Realtime.Repo.Replica.Local => default_db_host
   }
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,7 +10,12 @@ for repo <- [
       Realtime.Repo.Replica.FRA,
       Realtime.Repo.Replica.IAD,
       Realtime.Repo.Replica.SIN,
-      Realtime.Repo.Replica.SJC
+      Realtime.Repo.Replica.SJC,
+      Realtime.Repo.Replica.Singapore,
+      Realtime.Repo.Replica.Sydney,
+      Realtime.Repo.Replica.Ireland,
+      Realtime.Repo.Replica.London,
+      Realtime.Repo.Replica.NorthVirginia
     ] do
   config :realtime, repo,
     username: "postgres",

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,10 +12,9 @@ for repo <- [
       Realtime.Repo.Replica.SIN,
       Realtime.Repo.Replica.SJC,
       Realtime.Repo.Replica.Singapore,
-      Realtime.Repo.Replica.Sydney,
-      Realtime.Repo.Replica.Ireland,
       Realtime.Repo.Replica.London,
-      Realtime.Repo.Replica.NorthVirginia
+      Realtime.Repo.Replica.NorthVirginia,
+      Realtime.Repo.Replica.Oregon
     ] do
   config :realtime, repo,
     username: "postgres",

--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -61,11 +61,11 @@ defmodule Extensions.PostgresCdcRls do
   ## Internal functions
 
   def start_distributed(%{"region" => region, "id" => tenant} = args) do
-    fly_region = PostgresCdc.aws_to_fly(region)
-    launch_node = PostgresCdc.launch_node(tenant, fly_region, node())
+    platform_region = PostgresCdc.platform_region_translator(region)
+    launch_node = PostgresCdc.launch_node(tenant, platform_region, node())
 
     Logger.warning(
-      "Starting distributed postgres extension #{inspect(lauch_node: launch_node, region: region, fly_region: fly_region)}"
+      "Starting distributed postgres extension #{inspect(lauch_node: launch_node, region: region, platform_region: platform_region)}"
     )
 
     case :rpc.call(launch_node, __MODULE__, :start, [args], 30_000) do

--- a/lib/extensions/postgres_cdc_rls/syn_handler.ex
+++ b/lib/extensions/postgres_cdc_rls/syn_handler.ex
@@ -19,15 +19,15 @@ defmodule Extensions.PostgresCdcRls.SynHandler do
         {pid1, %{region: region}, time1},
         {pid2, _, time2}
       ) do
-    fly_region = Realtime.PostgresCdc.aws_to_fly(region)
+    platform_region = Realtime.PostgresCdc.platform_region_translator(region)
 
-    fly_region_nodes =
-      :syn.members(RegionNodes, fly_region)
+    platform_region_nodes =
+      :syn.members(RegionNodes, platform_region)
       |> Enum.map(fn {_, [node: node]} -> node end)
 
     {keep, stop} =
       Enum.filter([pid1, pid2], fn pid ->
-        Enum.member?(fly_region_nodes, node(pid))
+        Enum.member?(platform_region_nodes, node(pid))
       end)
       |> case do
         [pid] ->

--- a/lib/extensions/postgres_cdc_stream/cdc_stream.ex
+++ b/lib/extensions/postgres_cdc_stream/cdc_stream.ex
@@ -56,11 +56,11 @@ defmodule Extensions.PostgresCdcStream do
   end
 
   def start_distributed(%{"region" => region, "id" => tenant} = args) do
-    fly_region = PostgresCdc.aws_to_fly(region)
-    launch_node = PostgresCdc.launch_node(tenant, fly_region, node())
+    platform_region = PostgresCdc.platform_region_translator(region)
+    launch_node = PostgresCdc.launch_node(tenant, platform_region, node())
 
     Logger.warning(
-      "Starting distributed postgres extension #{inspect(lauch_node: launch_node, region: region, fly_region: fly_region)}"
+      "Starting distributed postgres extension #{inspect(lauch_node: launch_node, region: region, platform_region: platform_region)}"
     )
 
     case :rpc.call(launch_node, __MODULE__, :start, [args], 30_000) do

--- a/lib/realtime/api.ex
+++ b/lib/realtime/api.ex
@@ -6,7 +6,13 @@ defmodule Realtime.Api do
 
   import Ecto.Query
 
-  alias Realtime.{Repo, Api.Tenant, Api.Extensions, RateCounter, GenCounter, Tenants}
+  alias Realtime.Repo
+  alias Realtime.Repo.Replica
+  alias Realtime.Api.Tenant
+  alias Realtime.Api.Extensions
+  alias Realtime.RateCounter
+  alias Realtime.GenCounter
+  alias Realtime.Tenants
 
   @doc """
   Returns the list of tenants.
@@ -18,7 +24,7 @@ defmodule Realtime.Api do
 
   """
   def list_tenants() do
-    repo_replica = Repo.replica()
+    repo_replica = Replica.replica()
 
     Tenant
     |> repo_replica.all()
@@ -33,7 +39,7 @@ defmodule Realtime.Api do
   * ordering (desc / asc)
   """
   def list_tenants(opts) when is_list(opts) do
-    repo_replica = Repo.replica()
+    repo_replica = Replica.replica()
 
     field = Keyword.get(opts, :order_by, "inserted_at") |> String.to_atom()
     external_id = Keyword.get(opts, :search)
@@ -71,7 +77,7 @@ defmodule Realtime.Api do
       ** (Ecto.NoResultsError)
 
   """
-  def get_tenant!(id), do: Repo.replica().get!(Tenant, id)
+  def get_tenant!(id), do: Replica.replica().get!(Tenant, id)
 
   @doc """
   Creates a tenant.
@@ -155,7 +161,7 @@ defmodule Realtime.Api do
 
   @spec get_tenant_by_external_id(String.t()) :: Tenant.t() | nil
   def get_tenant_by_external_id(external_id) do
-    repo_replica = Repo.replica()
+    repo_replica = Replica.replica()
 
     Tenant
     |> repo_replica.get_by(external_id: external_id)
@@ -167,7 +173,7 @@ defmodule Realtime.Api do
       where: e.type == ^type,
       select: e
     )
-    |> Repo.replica().all()
+    |> Replica.replica().all()
   end
 
   def rename_settings_field(from, to) do

--- a/lib/realtime/postgres_cdc.ex
+++ b/lib/realtime/postgres_cdc.ex
@@ -61,36 +61,53 @@ defmodule Realtime.PostgresCdc do
   end
 
   @doc """
-  Translates a region from a platform to another
-
-  If the platform is `:fly` then the region is translated from an AWS region to a Fly region
-  If the platform is `:aws` then the region is not translated
+  Translates a region from a platform to the closest Supabase tenant region
   """
   @spec platform_region_translator(String.t()) :: nil | binary()
-  def platform_region_translator(aws_region) when is_binary(aws_region) do
+  def platform_region_translator(tenant_region) when is_binary(tenant_region) do
     platform = Application.get_env(:realtime, :platform)
+    region_mapping(platform, tenant_region)
+  end
 
-    if platform == :fly do
-      case aws_region do
-        "us-east-1" -> "iad"
-        "us-west-1" -> "sea"
-        "sa-east-1" -> "iad"
-        "ca-central-1" -> "iad"
-        "ap-southeast-1" -> "syd"
-        "ap-northeast-1" -> "syd"
-        "ap-northeast-2" -> "syd"
-        "ap-southeast-2" -> "syd"
-        "ap-south-1" -> "syd"
-        "eu-west-1" -> "lhr"
-        "eu-west-2" -> "lhr"
-        "eu-west-3" -> "lhr"
-        "eu-central-1" -> "lhr"
-        _ -> nil
-      end
-    else
-      aws_region
+  defp region_mapping(:aws, tenant_region) do
+    case tenant_region do
+      "us-west-1" -> "us-west-1"
+      "us-east-1" -> "us-east-1"
+      "sa-east-1" -> "us-east-1"
+      "ca-central-1" -> "us-east-1"
+      "ap-southeast-1" -> "ap-southeast-1"
+      "ap-northeast-1" -> "ap-southeast-1"
+      "ap-northeast-2" -> "ap-southeast-1"
+      "ap-southeast-2" -> "ap-southeast-2"
+      "ap-south-1" -> "ap-southeast-2"
+      "eu-west-1" -> "eu-west-2"
+      "eu-west-2" -> "eu-west-2"
+      "eu-west-3" -> "eu-west-2"
+      "eu-central-1" -> "eu-west-2"
+      _ -> nil
     end
   end
+
+  defp region_mapping(:fly, tenant_region) do
+    case tenant_region do
+      "us-east-1" -> "iad"
+      "us-west-1" -> "sea"
+      "sa-east-1" -> "iad"
+      "ca-central-1" -> "iad"
+      "ap-southeast-1" -> "syd"
+      "ap-northeast-1" -> "syd"
+      "ap-northeast-2" -> "syd"
+      "ap-southeast-2" -> "syd"
+      "ap-south-1" -> "syd"
+      "eu-west-1" -> "lhr"
+      "eu-west-2" -> "lhr"
+      "eu-west-3" -> "lhr"
+      "eu-central-1" -> "lhr"
+      _ -> nil
+    end
+  end
+
+  defp region_mapping(_, tenant_region), do: tenant_region
 
   @doc """
   Lists the nodes in a region. Sorts by node name in case the list order

--- a/lib/realtime/postgres_cdc.ex
+++ b/lib/realtime/postgres_cdc.ex
@@ -60,23 +60,35 @@ defmodule Realtime.PostgresCdc do
     end
   end
 
-  @spec aws_to_fly(String.t()) :: nil | <<_::24>>
-  def aws_to_fly(aws_region) when is_binary(aws_region) do
-    case aws_region do
-      "us-east-1" -> "iad"
-      "us-west-1" -> "sea"
-      "sa-east-1" -> "iad"
-      "ca-central-1" -> "iad"
-      "ap-southeast-1" -> "syd"
-      "ap-northeast-1" -> "syd"
-      "ap-northeast-2" -> "syd"
-      "ap-southeast-2" -> "syd"
-      "ap-south-1" -> "syd"
-      "eu-west-1" -> "lhr"
-      "eu-west-2" -> "lhr"
-      "eu-west-3" -> "lhr"
-      "eu-central-1" -> "lhr"
-      _ -> nil
+  @doc """
+  Translates a region from a platform to another
+
+  If the platform is `:fly` then the region is translated from an AWS region to a Fly region
+  If the platform is `:aws` then the region is not translated
+  """
+  @spec platform_region_translator(String.t()) :: nil | binary()
+  def platform_region_translator(aws_region) when is_binary(aws_region) do
+    platform = Application.get_env(:realtime, :platform)
+
+    if platform == :fly do
+      case aws_region do
+        "us-east-1" -> "iad"
+        "us-west-1" -> "sea"
+        "sa-east-1" -> "iad"
+        "ca-central-1" -> "iad"
+        "ap-southeast-1" -> "syd"
+        "ap-northeast-1" -> "syd"
+        "ap-northeast-2" -> "syd"
+        "ap-southeast-2" -> "syd"
+        "ap-south-1" -> "syd"
+        "eu-west-1" -> "lhr"
+        "eu-west-2" -> "lhr"
+        "eu-west-3" -> "lhr"
+        "eu-central-1" -> "lhr"
+        _ -> nil
+      end
+    else
+      aws_region
     end
   end
 

--- a/lib/realtime/repo.ex
+++ b/lib/realtime/repo.ex
@@ -3,18 +3,6 @@ defmodule Realtime.Repo do
     otp_app: :realtime,
     adapter: Ecto.Adapters.Postgres
 
-  @replicas %{
-    "sea" => Realtime.Repo.Replica.SJC,
-    "sjc" => Realtime.Repo.Replica.SJC,
-    "gru" => Realtime.Repo.Replica.IAD,
-    "iad" => Realtime.Repo.Replica.IAD,
-    "sin" => Realtime.Repo.Replica.SIN,
-    "maa" => Realtime.Repo.Replica.SIN,
-    "syd" => Realtime.Repo.Replica.SIN,
-    "lhr" => Realtime.Repo.Replica.FRA,
-    "fra" => Realtime.Repo.Replica.FRA
-  }
-
   def with_dynamic_repo(config, callback) do
     default_dynamic_repo = get_dynamic_repo()
     {:ok, repo} = [name: nil, pool_size: 1] |> Keyword.merge(config) |> Realtime.Repo.start_link()
@@ -25,27 +13,6 @@ defmodule Realtime.Repo do
     after
       Realtime.Repo.put_dynamic_repo(default_dynamic_repo)
       Supervisor.stop(repo)
-    end
-  end
-
-  if Mix.env() == :test do
-    def replica, do: __MODULE__
-  else
-    def replica,
-      do:
-        Map.get(
-          @replicas,
-          Application.get_env(:realtime, :fly_region),
-          Realtime.Repo
-        )
-  end
-
-  for replica_repo <- @replicas |> Map.values() |> Enum.uniq() do
-    defmodule replica_repo do
-      use Ecto.Repo,
-        otp_app: :realtime,
-        adapter: Ecto.Adapters.Postgres,
-        read_only: true
     end
   end
 end

--- a/lib/realtime/repo_replica.ex
+++ b/lib/realtime/repo_replica.ex
@@ -1,0 +1,75 @@
+defmodule Realtime.Repo.Replica do
+  @moduledoc """
+  Generates a read-only replica repo for the region specified in config/runtime.exs.
+  """
+  require Logger
+
+  @replicas_fly %{
+    "sea" => Realtime.Repo.Replica.SJC,
+    "sjc" => Realtime.Repo.Replica.SJC,
+    "gru" => Realtime.Repo.Replica.IAD,
+    "iad" => Realtime.Repo.Replica.IAD,
+    "sin" => Realtime.Repo.Replica.SIN,
+    "maa" => Realtime.Repo.Replica.SIN,
+    "syd" => Realtime.Repo.Replica.SIN,
+    "lhr" => Realtime.Repo.Replica.FRA,
+    "fra" => Realtime.Repo.Replica.FRA
+  }
+
+  @replicas_aws %{
+    "ap-southeast-1" => Realtime.Repo.Replica.Singapore,
+    "ap-southeast-2" => Realtime.Repo.Replica.Sydney,
+    "eu-west-1" => Realtime.Repo.Replica.Ireland,
+    "eu-west-2" => Realtime.Repo.Replica.London,
+    "us-east-1" => Realtime.Repo.Replica.NorthVirginia
+  }
+
+  @ast (quote do
+          use Ecto.Repo,
+            otp_app: :realtime,
+            adapter: Ecto.Adapters.Postgres,
+            read_only: true
+        end)
+  @doc """
+  Returns the replica repo module for the region specified in config/runtime.exs.
+  """
+  @spec replica() :: module()
+  def replica do
+    replicas =
+      case Application.get_env(:realtime, :platform) do
+        :aws -> @replicas_aws
+        :fly -> @replicas_fly
+        _ -> %{}
+      end
+
+    region = Application.get_env(:realtime, :region)
+    replica = Map.get(replicas, region)
+    replica_conf = Application.get_env(:realtime, replica)
+
+    # Do not create module if replica isn't set or configuration is not present
+    cond do
+      is_nil(replica) ->
+        Logger.warning("Replica region not found, defaulting to Realtime.Repo")
+        Realtime.Repo
+
+      is_nil(replica_conf) ->
+        Logger.error("Replica config not found for #{region} region")
+        Realtime.Repo
+
+      true ->
+        # Check if module is present
+        case Code.ensure_compiled(replica) do
+          {:module, _} -> nil
+          _ -> {:module, _, _, _} = Module.create(replica, @ast, Macro.Env.location(__ENV__))
+        end
+
+        replica
+    end
+  end
+
+  if Mix.env() == :test do
+    def replicas_aws, do: @replicas_aws
+
+    def replicas_fly, do: @replicas_fly
+  end
+end

--- a/lib/realtime/repo_replica.ex
+++ b/lib/realtime/repo_replica.ex
@@ -18,10 +18,10 @@ defmodule Realtime.Repo.Replica do
 
   @replicas_aws %{
     "ap-southeast-1" => Realtime.Repo.Replica.Singapore,
-    "ap-southeast-2" => Realtime.Repo.Replica.Sydney,
-    "eu-west-1" => Realtime.Repo.Replica.Ireland,
+    "ap-southeast-2" => Realtime.Repo.Replica.Singapore,
     "eu-west-2" => Realtime.Repo.Replica.London,
-    "us-east-1" => Realtime.Repo.Replica.NorthVirginia
+    "us-east-1" => Realtime.Repo.Replica.NorthVirginia,
+    "us-west-2" => Realtime.Repo.Replica.Oregon
   }
 
   @ast (quote do
@@ -30,6 +30,7 @@ defmodule Realtime.Repo.Replica do
             adapter: Ecto.Adapters.Postgres,
             read_only: true
         end)
+
   @doc """
   Returns the replica repo module for the region specified in config/runtime.exs.
   """

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -4,8 +4,7 @@ defmodule Realtime.Tenants do
   """
 
   require Logger
-
-  alias Realtime.Repo
+  alias Realtime.Repo.Replica
   alias Realtime.Api.Tenant
 
   @doc """
@@ -122,7 +121,7 @@ defmodule Realtime.Tenants do
 
   @spec get_tenant_by_external_id(String.t()) :: Tenant.t() | nil
   def get_tenant_by_external_id(external_id) do
-    repo_replica = Repo.replica()
+    repo_replica = Replica.replica()
 
     Tenant
     |> repo_replica.get_by(external_id: external_id)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.7",
+      version: "2.22.8",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/tailscale/wrapper.sh
+++ b/tailscale/wrapper.sh
@@ -11,4 +11,5 @@ if [ "${ENABLE_TAILSCALE-}" = true ]; then
 fi
 
 echo "Starting Realtime"
+sudo -E -u nobody /app/bin/eval Realtime.Release.migrate
 sudo -E -u nobody /app/bin/server

--- a/test/realtime/repo_replica_test.exs
+++ b/test/realtime/repo_replica_test.exs
@@ -1,0 +1,55 @@
+defmodule Realtime.Repo.ReplicaTest do
+  use ExUnit.Case
+  alias Realtime.Repo.Replica
+
+  setup do
+    previous_platform = Application.get_env(:realtime, :platform)
+    previous_region = Application.get_env(:realtime, :region)
+
+    on_exit(fn ->
+      Application.put_env(:realtime, :platform, previous_platform)
+      Application.put_env(:realtime, :region, previous_region)
+    end)
+  end
+
+  describe "handle aws platform" do
+    for {region, mod} <- Replica.replicas_aws() do
+      setup do
+        Application.put_env(:realtime, :platform, :aws)
+      end
+
+      test "handles #{region} region" do
+        Application.put_env(:realtime, :region, unquote(region))
+        replica_asserts(unquote(mod), Replica.replica())
+      end
+    end
+
+    test "defaults to Realtime.Repo if region is not configured" do
+      Application.put_env(:realtime, :region, "unknown")
+      replica_asserts(Realtime.Repo, Replica.replica())
+    end
+  end
+
+  describe "handle fly platform" do
+    for {region, mod} <- Replica.replicas_fly() do
+      setup do
+        Application.put_env(:realtime, :platform, :fly)
+      end
+
+      test "handles #{region} region" do
+        Application.put_env(:realtime, :region, unquote(region))
+        replica_asserts(unquote(mod), Replica.replica())
+      end
+    end
+
+    test "defaults to Realtime.Repo if region is not configured" do
+      Application.put_env(:realtime, :region, "unknown")
+      replica_asserts(Realtime.Repo, Replica.replica())
+    end
+  end
+
+  defp replica_asserts(mod, replica) do
+    assert mod == replica
+    assert [Ecto.Repo] == replica.__info__(:attributes) |> Keyword.get(:behaviour)
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes multiple elements to support AWS regions:
* Read replicas now point to the correct server and set the correct module name
* Replica repository is loaded dynamically and only when required to avoid extra modules to be loaded
