### PR TITLE
fix: Fix broken runtime.exs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,7 +1,5 @@
 import Config
 
-version = Mix.Project.config()[:version] |> String.replace(".", "_") |> String.downcase()
-
 config :logflare_logger_backend,
   url: System.get_env("LOGFLARE_LOGGER_BACKEND_URL", "https://api.logflare.app")
 
@@ -11,9 +9,7 @@ username = System.get_env("DB_USER", "postgres")
 password = System.get_env("DB_PASSWORD", "postgres")
 database = System.get_env("DB_NAME", "postgres")
 port = System.get_env("DB_PORT", "5432")
-slot_name_suffix = System.get_env("SLOT_NAME_SUFFIX", version)
-
-config :realtime, slot_name_suffix: slot_name_suffix
+slot_name_suffix = System.get_env("SLOT_NAME_SUFFIX")
 
 if config_env() == :prod do
   secret_key_base =
@@ -59,7 +55,8 @@ if config_env() != :test do
     region: System.get_env("FLY_REGION") || System.get_env("REGION"),
     fly_alloc_id: System.get_env("FLY_ALLOC_ID", ""),
     prom_poll_rate: System.get_env("PROM_POLL_RATE", "5000") |> String.to_integer(),
-    platform: platform
+    platform: platform,
+    slot_name_suffix: slot_name_suffix
 
   queue_target = System.get_env("DB_QUEUE_TARGET", "5000") |> String.to_integer()
   queue_interval = System.get_env("DB_QUEUE_INTERVAL", "5000") |> String.to_integer()

--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -151,8 +151,10 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
   end
 
   def slot_name_suffix() do
-    slot_name_suffix = Application.get_env(:realtime, :slot_name_suffix)
-    "_" <> slot_name_suffix
+    case Application.get_env(:realtime, :slot_name_suffix) do
+      nil -> ""
+      slot_name_suffix -> "_" <> slot_name_suffix
+    end
   end
 
   defp convert_errors([_ | _] = errors), do: errors

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.9",
+      version: "2.25.10",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/extensions/cdc_rls/replication_poller_test.exs
+++ b/test/realtime/extensions/cdc_rls/replication_poller_test.exs
@@ -299,9 +299,8 @@ defmodule ReplicationPollerTest do
       assert Poller.slot_name_suffix() == "_" <> slot_name_suffix
     end
 
-    test "defaults to project version" do
-      version = Mix.Project.config()[:version] |> String.replace(".", "_")
-      assert Poller.slot_name_suffix() == "_" <> version
+    test "defaults to no suffix" do
+      assert Poller.slot_name_suffix() == ""
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Mix project isn't available on bootup. Revert to use a env var
