### PR TITLE
fix: override `max_header_value_length` using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ TAILSCALE_APP_NAME         # {string}      Name of the Tailscale app.
 TAILSCALE_AUTHKEY          # {string}      Auth key for the Tailscape app.
 DNS_NODES                  # {string}      Node name used when running server in a cluster.
 MAX_CONNECTIONS            # {string}     Set the soft maximum for WebSocket connections. Defaults to '16384'.
+MAX_HEADER_LENGTH          # {string}      Set the maximum header length for connections (in bytes). Defaults to '4096'.
 NUM_ACCEPTORS              # {string}     Set the number of server processes that will relay incoming WebSocket connection requests. Defaults to '100'.
 DB_QUEUE_TARGET            # {string}     Maximum time to wait for a connection from the pool. Defaults to '5000' or 5 seconds. See for more info: https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config.
 DB_QUEUE_INTERVAL          # {string}     Interval to wait to check if all connections were checked out under DB_QUEUE_TARGET. If all connections surpassed the target during this interval than the target is doubled. Defaults to '5000' or 5 seconds. See for more info: https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,6 +28,9 @@ if config_env() == :prod do
     url: [host: "#{app_name}.fly.dev", port: 80],
     http: [
       port: String.to_integer(System.get_env("PORT") || "4000"),
+      protocol_options: [
+        max_header_value_length: String.to_integer(System.get_env("MAX_HEADER_LENGTH") || "4096")
+      ],
       transport_options: [
         # max_connection is per connection supervisor
         # num_conns_sups defaults to num_acceptors

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.43",
+      version: "2.25.50",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for https://github.com/supabase/realtime/issues/761:
- introduces a new environment variable `MAX_HEADER_LENGTH` that can be used to override config -> http -> protocol_options -> max_header_value_length from its default value in Elixr (4096)
- If no value is set, the Elixr default of 4096 will continue to be used
- updates README to reflect these changes

## What is the current behavior?

With SSR and the use of cookies to authenticate on the server, all cookies need to be sent to Supabase requests, including Realtime. If these cookies exceed the (rather low) default of 4096 (which, with an auth provider for supabase, can happen extremely easily), realtime subscriptions fail with a 431 error. 

Edit: we are using Keycloak as our Supabase authentication provider, and it looks like Keycloak is a bit notorious for large cookies (see https://github.com/supabase/realtime/issues/761#issuecomment-1863507257). Hence the further need to increase the limit, but in a dynamic fashion (for users who wish to retain the security benefits of smaller limits and don't use Keycloak or other services with larger cookies).

## What is the new behavior?

With the new behavior, a user could specify a `MAX_HEADER_LENGTH` environment variable to a higher value (such as `8192`, doubling the limit) to cease the 431 errors.

## Additional context

See https://github.com/supabase/realtime/issues/761

Edit: I test-built with these changes locally and it 100% fixed the issue.