### PR TITLE
fix: Set id based on host name instead of fly variable

### DIFF
--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -130,15 +130,6 @@ defmodule Realtime.Helpers do
     }
   end
 
-  def short_node_id() do
-    fly_alloc_id = Application.get_env(:realtime, :fly_alloc_id)
-
-    case String.split(fly_alloc_id, "-", parts: 2) do
-      [short_alloc_id, _] -> short_alloc_id
-      _ -> fly_alloc_id
-    end
-  end
-
   @doc """
   Gets a short node name from a node name when a node name looks like `realtime-prod@fdaa:0:cc:a7b:b385:83c3:cfe3:2`
 

--- a/lib/realtime/monitoring/prom_ex.ex
+++ b/lib/realtime/monitoring/prom_ex.ex
@@ -1,7 +1,7 @@
 defmodule Realtime.PromEx do
   alias Realtime.PromEx.Plugins.{OsMon, Phoenix, Tenants, Tenant}
 
-  import Realtime.Helpers, only: [short_node_id: 0]
+  import Realtime.Helpers, only: [short_node_id_from_name: 1]
 
   @moduledoc """
   Be sure to add the following to finish setting up PromEx:
@@ -143,7 +143,7 @@ defmodule Realtime.PromEx do
     metrics_tags = %{
       region: Application.get_env(:realtime, :region),
       node_host: node_host,
-      short_alloc_id: short_node_id()
+      short_alloc_id: short_node_id_from_name(node())
     }
 
     Application.put_env(:realtime, :metrics_tags, metrics_tags)

--- a/lib/realtime_web/templates/layout/live.html.heex
+++ b/lib/realtime_web/templates/layout/live.html.heex
@@ -99,7 +99,9 @@
   </div>
   <ul class="flex flex-wrap items-center mt-3 text-sm text-gray-900">
     <li><span class="mr-4">Apache 2.0 License</span></li>
-    <li><span class="font-mono mr-4"><%= Realtime.Helpers.short_node_id() %></span></li>
+    <li>
+      <span class="font-mono mr-4"><%= Realtime.Helpers.short_node_id_from_name(node()) %></span>
+    </li>
     <li><span class="font-mono mr-4"><%= System.get_env("FLY_REGION") %></span></li>
     <li><%= live_render(@socket, RealtimeWeb.PingLive, id: "ping") %></li>
   </ul>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.18",
+      version: "2.22.19",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Set id based on host name instead of fly variable

Currently we're using a variable set at the cluster level meaning that we will get repeated metrics for id ending up with the wrong metrics on metrics dashboards