### PR TITLE
fix: Broaden the errors that stop the Connect module

### DIFF
--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -152,8 +152,12 @@ defmodule Realtime.Helpers do
           {:ok, _} ->
             {:ok, conn}
 
-          {:error, e} ->
-            Logger.error("Error connecting to tenant database: #{inspect(e)}")
+          {:error, error} ->
+            Logger.error("Error connecting to tenant database: #{inspect(error)}")
+            {:error, :tenant_database_unavailable}
+
+          error ->
+            Logger.error("Error connecting to tenant database: #{inspect(error)}")
             {:error, :tenant_database_unavailable}
         end
       end

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -102,6 +102,10 @@ defmodule Realtime.Tenants.Connect do
         {:error, error} ->
           Logger.error("Error connecting to tenant database: #{inspect(error)}")
           {:stop, :normal}
+
+        error ->
+          Logger.error("Error connecting to tenant database: #{inspect(error)}")
+          {:stop, :normal}
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.20",
+      version: "2.25.21",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Broaden the errors that stop the Connect module
