### PR TITLE
fix: Add suspend flag to block new connections to tenant db

### DIFF
--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -21,6 +21,7 @@ defmodule Realtime.Api.Tenant do
     field(:max_bytes_per_second, :integer, default: 100_000)
     field(:max_channels_per_client, :integer, default: 100)
     field(:max_joins_per_second, :integer, default: 100)
+    field(:suspend, :boolean, default: false)
     field(:events_per_second_rolling, :float, virtual: true)
     field(:events_per_second_now, :integer, virtual: true)
 
@@ -69,7 +70,8 @@ defmodule Realtime.Api.Tenant do
       :postgres_cdc_default,
       :max_bytes_per_second,
       :max_channels_per_client,
-      :max_joins_per_second
+      :max_joins_per_second,
+      :suspend
     ])
     |> validate_required([
       :external_id,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.11",
+      version: "2.25.12",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20231024094642_add_tenant_suspend_flag.exs
+++ b/priv/repo/migrations/20231024094642_add_tenant_suspend_flag.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.Realtime.Repo.Migrations.Add-tenant-suspend-flag" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenants) do
+      add :suspend, :boolean, default: false
+    end
+  end
+end

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -98,5 +98,11 @@ defmodule Realtime.Tenants.ConnectTest do
       assert :undefined = :syn.lookup(Connect, tenant_id)
       refute Process.alive?(db_conn)
     end
+
+    test "error if tenant is suspended" do
+      tenant = tenant_fixture(suspend: true)
+
+      assert {:error, :tenant_suspended} == Connect.lookup_or_start_connection(tenant.external_id)
+    end
   end
 end

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -38,4 +38,22 @@ defmodule Realtime.TenantsTest do
       end
     end
   end
+
+  describe "suspend_tenant_by_external_id/1" do
+    test "sets suspend flag to true" do
+      tenant = tenant_fixture()
+      {:ok, tenant} = Tenants.suspend_tenant_by_external_id(tenant.external_id)
+
+      assert tenant.suspend == true
+    end
+  end
+
+  describe "unsuspend_tenant_by_external_id/1" do
+    test "sets suspend flag to true" do
+      tenant = tenant_fixture(suspend: true)
+      {:ok, tenant} = Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
+
+      assert tenant.suspend == false
+    end
+  end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add suspend flag to block new connections to tenant db