### PR TITLE
fix: Change event payload to match current broadcast logic

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -43,5 +43,5 @@ config :realtime,
 config :joken,
   current_time_adapter: RealtimeWeb.Joken.CurrentTime.Mock
 
-# Print only warnings and errors during test
-config :logger, level: :warn
+# Print only errors during test
+config :logger, level: :error

--- a/lib/realtime_web/controllers/broadcast_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_controller.ex
@@ -45,7 +45,7 @@ defmodule RealtimeWeb.BroadcastController do
          :ok <- check_rate_limit(events_per_second_key, tenant, length(messages)) do
       for %{changes: %{topic: sub_topic, payload: payload, event: event}} <- messages do
         tenant_topic = Tenants.tenant_topic(tenant, sub_topic)
-        payload = %{"payload" => Map.merge(payload, %{"event" => event})}
+        payload = %{"payload" => payload, "event" => event, "type" => "broadcast"}
 
         Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.22.25",
+      version: "2.22.26",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?
Changes the event payload to match the current channel broadcast logic.

Also reduce test flakiness by adding mocks to Broadcast tests as they were testing the Counters logic without the need for it.