### PR TITLE
fix: Disconnect when tenant has no users

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.4",
+      version: "2.25.5",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -112,72 +112,75 @@ defmodule Realtime.Integration.RtChannelTest do
     P.query!(conn, "insert into test (details) values ('test')", [])
 
     assert_receive %Message{
-      event: "postgres_changes",
-      payload: %{
-        "data" => %{
-          "columns" => [
-            %{"name" => "id", "type" => "int4"},
-            %{"name" => "details", "type" => "text"}
-          ],
-          "commit_timestamp" => _ts,
-          "errors" => nil,
-          "record" => %{"details" => "test", "id" => id},
-          "schema" => "public",
-          "table" => "test",
-          "type" => "INSERT"
-        },
-        "ids" => [^sub_id]
-      },
-      ref: nil,
-      topic: "realtime:any"
-    }
+                     event: "postgres_changes",
+                     payload: %{
+                       "data" => %{
+                         "columns" => [
+                           %{"name" => "id", "type" => "int4"},
+                           %{"name" => "details", "type" => "text"}
+                         ],
+                         "commit_timestamp" => _ts,
+                         "errors" => nil,
+                         "record" => %{"details" => "test", "id" => id},
+                         "schema" => "public",
+                         "table" => "test",
+                         "type" => "INSERT"
+                       },
+                       "ids" => [^sub_id]
+                     },
+                     ref: nil,
+                     topic: "realtime:any"
+                   },
+                   2000
 
     P.query!(conn, "update test set details = 'test' where id = #{id}", [])
 
     assert_receive %Message{
-      event: "postgres_changes",
-      payload: %{
-        "data" => %{
-          "columns" => [
-            %{"name" => "id", "type" => "int4"},
-            %{"name" => "details", "type" => "text"}
-          ],
-          "commit_timestamp" => _ts,
-          "errors" => nil,
-          "old_record" => %{"id" => ^id},
-          "record" => %{"details" => "test", "id" => ^id},
-          "schema" => "public",
-          "table" => "test",
-          "type" => "UPDATE"
-        },
-        "ids" => [^sub_id]
-      },
-      ref: nil,
-      topic: "realtime:any"
-    }
+                     event: "postgres_changes",
+                     payload: %{
+                       "data" => %{
+                         "columns" => [
+                           %{"name" => "id", "type" => "int4"},
+                           %{"name" => "details", "type" => "text"}
+                         ],
+                         "commit_timestamp" => _ts,
+                         "errors" => nil,
+                         "old_record" => %{"id" => ^id},
+                         "record" => %{"details" => "test", "id" => ^id},
+                         "schema" => "public",
+                         "table" => "test",
+                         "type" => "UPDATE"
+                       },
+                       "ids" => [^sub_id]
+                     },
+                     ref: nil,
+                     topic: "realtime:any"
+                   },
+                   2000
 
     P.query!(conn, "delete from test where id = #{id}", [])
 
     assert_receive %Message{
-      event: "postgres_changes",
-      payload: %{
-        "data" => %{
-          "columns" => [
-            %{"name" => "id", "type" => "int4"},
-            %{"name" => "details", "type" => "text"}
-          ],
-          "commit_timestamp" => _ts,
-          "errors" => nil,
-          "old_record" => %{"id" => ^id},
-          "schema" => "public",
-          "table" => "test",
-          "type" => "DELETE"
-        },
-        "ids" => [^sub_id]
-      },
-      ref: nil,
-      topic: "realtime:any"
-    }
+                     event: "postgres_changes",
+                     payload: %{
+                       "data" => %{
+                         "columns" => [
+                           %{"name" => "id", "type" => "int4"},
+                           %{"name" => "details", "type" => "text"}
+                         ],
+                         "commit_timestamp" => _ts,
+                         "errors" => nil,
+                         "old_record" => %{"id" => ^id},
+                         "schema" => "public",
+                         "table" => "test",
+                         "type" => "DELETE"
+                       },
+                       "ids" => [^sub_id]
+                     },
+                     ref: nil,
+                     topic: "realtime:any"
+                   },
+                   2000
   end
 
   test "broadcast" do


### PR DESCRIPTION
## What kind of change does this PR introduce?

To ensure that we limit the amount of connections to a tenant database, we will check if that tenant has any users and if not, we kill the database connection.
