### PR TITLE
fix: Handle suspend / unsuspend tenants properly in Connect module

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -60,7 +60,7 @@ defmodule Realtime.Application do
         {Phoenix.PubSub, name: Realtime.PubSub, pool_size: 10},
         Realtime.GenCounter.DynamicSupervisor,
         {Cachex, name: Realtime.RateCounter},
-        Realtime.Tenants.Cache,
+        Realtime.Tenants.CacheSupervisor,
         Realtime.RateCounter.DynamicSupervisor,
         RealtimeWeb.Endpoint,
         RealtimeWeb.Presence,

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -204,7 +204,7 @@ defmodule Realtime.Tenants do
     |> Cache.get_tenant_by_external_id()
     |> Tenant.changeset(%{suspend: true})
     |> Repo.update!()
-    |> tap(fn _ -> broadcast_operation_event(:suspend, external_id) end)
+    |> tap(fn _ -> broadcast_operation_event(:suspend_tenant, external_id) end)
   end
 
   @doc """
@@ -216,10 +216,14 @@ defmodule Realtime.Tenants do
     |> Cache.get_tenant_by_external_id()
     |> Tenant.changeset(%{suspend: false})
     |> Repo.update!()
-    |> tap(fn _ -> broadcast_operation_event(:unsuspend, external_id) end)
+    |> tap(fn _ -> broadcast_operation_event(:unsuspend_tenant, external_id) end)
   end
 
   defp broadcast_operation_event(action, external_id) do
-    Phoenix.PubSub.broadcast!(Realtime.PubSub, "realtime:operations", {action, external_id})
+    Phoenix.PubSub.broadcast!(
+      Realtime.PubSub,
+      "realtime:operations:suspend_tenant",
+      {action, external_id}
+    )
   end
 end

--- a/lib/realtime/tenants/cache.ex
+++ b/lib/realtime/tenants/cache.ex
@@ -17,6 +17,10 @@ defmodule Realtime.Tenants.Cache do
 
   def get_tenant_by_external_id(keyword), do: apply_repo_fun(__ENV__.function, [keyword])
 
+  def invalidate_tenant_cache(tenant_id) do
+    Cachex.del(__MODULE__, {{:get_tenant_by_external_id, 1}, [tenant_id]})
+  end
+
   defp apply_repo_fun(arg1, arg2) do
     Realtime.ContextCache.apply_fun(Tenants, arg1, arg2)
   end

--- a/lib/realtime/tenants/cache.ex
+++ b/lib/realtime/tenants/cache.ex
@@ -2,7 +2,6 @@ defmodule Realtime.Tenants.Cache do
   @moduledoc """
   Cache for Tenants.
   """
-
   require Cachex.Spec
 
   alias Realtime.Tenants

--- a/lib/realtime/tenants/cache_pub_sub_handler.ex
+++ b/lib/realtime/tenants/cache_pub_sub_handler.ex
@@ -1,0 +1,24 @@
+defmodule Realtime.Tenants.CachePubSubHandler do
+  use GenServer
+
+  require Logger
+
+  alias Realtime.Tenants.Cache
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(topics: topics) do
+    Enum.each(topics, fn topic -> Phoenix.PubSub.subscribe(Realtime.PubSub, topic) end)
+    {:ok, []}
+  end
+
+  @impl true
+  def handle_info({_, tenant_id}, state) do
+    Logger.warn("Triggering cache invalidation", external_id: tenant_id)
+    Cache.invalidate_tenant_cache(tenant_id)
+    {:noreply, state}
+  end
+end

--- a/lib/realtime/tenants/cache_pub_sub_handler.ex
+++ b/lib/realtime/tenants/cache_pub_sub_handler.ex
@@ -1,4 +1,7 @@
 defmodule Realtime.Tenants.CachePubSubHandler do
+  @moduledoc """
+  Process that listens to PubSub messages and triggers tenant cache invalidation.
+  """
   use GenServer
 
   require Logger
@@ -16,7 +19,8 @@ defmodule Realtime.Tenants.CachePubSubHandler do
   end
 
   @impl true
-  def handle_info({_, tenant_id}, state) do
+  def handle_info({action, tenant_id}, state)
+      when action in [:suspend_tenant, :unsuspend_tenant] do
     Logger.warn("Triggering cache invalidation", external_id: tenant_id)
     Cache.invalidate_tenant_cache(tenant_id)
     {:noreply, state}

--- a/lib/realtime/tenants/cache_supervisor.ex
+++ b/lib/realtime/tenants/cache_supervisor.ex
@@ -1,7 +1,9 @@
 defmodule Realtime.Tenants.CacheSupervisor do
+  @moduledoc """
+  Supervisor for Tenants Cache and Operational processes
+  """
   use Supervisor
 
-  alias Phoenix.PubSub
   alias Realtime.Tenants.Cache
   alias Realtime.Tenants.CachePubSubHandler
 
@@ -12,15 +14,10 @@ defmodule Realtime.Tenants.CacheSupervisor do
   @impl true
   def init(_init_arg) do
     children = [
-      {CachePubSubHandler, topics: ["realtime:operations"]},
+      {CachePubSubHandler, topics: ["realtime:operations:suspend_tenant"]},
       Cache
     ]
 
     Supervisor.init(children, strategy: :one_for_one)
-  end
-
-  def handle_info({_, tenant_id}, state) do
-    Cache.invalidate_tenant_cache(tenant_id)
-    {:noreply, state}
   end
 end

--- a/lib/realtime/tenants/cache_supervisor.ex
+++ b/lib/realtime/tenants/cache_supervisor.ex
@@ -1,0 +1,26 @@
+defmodule Realtime.Tenants.CacheSupervisor do
+  use Supervisor
+
+  alias Phoenix.PubSub
+  alias Realtime.Tenants.Cache
+  alias Realtime.Tenants.CachePubSubHandler
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    children = [
+      {CachePubSubHandler, topics: ["realtime:operations"]},
+      Cache
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  def handle_info({_, tenant_id}, state) do
+    Cache.invalidate_tenant_cache(tenant_id)
+    {:noreply, state}
+  end
+end

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -132,13 +132,13 @@ defmodule Realtime.Tenants.Connect do
 
   def handle_info(:shutdown, %{db_conn_pid: db_conn_pid} = state) do
     Logger.info("Tenant has no connected users, database connection will be terminated")
-    :ok = GenServer.stop(db_conn_pid, :normal)
+    :ok = GenServer.stop(db_conn_pid, :normal, 1000)
     {:stop, :normal, state}
   end
 
   def handle_info(:suspend, %{db_conn_pid: db_conn_pid} = state) do
-    Logger.warn("Tenant was suspended, database connection will be terminated")
-    :ok = GenServer.stop(db_conn_pid, :normal)
+    Logger.warning("Tenant was suspended, database connection will be terminated")
+    :ok = GenServer.stop(db_conn_pid, :normal, 1000)
     {:stop, :normal, state}
   end
 

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -90,7 +90,13 @@ defmodule Realtime.Tenants.Connect do
         {:ok, conn} ->
           :syn.update_registry(__MODULE__, tenant_id, fn _pid, meta -> %{meta | conn: conn} end)
           state = %{state | db_conn_reference: Process.monitor(conn), db_conn_pid: conn}
-          :ok = Phoenix.PubSub.subscribe(Realtime.PubSub, "realtime:operations")
+
+          :ok =
+            Phoenix.PubSub.subscribe(
+              Realtime.PubSub,
+              "realtime:operations:suspend_tenant"
+            )
+
           {:ok, state, {:continue, :setup_connected_users}}
 
         {:error, error} ->
@@ -136,14 +142,14 @@ defmodule Realtime.Tenants.Connect do
     {:stop, :normal, state}
   end
 
-  def handle_info({:suspend, _}, %{db_conn_pid: db_conn_pid} = state) do
+  def handle_info({:suspend_tenant, _}, %{db_conn_pid: db_conn_pid} = state) do
     Logger.warning("Tenant was suspended, database connection will be terminated")
     :ok = GenServer.stop(db_conn_pid, :normal, 1000)
     {:stop, :normal, state}
   end
 
   # Ignore unsuspend messages to avoid handle_info unmatched functions
-  def handle_info({:unsuspend, _}, state) do
+  def handle_info({:unsuspend_tenant, _}, state) do
     {:noreply, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.17",
+      version: "2.25.18",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/cache_supervisor_test.exs
+++ b/test/realtime/tenants/cache_supervisor_test.exs
@@ -13,13 +13,17 @@ defmodule Realtime.Tenants.CacheSupervisorTest do
     assert %Tenant{suspend: false} = Cache.get_tenant_by_external_id(external_id)
 
     # Update a tenant
-    tenant |> Realtime.Api.Tenant.changeset(%{suspend: true}) |> Realtime.Repo.update!()
+    tenant |> Tenant.changeset(%{suspend: true}) |> Realtime.Repo.update!()
 
     # Cache showing old value
     assert %Tenant{suspend: false} = Cache.get_tenant_by_external_id(external_id)
 
     # PubSub message
-    Phoenix.PubSub.broadcast(Realtime.PubSub, "realtime:operations", {:suspend, external_id})
+    Phoenix.PubSub.broadcast(
+      Realtime.PubSub,
+      "realtime:operations:suspend_tenant",
+      {:suspend_tenant, external_id}
+    )
 
     :timer.sleep(500)
     assert %Tenant{suspend: true} = Cache.get_tenant_by_external_id(external_id)

--- a/test/realtime/tenants/cache_supervisor_test.exs
+++ b/test/realtime/tenants/cache_supervisor_test.exs
@@ -1,0 +1,27 @@
+defmodule Realtime.Tenants.CacheSupervisorTest do
+  use Realtime.DataCase, async: false
+
+  alias Realtime.Api.Tenant
+  alias Realtime.Tenants.Cache
+
+  setup do
+    %{tenant: tenant_fixture()}
+  end
+
+  test "invalidates cache on PubSub message", %{tenant: tenant} do
+    external_id = tenant.external_id
+    assert %Tenant{suspend: false} = Cache.get_tenant_by_external_id(external_id)
+
+    # Update a tenant
+    tenant |> Realtime.Api.Tenant.changeset(%{suspend: true}) |> Realtime.Repo.update!()
+
+    # Cache showing old value
+    assert %Tenant{suspend: false} = Cache.get_tenant_by_external_id(external_id)
+
+    # PubSub message
+    Phoenix.PubSub.broadcast(Realtime.PubSub, "realtime:operations", {:suspend, external_id})
+
+    :timer.sleep(500)
+    assert %Tenant{suspend: true} = Cache.get_tenant_by_external_id(external_id)
+  end
+end

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -104,5 +104,21 @@ defmodule Realtime.Tenants.ConnectTest do
 
       assert {:error, :tenant_suspended} == Connect.lookup_or_start_connection(tenant.external_id)
     end
+
+    test "handles tenant suspension and unsuspension in a reactive way" do
+      tenant = tenant_fixture()
+
+      assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
+      Realtime.Tenants.suspend_tenant_by_external_id(tenant.external_id)
+
+      :timer.sleep(1000)
+
+      assert {:error, :tenant_suspended} = Connect.lookup_or_start_connection(tenant.external_id)
+      assert Process.alive?(db_conn) == false
+
+      Realtime.Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
+      assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
+    end
   end
 end

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -112,12 +112,15 @@ defmodule Realtime.Tenants.ConnectTest do
 
       Realtime.Tenants.suspend_tenant_by_external_id(tenant.external_id)
 
-      :timer.sleep(1000)
+      :timer.sleep(100)
 
       assert {:error, :tenant_suspended} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Process.alive?(db_conn) == false
 
       Realtime.Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
+
+      :timer.sleep(100)
+
       assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
     end
   end

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -5,6 +5,7 @@ defmodule Realtime.TenantsTest do
 
   alias Realtime.GenCounter
   alias Realtime.Tenants
+  alias Realtime.Api.Tenant
 
   describe "tenants" do
     test "get_tenant_limits/1" do
@@ -40,20 +41,56 @@ defmodule Realtime.TenantsTest do
   end
 
   describe "suspend_tenant_by_external_id/1" do
-    test "sets suspend flag to true" do
+    setup do
       tenant = tenant_fixture()
-      {:ok, tenant} = Tenants.suspend_tenant_by_external_id(tenant.external_id)
+      topic = "tenant:operations:#{tenant.external_id}"
+      Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
+      %{topic: topic, tenant: tenant}
+    end
 
+    test "sets suspend flag to true and publishes message", %{tenant: tenant} do
+      tenant = Tenants.suspend_tenant_by_external_id(tenant.external_id)
       assert tenant.suspend == true
+      assert_receive :suspend
+    end
+
+    test "invalidates tenants cache", %{tenant: tenant} do
+      assert %Tenant{suspend: false} =
+               Realtime.Tenants.Cache.get_tenant_by_external_id(tenant.external_id)
+
+      Tenants.suspend_tenant_by_external_id(tenant.external_id)
+
+      assert %{suspend: true} =
+               Realtime.Tenants.Cache.get_tenant_by_external_id(tenant.external_id)
     end
   end
 
   describe "unsuspend_tenant_by_external_id/1" do
-    test "sets suspend flag to true" do
-      tenant = tenant_fixture(suspend: true)
-      {:ok, tenant} = Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
+    setup do
+      tenant = tenant_fixture()
+      topic = "tenant:operations:#{tenant.external_id}"
+      Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
+      %{topic: topic, tenant: tenant}
+    end
+
+    test "sets suspend flag to true and publishes message", %{tenant: tenant} do
+      Tenants.suspend_tenant_by_external_id(tenant.external_id)
+      tenant = Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
 
       assert tenant.suspend == false
+      assert_receive :unsuspend
+    end
+
+    test "invalidates tenants cache" do
+      tenant = tenant_fixture(suspend: true)
+
+      assert %Tenant{suspend: true} =
+               Realtime.Tenants.Cache.get_tenant_by_external_id(tenant.external_id)
+
+      Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
+
+      assert %{suspend: false} =
+               Realtime.Tenants.Cache.get_tenant_by_external_id(tenant.external_id)
     end
   end
 end

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -42,7 +42,7 @@ defmodule Realtime.TenantsTest do
   describe "suspend_tenant_by_external_id/1" do
     setup do
       tenant = tenant_fixture()
-      topic = "realtime:operations"
+      topic = "realtime:operations:suspend_tenant"
       Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
       %{topic: topic, tenant: tenant}
     end
@@ -50,23 +50,23 @@ defmodule Realtime.TenantsTest do
     test "sets suspend flag to true and publishes message", %{tenant: %{external_id: external_id}} do
       tenant = Tenants.suspend_tenant_by_external_id(external_id)
       assert tenant.suspend == true
-      assert_receive {:suspend, ^external_id}, 1000
+      assert_receive {:suspend_tenant, ^external_id}, 1000
     end
   end
 
   describe "unsuspend_tenant_by_external_id/1" do
     setup do
       tenant = tenant_fixture()
-      topic = "realtime:operations"
+      topic = "realtime:operations:suspend_tenant"
       Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
       %{topic: topic, tenant: tenant}
     end
 
-    test "sets suspend flag to true and publishes message" do
+    test "sets suspend flag to false and publishes message" do
       %{external_id: external_id} = tenant_fixture(suspend: true)
-      tenant = Tenants.suspend_tenant_by_external_id(external_id)
-      assert tenant.suspend == true
-      assert_receive {:suspend, ^external_id}, 1000
+      tenant = Tenants.unsuspend_tenant_by_external_id(external_id)
+      assert tenant.suspend == false
+      assert_receive {:unsuspend_tenant, ^external_id}, 1000
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Handles events of suspending and unsuspending tenants by:
* Broadcasting a operation message to suspend / unsuspend a tenant
* Connect receives said messages and handles them appropriately
* Invalidates Cachex for that tenant