### PR TITLE
fix: add support for San Jose AWS region

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -88,6 +88,7 @@ if config_env() != :test do
     Realtime.Repo.Replica.London => System.get_env("DB_HOST_REPLICA_FRA", default_db_host),
     Realtime.Repo.Replica.NorthVirginia => System.get_env("DB_HOST_REPLICA_IAD", default_db_host),
     Realtime.Repo.Replica.Oregon => System.get_env("DB_HOST_REPLICA_SJC", default_db_host),
+    Realtime.Repo.Replica.SanJose => System.get_env("DB_HOST_REPLICA_SJC", default_db_host),
     Realtime.Repo.Replica.Local => default_db_host
   }
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,8 @@ for repo <- [
       Realtime.Repo.Replica.Singapore,
       Realtime.Repo.Replica.London,
       Realtime.Repo.Replica.NorthVirginia,
-      Realtime.Repo.Replica.Oregon
+      Realtime.Repo.Replica.Oregon,
+      Realtime.Repo.Replica.SanJose
     ] do
   config :realtime, repo,
     username: "postgres",

--- a/lib/realtime/repo_replica.ex
+++ b/lib/realtime/repo_replica.ex
@@ -21,7 +21,8 @@ defmodule Realtime.Repo.Replica do
     "ap-southeast-2" => Realtime.Repo.Replica.Singapore,
     "eu-west-2" => Realtime.Repo.Replica.London,
     "us-east-1" => Realtime.Repo.Replica.NorthVirginia,
-    "us-west-2" => Realtime.Repo.Replica.Oregon
+    "us-west-2" => Realtime.Repo.Replica.Oregon,
+    "us-west-1" => Realtime.Repo.Replica.SanJose
   }
 
   @ast (quote do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.20",
+      version: "2.22.21",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Adds read replica support if deployed in us-west-1 AWS (San Jose).