### PR TITLE
fix: Improving Migrations error handling

### DIFF
--- a/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
+++ b/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
@@ -47,6 +47,6 @@ defmodule Extensions.PostgresCdcRls.WorkerSupervisor do
       }
     ]
 
-    Supervisor.init(children, strategy: :one_for_all, max_restarts: 10, max_seconds: 60)
+    Supervisor.init(children, strategy: :rest_for_one, max_restarts: 10, max_seconds: 60)
   end
 end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -127,7 +127,11 @@ defmodule Realtime.Tenants.Migrations do
       password: pass,
       username: user,
       pool_size: 2,
-      socket_options: db_socket_opts
+      socket_options: db_socket_opts,
+      parameters: [
+        application_name: "realtime_migrations"
+      ],
+      backoff_type: :stop
     ]
     |> H.maybe_enforce_ssl_config(ssl_enforced)
     |> Repo.with_dynamic_repo(fn repo ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.26",
+      version: "2.25.27",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Switched migration to be rest_for_all to avoid migrations from restarting constantly
* Added application_name to migrations to easily debug issues
* Changed backoff strategy on Migrations which will avoid exponential backoff and kill pid on fail