### PR TITLE
fix: Take version into consideration in Postgres libcluster Strategy

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,6 +136,8 @@ cluster_topologies =
         ] ++ acc
 
       "POSTGRES" ->
+        version = "#{Application.spec(:realtime)[:vsn]}" |> String.replace(".", "_")
+
         [
           postgres: [
             strategy: Realtime.Cluster.Strategy.Postgres,
@@ -149,7 +151,9 @@ cluster_topologies =
                 application_name: "cluster_node_#{node()}"
               ],
               heartbeat_interval: 5_000,
-              node_timeout: 15_000
+              node_timeout: 15_000,
+              channel_name:
+                System.get_env("POSTGRES_CLUSTER_CHANNEL_NAME", "realtime_cluster_#{version}")
             ]
           ]
         ] ++ acc

--- a/lib/realtime/cluster_strategy/postgres.ex
+++ b/lib/realtime/cluster_strategy/postgres.ex
@@ -28,13 +28,13 @@ defmodule Realtime.Cluster.Strategy.Postgres do
       password: Keyword.fetch!(state.config, :password),
       database: Keyword.fetch!(state.config, :database),
       port: Keyword.fetch!(state.config, :port),
-      parameters: Keyword.fetch!(state.config, :parameters)
+      parameters: Keyword.fetch!(state.config, :parameters),
+      channel_name: Keyword.fetch!(state.config, :channel_name)
     ]
 
     new_config =
       state.config
       |> Keyword.put_new(:heartbeat_interval, 5_000)
-      |> Keyword.put_new(:channel_name, "realtime_cluster")
       |> Keyword.delete(:url)
 
     meta = %{
@@ -83,11 +83,8 @@ defmodule Realtime.Cluster.Strategy.Postgres do
       Logger.debug(topology, "Trying to connect to node: #{node}")
 
       case Strategy.connect_nodes(topology, state.connect, state.list_nodes, [node]) do
-        :ok ->
-          Logger.debug(topology, "Connected to node: #{node}")
-
-        {:error, _} ->
-          Logger.error(topology, "Failed to connect to node: #{node}")
+        :ok -> Logger.debug(topology, "Connected to node: #{node}")
+        {:error, _} -> Logger.error(topology, "Failed to connect to node: #{node}")
       end
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.19",
+      version: "2.22.20",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/cluster_strategy/postgres_test.exs
+++ b/test/realtime/cluster_strategy/postgres_test.exs
@@ -17,12 +17,14 @@ defmodule Realtime.Cluster.Strategy.PostgresTest do
 
   test "notify cluster after start" do
     state = libcluster_state()
+    channel_name = Keyword.fetch!(state.config, :channel_name)
+
     Postgres.start_link([state])
 
     {:ok, conn_notif} = PN.start_link(state.meta.opts.())
-    PN.listen(conn_notif, "realtime_cluster")
+    PN.listen(conn_notif, channel_name)
     node = "#{node()}"
-    assert_receive {:notification, _, _, "realtime_cluster", ^node}
+    assert_receive {:notification, _, _, channel_name, ^node}
   end
 
   defp libcluster_state() do
@@ -52,7 +54,8 @@ defmodule Realtime.Cluster.Strategy.PostgresTest do
         application_name: "#{node()}"
       ],
       heartbeat_interval: 5_000,
-      node_timeout: 15_000
+      node_timeout: 15_000,
+      channel_name: "test_channel_name"
     ]
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently we have nodes connecting from different versions which could have a negative impact on the overall cluster operations. To avoid it, we're taking into consideration the version when connecting nodes via libcluster Postgres strategy.
