### PR TITLE
fix: Reduce code for ecto schema loading

### DIFF
--- a/lib/realtime/repo.ex
+++ b/lib/realtime/repo.ex
@@ -20,14 +20,8 @@ defmodule Realtime.Repo do
   Converts a Postgrex.Result into a given struct
   """
   @spec pg_result_to_struct(Postgrex.Result.t(), module()) :: [struct()]
-  def pg_result_to_struct(%Postgrex.Result{rows: rows, columns: columns}, struct) do
-    Enum.map(rows, fn row ->
-      columns
-      |> Enum.zip(row)
-      |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), v} end)
-      |> Map.new()
-      |> then(&struct(struct, &1))
-    end)
+  def pg_result_to_struct(%Postgrex.Result{rows: rows, columns: columns} = res, struct) do
+    Enum.map(rows, &Realtime.Repo.load(struct, Enum.zip(columns, &1)))
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.25",
+      version: "2.25.26",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -148,16 +148,35 @@ defmodule Realtime.RepoTest do
 
   describe "pg_result_to_struct/2" do
     test "converts Postgrex.Result to struct" do
-      timestamp = NaiveDateTime.utc_now()
+      timestamp = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
 
       result = %Postgrex.Result{
         columns: ["id", "name", "updated_at", "inserted_at"],
         rows: [[1, "foo", timestamp, timestamp], [2, "bar", timestamp, timestamp]]
       }
 
+      metadata = %Ecto.Schema.Metadata{
+        prefix: Channel.__schema__(:prefix),
+        schema: Channel,
+        source: Channel.__schema__(:source),
+        state: :loaded
+      }
+
       expected = [
-        %Channel{id: 1, name: "foo", updated_at: timestamp, inserted_at: timestamp},
-        %Channel{id: 2, name: "bar", updated_at: timestamp, inserted_at: timestamp}
+        %Channel{
+          __meta__: metadata,
+          id: 1,
+          name: "foo",
+          updated_at: timestamp,
+          inserted_at: timestamp
+        },
+        %Channel{
+          __meta__: metadata,
+          id: 2,
+          name: "bar",
+          updated_at: timestamp,
+          inserted_at: timestamp
+        }
       ]
 
       assert Repo.pg_result_to_struct(result, Channel) == expected


### PR DESCRIPTION
## What kind of change does this PR introduce?

Using the Repo loader to reduce the code loaded and to properly set the metadata of the created struct
