### PR TITLE
fix: terminate zombie migration runners

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.33",
+      version: "2.25.34",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
While applying migrations to a tenant's database, I observed that `Ecto.Migration.Runner` does not stop when encountering errors. Upon brief inspection, I noticed that the `Ecto.Migrator` only [stops](https://github.com/elixir-ecto/ecto_sql/blob/30c2cbabef78d3fd5647475b6e6c840252571495/lib/ecto/migration/runner.ex#L28) the Agent if the migration succeeds. In the case of an error, the Migrator [catches](https://github.com/elixir-ecto/ecto_sql/blob/30c2cbabef78d3fd5647475b6e6c840252571495/lib/ecto/migrator.ex#L358-L361) it and exits with a `normal` reason, which does not lead to the termination of the [linked](https://github.com/elixir-ecto/ecto_sql/blob/30c2cbabef78d3fd5647475b6e6c840252571495/lib/ecto/migration/runner.ex#L44) Runner process. As a result, this leads to memory leaks when Realtime continuously attempts to run migrations that encounter errors

As a quick solution from our side, we could stop all runners that are linked only to `MigratorSupervisor` after a failure. Normally, they also have a link to the Migrator that initiated them



https://github.com/supabase/realtime/assets/1172600/c6e3c202-a9f7-42a2-b2e7-05e9cc4c3bf6

