### PR TITLE
fix: Avoid exponential connection creation

### DIFF
--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -153,6 +153,7 @@ defmodule Realtime.Helpers do
             {:ok, conn}
 
           {:error, e} ->
+            Process.exit(conn, :kill)
             Logger.error("Error connecting to tenant database: #{inspect(e)}")
             {:error, :tenant_database_unavailable}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.20",
+      version: "2.25.21",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -146,7 +146,7 @@ defmodule Realtime.Tenants.ConnectTest do
           ]
         })
 
-      Enum.each(1..1000, fn _ ->
+      Enum.each(1..10, fn _ ->
         Task.start(fn -> Connect.lookup_or_start_connection(tenant.external_id) end)
       end)
 

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -123,5 +123,65 @@ defmodule Realtime.Tenants.ConnectTest do
 
       assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
     end
+
+    test "properly handles of failing calls by avoid creating too many connections" do
+      tenant =
+        tenant_fixture(%{
+          extensions: [
+            %{
+              "type" => "postgres_cdc_rls",
+              "settings" => %{
+                "db_host" => "localhost",
+                "db_name" => "postgres",
+                "db_user" => "postgres",
+                "db_password" => "postgres",
+                "db_port" => "5432",
+                "poll_interval" => 100,
+                "poll_max_changes" => 100,
+                "poll_max_record_bytes" => 1_048_576,
+                "region" => "us-east-1",
+                "ssl_enforced" => true
+              }
+            }
+          ]
+        })
+
+      Enum.each(1..1000, fn _ ->
+        Task.start(fn -> Connect.lookup_or_start_connection(tenant.external_id) end)
+      end)
+
+      send(check_db_connections_created(self(), tenant.external_id), :check)
+      :timer.sleep(4000)
+      refute_receive :too_many_connections
+    end
+  end
+
+  defp check_db_connections_created(test_pid, tenant_id) do
+    spawn(fn ->
+      receive do
+        :check ->
+          Process.list()
+          |> Enum.map(&Process.info/1)
+          |> Enum.reject(fn info -> is_nil(info) end)
+          |> Enum.map(fn info -> Keyword.get(info, :dictionary, []) end)
+          |> Enum.map(fn dict ->
+            {Keyword.get(dict, :"$logger_metadata$", %{}),
+             Keyword.get(dict, :"$initial_call", {})}
+          end)
+          |> Enum.reject(fn {metadata, _} -> Map.get(metadata, :external_id) != tenant_id end)
+          |> Enum.filter(fn {_, init} -> init == {DBConnection.Connection, :init, 1} end)
+          |> Enum.count()
+          |> then(fn count ->
+            if count > 1,
+              do: send(test_pid, :too_many_connections),
+              else:
+                Process.send_after(
+                  check_db_connections_created(test_pid, tenant_id),
+                  :check,
+                  100
+                )
+          end)
+      end
+    end)
   end
 end

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -147,7 +147,9 @@ defmodule Realtime.Tenants.ConnectTest do
         })
 
       Enum.each(1..10, fn _ ->
-        Task.start(fn -> Connect.lookup_or_start_connection(tenant.external_id) end)
+        Task.start(fn ->
+          Connect.lookup_or_start_connection(tenant.external_id, erpc_timeout: 10000)
+        end)
       end)
 
       send(check_db_connections_created(self(), tenant.external_id), :check)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Due to the way we were creating connections we kept a lot of Db Connections working that would keep retrying increasing the number of connections per tenant whenever one call would fail.

We now kill the Postgrex pid if we fail to query the database.