### PR TITLE
fix: calls fetch_publication_tables on init

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscription_manager.ex
+++ b/lib/extensions/postgres_cdc_rls/subscription_manager.ex
@@ -102,11 +102,14 @@ defmodule Extensions.PostgresCdcRls.SubscriptionManager do
     {:ok, _} = Subscriptions.maybe_delete_all(conn)
     Rls.update_meta(id, self(), conn_pub)
 
+    oids = Subscriptions.fetch_publication_tables(conn, publication)
+
     state = %State{
       id: id,
       conn: conn,
       publication: publication,
       subscribers_tid: subscribers_tid,
+      oids: oids,
       delete_queue: %{
         ref: check_delete_queue(),
         queue: :queue.new()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.50",
+      version: "2.25.51",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This does two things:
- [x] keeps the SubscriptionManager from calling postgres_subscribe again after a client first connects. Because the SubscriptionManager doesn't have the state of the publication tables on init it always resubscribes the client on connect doubling that work (RPCs and tenant db calls to Subscription.create)
- [x] keeps the SubscriptionManager from calling postgres_subscribe on ALL clients if it crashes. Because it doesn't get the state of the publication tables on init if it crashes it hits the path of postgres_subscribe effectively resubscribing all clients on a crash. If the tenant has a lot of clients connected this can cause issues.