### PR TITLE
fix: Change backoff type to stop connection

### DIFF
--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -105,6 +105,7 @@ defmodule Realtime.Helpers do
         application_name: application_name
       ],
       socket_options: socket_opts,
+      backoff_type: :stop,
       configure: fn args ->
         Logger.metadata(metadata)
         args

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -130,7 +130,8 @@ defmodule Realtime.Tenants.Migrations do
       socket_options: db_socket_opts,
       parameters: [
         application_name: "realtime_migrations"
-      ]
+      ],
+      backoff_type: :stop
     ]
     |> H.maybe_enforce_ssl_config(ssl_enforced)
     |> Repo.with_dynamic_repo(fn repo ->

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -130,8 +130,7 @@ defmodule Realtime.Tenants.Migrations do
       socket_options: db_socket_opts,
       parameters: [
         application_name: "realtime_migrations"
-      ],
-      backoff_type: :stop
+      ]
     ]
     |> H.maybe_enforce_ssl_config(ssl_enforced)
     |> Repo.with_dynamic_repo(fn repo ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.29",
+      version: "2.25.30",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

DBConnection seems to not properly link to parent process.

As such, when a parent process dies, the DBConnection pool will be kept alive and keeps retrying to connect potentially creating a big issues of pending processes that keep accumulating.

This change will change the backoff strategy to `:stop` and let the parent process do the retrying
