### PR TITLE
fix: Add helper to kill all db conns to a given tenant

### DIFF
--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -308,7 +308,11 @@ defmodule Realtime.Helpers do
     end)
   end
 
-  def kill_connections_to_tenant_id(tenant_id) do
+  @doc """
+  Kills all connections to a tenant database in the current node
+  """
+  @spec kill_connections_to_tenant_id(String.t(), atom()) :: :ok
+  def kill_connections_to_tenant_id(tenant_id, reason) do
     Enum.each(Process.list(), fn pid ->
       case Process.info(pid)[:dictionary] do
         [_, "$initial_call": {:supervisor, DBConnection.ConnectionPool.Pool, _}] ->
@@ -318,7 +322,7 @@ defmodule Realtime.Helpers do
             {pid, _, Postgrex.Protocol, opts} ->
               if opts[:hostname] == "db.#{tenant_id}.supabase.co" do
                 IO.puts("Killing #{inspect(pid)}")
-                Process.exit(pid, :normal)
+                Process.exit(pid, reason)
               end
 
             _ ->

--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -308,6 +308,29 @@ defmodule Realtime.Helpers do
     end)
   end
 
+  def kill_connections_to_tenant_id(tenant_id) do
+    Enum.each(Process.list(), fn pid ->
+      case Process.info(pid)[:dictionary] do
+        [_, "$initial_call": {:supervisor, DBConnection.ConnectionPool.Pool, _}] ->
+          state = :sys.get_state(pid, 5000)
+
+          case elem(state, 11) do
+            {pid, _, Postgrex.Protocol, opts} ->
+              if opts[:hostname] == "db.#{tenant_id}.supabase.co" do
+                IO.puts("Killing #{inspect(pid)}")
+                Process.exit(pid, :normal)
+              end
+
+            _ ->
+              nil
+          end
+
+        _ ->
+          nil
+      end
+    end)
+  end
+
   defp stop_user_tenant_process(tenant, platform_region, acc) do
     Extensions.PostgresCdcRls.handle_stop(tenant, 5_000)
     # credo:disable-for-next-line

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.16",
+      version: "2.25.17",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add helper to kill all db conns to a given tenant