### PR TITLE
fix: Improve docs on Broadcast endpoint

### DIFF
--- a/lib/realtime_web/open_api_schemas.ex
+++ b/lib/realtime_web/open_api_schemas.ex
@@ -17,7 +17,11 @@ defmodule RealtimeWeb.OpenApiSchemas do
           items: %Schema{
             type: :object,
             properties: %{
-              topic: %Schema{type: :string},
+              topic: %Schema{
+                type: :string,
+                description:
+                  "Note: libraries will prepend the channel name with 'realtime:' so if you use this endpoint directly you'll need to also prepend 'realtime:' so it's captured by clients properly"
+              },
               payload: %Schema{type: :object},
               event: %Schema{type: :object}
             }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.24.1",
+      version: "2.24.2",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the information that clients will prepend realtime: as their channel and users using this endpoint directly should also do that
