### PR TITLE
fix: Add Rate limit to Broadcast endpoint

### DIFF
--- a/lib/realtime_web/controllers/broadcast_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_controller.ex
@@ -3,7 +3,9 @@ defmodule RealtimeWeb.BroadcastController do
   use RealtimeWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  alias Realtime.Api.Tenant
   alias Realtime.GenCounter
+  alias Realtime.RateCounter
   alias Realtime.Tenants
   alias Realtime.Tenants.BatchBroadcast
   alias RealtimeWeb.Endpoint
@@ -11,6 +13,7 @@ defmodule RealtimeWeb.BroadcastController do
   alias RealtimeWeb.OpenApiSchemas.EmptyResponse
   alias RealtimeWeb.OpenApiSchemas.TenantBatchParams
   alias RealtimeWeb.OpenApiSchemas.UnprocessableEntityResponse
+  alias RealtimeWeb.OpenApiSchemas.TooManyRequestsResponse
 
   action_fallback(RealtimeWeb.FallbackController)
 
@@ -30,7 +33,8 @@ defmodule RealtimeWeb.BroadcastController do
     responses: %{
       202 => EmptyResponse.response(),
       403 => EmptyResponse.response(),
-      422 => UnprocessableEntityResponse.response()
+      422 => UnprocessableEntityResponse.response(),
+      429 => TooManyRequestsResponse.response()
     }
   )
 
@@ -38,7 +42,8 @@ defmodule RealtimeWeb.BroadcastController do
     with %Ecto.Changeset{valid?: true} = changeset <-
            BatchBroadcast.changeset(%BatchBroadcast{}, attrs),
          %Ecto.Changeset{changes: %{messages: messages}} <- changeset,
-         events_per_second_key <- Tenants.events_per_second_key(tenant) do
+         events_per_second_key <- Tenants.events_per_second_key(tenant),
+         :ok <- check_rate_limit(events_per_second_key, tenant, length(messages)) do
       for %{changes: %{topic: sub_topic, payload: payload, event: event}} <- messages do
         tenant_topic = Tenants.tenant_topic(tenant, sub_topic)
         payload = %{"payload" => Map.merge(payload, %{"event" => event})}
@@ -46,10 +51,27 @@ defmodule RealtimeWeb.BroadcastController do
         Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
 
         GenCounter.add(events_per_second_key)
-        Logger.info("Broadcasted message to using HTTP API: " <> tenant_topic)
+        Logger.info("Broadcasted message using HTTP API to topic " <> tenant_topic)
       end
 
       send_resp(conn, :accepted, "")
+    end
+  end
+
+  defp check_rate_limit(events_per_second_key, %Tenant{} = tenant, total_messages_to_broadcast) do
+    %{max_events_per_second: max_events_per_second} = tenant
+    {:ok, %{avg: events_per_second}} = RateCounter.get(events_per_second_key)
+
+    cond do
+      events_per_second > max_events_per_second ->
+        {:error, :too_many_requests, "You have exceeded your rate limit"}
+
+      total_messages_to_broadcast + events_per_second > max_events_per_second ->
+        {:error, :too_many_requests,
+         "Too many messages to broadcast, please reduce the batch size"}
+
+      true ->
+        :ok
     end
   end
 end

--- a/lib/realtime_web/controllers/broadcast_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_controller.ex
@@ -1,5 +1,4 @@
 defmodule RealtimeWeb.BroadcastController do
-  require Logger
   use RealtimeWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
@@ -51,7 +50,6 @@ defmodule RealtimeWeb.BroadcastController do
         Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
 
         GenCounter.add(events_per_second_key)
-        Logger.info("Broadcasted message using HTTP API to topic " <> tenant_topic)
       end
 
       send_resp(conn, :accepted, "")

--- a/lib/realtime_web/controllers/fallback_controller.ex
+++ b/lib/realtime_web/controllers/fallback_controller.ex
@@ -6,7 +6,6 @@ defmodule RealtimeWeb.FallbackController do
   """
   use RealtimeWeb, :controller
 
-  # This clause handles errors returned by Ecto's insert/update/delete.
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)
@@ -14,12 +13,18 @@ defmodule RealtimeWeb.FallbackController do
     |> render("error.json", changeset: changeset)
   end
 
-  # This clause is an example of how to handle resources that cannot be found.
   def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)
     |> put_view(RealtimeWeb.ErrorView)
     |> render(:"404")
+  end
+
+  def call(conn, {:error, status, message}) when is_atom(status) and is_binary(message) do
+    conn
+    |> put_status(status)
+    |> put_view(RealtimeWeb.ErrorView)
+    |> render("error.json", message: message)
   end
 
   def call(conn, %Ecto.Changeset{valid?: false} = changeset) do

--- a/lib/realtime_web/open_api_schemas.ex
+++ b/lib/realtime_web/open_api_schemas.ex
@@ -18,7 +18,8 @@ defmodule RealtimeWeb.OpenApiSchemas do
             type: :object,
             properties: %{
               topic: %Schema{type: :string},
-              payload: %Schema{type: :object}
+              payload: %Schema{type: :object},
+              event: %Schema{type: :object}
             }
           }
         }
@@ -273,5 +274,27 @@ defmodule RealtimeWeb.OpenApiSchemas do
     })
 
     def response(), do: {"Unprocessable Entity", "application/json", __MODULE__}
+  end
+
+  defmodule TooManyRequestsResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        error: %Schema{
+          type: :object,
+          properties: %{
+            messages: %Schema{
+              type: :array,
+              items: %Schema{type: :object}
+            }
+          }
+        }
+      }
+    })
+
+    def response(), do: {"Too Many Requests", "application/json", __MODULE__}
   end
 end

--- a/lib/realtime_web/views/changeset_view.ex
+++ b/lib/realtime_web/views/changeset_view.ex
@@ -12,8 +12,6 @@ defmodule RealtimeWeb.ChangesetView do
   end
 
   def render("error.json", %{changeset: changeset}) do
-    # When encoded, the changeset returns its errors
-    # as a JSON object. So we just pass it forward.
     %{errors: translate_errors(changeset)}
   end
 end

--- a/lib/realtime_web/views/error_view.ex
+++ b/lib/realtime_web/views/error_view.ex
@@ -1,15 +1,10 @@
 defmodule RealtimeWeb.ErrorView do
   use RealtimeWeb, :view
 
-  # If you want to customize a particular status code
-  # for a certain format, you may uncomment below.
-  # def render("500.html", _assigns) do
-  #   "Internal Server Error"
-  # end
+  def render("error.json", %{conn: %{assigns: %{message: message}}}) do
+    %{message: message}
+  end
 
-  # By default, Phoenix returns the status message from
-  # the template name. For example, "404.html" becomes
-  # "Not Found".
   def template_not_found(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.24",
+      version: "2.22.25",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

To prevent over usage by customers, we will take into account the Rate Limits.

We handle two situations:
* The existing batch will trigger a rate limit so we advice to reduce the batch size
* Rate limit has been hit so we can't process the request
