### PR TITLE
fix: Check rate limits before checking connection

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -45,11 +45,11 @@ defmodule RealtimeWeb.RealtimeChannel do
     start_db_rate_counter(tenant)
 
     with false <- SignalHandler.shutdown_in_progress?(),
-         {:ok, _} <- Connect.lookup_or_start_connection(tenant),
          :ok <- limit_joins(socket),
          :ok <- limit_channels(socket),
          :ok <- limit_max_users(socket),
          {:ok, claims, confirm_token_ref} <- confirm_token(socket),
+         {:ok, _} <- Connect.lookup_or_start_connection(tenant),
          is_new_api <- is_new_api(params) do
       Realtime.UsersCounter.add(transport_pid, tenant)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.46",
+      version: "2.25.47",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

We should check the rate limits of the user before doing the more demanding check on Connection status.