### PR TITLE
feat: expose additional limits for tenant endpoints

### DIFF
--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -20,7 +20,7 @@ defmodule Realtime.Api.Tenant do
     field(:max_events_per_second, :integer, default: 100)
     field(:max_bytes_per_second, :integer, default: 100_000)
     field(:max_channels_per_client, :integer, default: 100)
-    field(:max_joins_per_second, :integer, default: 500)
+    field(:max_joins_per_second, :integer, default: 100)
     field(:events_per_second_rolling, :float, virtual: true)
     field(:events_per_second_now, :integer, virtual: true)
 

--- a/lib/realtime_web/open_api_schemas.ex
+++ b/lib/realtime_web/open_api_schemas.ex
@@ -141,6 +141,19 @@ defmodule RealtimeWeb.OpenApiSchemas do
           type: :number,
           description: "Maximum connected concurrent clients"
         },
+        max_channels_per_client: %Schema{
+          type: :number,
+          description: "Maximum channels per connected client"
+        },
+        max_events_per_second: %Schema{
+          type: :number,
+          description:
+            "Maximum number of events, or messages, that all connected clients are permitted to send"
+        },
+        max_joins_per_second: %Schema{
+          type: :number,
+          description: "Maximum number of channel joins permitted for all connected clients"
+        },
         inserted_at: %Schema{type: :string, format: "date-time", description: "Insert timestamp"},
         extensions: %Schema{
           type: :array,
@@ -177,6 +190,9 @@ defmodule RealtimeWeb.OpenApiSchemas do
         external_id: "tenant-1",
         name: "First Tenant",
         max_concurrent_users: 1000,
+        max_channels_per_client: 100,
+        max_events_per_second: 100,
+        max_joins_per_second: 100,
         inserted_at: "2023-01-01T00:00:00Z",
         extensions: [
           %{

--- a/lib/realtime_web/views/tenant_view.ex
+++ b/lib/realtime_web/views/tenant_view.ex
@@ -17,11 +17,14 @@ defmodule RealtimeWeb.TenantView do
   def render("tenant.json", %{tenant: tenant}) do
     %{
       id: tenant.id,
+      external_id: tenant.external_id,
       name: tenant.name,
       max_concurrent_users: tenant.max_concurrent_users,
-      external_id: tenant.external_id,
-      extensions: tenant.extensions,
-      inserted_at: tenant.inserted_at
+      max_channels_per_client: tenant.max_channels_per_client,
+      max_events_per_second: tenant.max_events_per_second,
+      max_joins_per_second: tenant.max_joins_per_second,
+      inserted_at: tenant.inserted_at,
+      extensions: tenant.extensions
     }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.23.4",
+      version: "2.24.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
+++ b/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
@@ -30,7 +30,7 @@ defmodule Realtime.Extensions.CdcRlsTest do
       limits: %{
         max_concurrent_users: 1,
         max_events_per_second: 100,
-        max_joins_per_second: 500,
+        max_joins_per_second: 100,
         max_channels_per_client: 100,
         max_bytes_per_second: 100_000
       },

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -12,7 +12,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
   @default_limits %{
     max_concurrent_users: 200,
     max_events_per_second: 100,
-    max_joins_per_second: 500,
+    max_joins_per_second: 100,
     max_channels_per_client: 100,
     max_bytes_per_second: 100_000
   }

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -13,7 +13,10 @@ defmodule RealtimeWeb.TenantControllerTest do
   @update_attrs %{
     jwt_secret: "some updated jwt_secret",
     name: "some updated name",
-    max_concurrent_users: 200
+    max_concurrent_users: 300,
+    max_channels_per_client: 150,
+    max_events_per_second: 250,
+    max_joins_per_second: 50
   }
 
   @default_tenant_attrs %{
@@ -64,6 +67,9 @@ defmodule RealtimeWeb.TenantControllerTest do
         conn = get(conn, Routes.tenant_path(conn, :show, ext_id))
         assert ^ext_id = json_response(conn, 200)["data"]["external_id"]
         assert 200 = json_response(conn, 200)["data"]["max_concurrent_users"]
+        assert 100 = json_response(conn, 200)["data"]["max_channels_per_client"]
+        assert 100 = json_response(conn, 200)["data"]["max_events_per_second"]
+        assert 100 = json_response(conn, 200)["data"]["max_joins_per_second"]
       end
     end
 
@@ -100,7 +106,10 @@ defmodule RealtimeWeb.TenantControllerTest do
         assert %{"id" => ^id, "external_id" => ^ext_id} = json_response(conn, 200)["data"]
         conn = get(conn, Routes.tenant_path(conn, :show, ext_id))
         assert "some updated name" = json_response(conn, 200)["data"]["name"]
-        assert 200 = json_response(conn, 200)["data"]["max_concurrent_users"]
+        assert 300 = json_response(conn, 200)["data"]["max_concurrent_users"]
+        assert 150 = json_response(conn, 200)["data"]["max_channels_per_client"]
+        assert 250 = json_response(conn, 200)["data"]["max_events_per_second"]
+        assert 50 = json_response(conn, 200)["data"]["max_joins_per_second"]
       end
     end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Only `max_concurrent_users` is in the response payload when creating, updating, and showing tenant on api request.

## What is the new behavior?

`max_channels_per_client`, `max_events_per_second`, and `max_joins_per_second` will now be part of response payload as well.
