### PR TITLE
fix: Only run migration on AWS and use the correct command

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.8",
+      version: "2.22.9",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/tailscale/wrapper.sh
+++ b/tailscale/wrapper.sh
@@ -11,5 +11,10 @@ if [ "${ENABLE_TAILSCALE-}" = true ]; then
 fi
 
 echo "Starting Realtime"
-sudo -E -u nobody /app/bin/eval Realtime.Release.migrate
+
+if [ "$AWS_EXECUTION_ENV" = "AWS_ECS_FARGATE" ]; then
+    echo "Running migrations"
+    sudo -E -u nobody /app/bin/migrate
+fi
+
 sudo -E -u nobody /app/bin/server


### PR DESCRIPTION
## What kind of change does this PR introduce?

Only run migration on AWS and use the correct command.

Fly does not need to run migrations (in fact was breaking in staging) and there's already a migration command available
