### PR TITLE
fix: Add write checks to channels

### DIFF
--- a/lib/realtime/api/channel.ex
+++ b/lib/realtime/api/channel.ex
@@ -11,15 +11,22 @@ defmodule Realtime.Api.Channel do
   @schema_prefix "realtime"
   schema "channels" do
     field(:name, :string)
+    field(:check, :boolean, default: false)
     timestamps()
   end
 
   def changeset(channel, attrs) do
     channel
-    |> cast(attrs, [:name, :inserted_at, :updated_at])
+    |> cast(attrs, [:name, :check, :inserted_at, :updated_at])
     |> validate_required([:name])
     |> put_timestamp(:updated_at)
     |> maybe_put_timestamp(:inserted_at)
+  end
+
+  def check_changeset(channel, attrs) do
+    channel
+    |> change()
+    |> put_change(:check, attrs[:check])
   end
 
   defp put_timestamp(changeset, field) do

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -43,7 +43,9 @@ defmodule Realtime.Tenants.Migrations do
     CreateChannels,
     SetRequiredGrants,
     CreateRlsHelperFunctions,
-    EnableChannelsRls
+    EnableChannelsRls,
+    AddChannelsColumnForWriteCheck,
+    AddUpdateGrantToChannels
   }
 
   alias Realtime.Helpers, as: H
@@ -83,7 +85,9 @@ defmodule Realtime.Tenants.Migrations do
     {20_231_018_144_023, CreateChannels},
     {20_231_204_144_023, SetRequiredGrants},
     {20_231_204_144_024, CreateRlsHelperFunctions},
-    {20_231_204_144_025, EnableChannelsRls}
+    {20_231_204_144_025, EnableChannelsRls},
+    {20_240_108_234_812, AddChannelsColumnForWriteCheck},
+    {20_240_109_165_339, AddUpdateGrantToChannels}
   ]
 
   @spec start_link(GenServer.options()) :: GenServer.on_start()

--- a/lib/realtime/tenants/repo/migrations/20240108234812_add_channels_column_for_write_check.ex
+++ b/lib/realtime/tenants/repo/migrations/20240108234812_add_channels_column_for_write_check.ex
@@ -1,0 +1,11 @@
+defmodule Realtime.Tenants.Migrations.AddChannelsColumnForWriteCheck do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:channels, prefix: "realtime") do
+      add :check, :boolean, default: false
+    end
+  end
+end

--- a/lib/realtime/tenants/repo/migrations/20240109165339_add_update_grant_to_channels.ex
+++ b/lib/realtime/tenants/repo/migrations/20240109165339_add_update_grant_to_channels.ex
@@ -1,0 +1,11 @@
+defmodule Realtime.Tenants.Migrations.AddUpdateGrantToChannels do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    GRANT UPDATE ON realtime.channels TO postgres, anon, authenticated, service_role
+    """)
+  end
+end

--- a/lib/realtime_web/plugs/rls_authorization.ex
+++ b/lib/realtime_web/plugs/rls_authorization.ex
@@ -21,7 +21,7 @@ defmodule RealtimeWeb.RlsAuthorization do
     }
 
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id),
-         params <- set_channel_name_for_authorization_check(conn, db_conn, params),
+         params <- set_channel_params_for_authorization_check(conn, db_conn, params),
          params <- Authorization.build_authorization_params(params),
          {:ok, conn} <- Authorization.get_authorizations(conn, db_conn, params) do
       conn
@@ -34,12 +34,13 @@ defmodule RealtimeWeb.RlsAuthorization do
 
   def call(conn, _opts), do: unauthorized(conn) |> halt()
 
-  defp set_channel_name_for_authorization_check(%{path_params: path_params}, db_conn, params) do
+  defp set_channel_params_for_authorization_check(%{path_params: path_params}, db_conn, params) do
     with {:ok, id} <- Map.fetch(path_params, "id"),
-         {:ok, %{name: name}} <- Channels.get_channel_by_id(id, db_conn) do
-      Map.put(params, :channel_name, name)
+         {:ok, channel} <- Channels.get_channel_by_id(id, db_conn) do
+      Map.put(params, :channel, channel)
     else
-      _ -> Map.put(params, :channel_name, nil)
+      _ ->
+        Map.put(params, :channel, nil)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.55",
+      version: "2.25.56",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -142,6 +142,11 @@ defmodule Realtime.RepoTest do
       assert {:ok, [^channel_1, ^channel_2] = res} = Repo.all(conn, Channel, Channel)
       assert Enum.all?(res, &(Ecto.get_meta(&1, :state) == :loaded))
     end
+
+    test "handles exceptions", %{conn: conn} do
+      Process.exit(conn, :kill)
+      assert {:error, :postgrex_exception} = Repo.all(conn, from(c in Channel), Channel)
+    end
   end
 
   describe "one/3" do
@@ -166,6 +171,12 @@ defmodule Realtime.RepoTest do
       query = from c in Channel, where: c.name == "potato"
       assert {:error, :not_found} = Repo.one(conn, query, Channel)
     end
+
+    test "handles exceptions", %{conn: conn} do
+      Process.exit(conn, :kill)
+      query = from c in Channel, where: c.name == "potato"
+      assert {:error, :postgrex_exception} = Repo.one(conn, query, Channel)
+    end
   end
 
   describe "insert/3" do
@@ -185,6 +196,12 @@ defmodule Realtime.RepoTest do
       assert {:ok, _} = Repo.insert(conn, changeset, Channel)
       assert {:error, _} = Repo.insert(conn, changeset, Channel)
     end
+
+    test "handles exceptions", %{conn: conn} do
+      Process.exit(conn, :kill)
+      changeset = Channel.changeset(%Channel{}, %{name: "foo"})
+      assert {:error, :postgrex_exception} = Repo.insert(conn, changeset, Channel)
+    end
   end
 
   describe "del/3" do
@@ -200,6 +217,11 @@ defmodule Realtime.RepoTest do
       assert_raise Ecto.QueryError, fn ->
         Repo.del(conn, query)
       end
+    end
+
+    test "handles exceptions", %{conn: conn} do
+      Process.exit(conn, :kill)
+      assert {:error, :postgrex_exception} = Repo.del(conn, Channel)
     end
   end
 
@@ -226,6 +248,12 @@ defmodule Realtime.RepoTest do
 
       changeset = Channel.changeset(channel_to_update, %{name: channel.name})
       assert {:error, _} = Repo.update(conn, changeset, Channel)
+    end
+
+    test "handles exceptions", %{tenant: tenant, conn: conn} do
+      changeset = Channel.changeset(channel_fixture(tenant), %{name: "foo"})
+      Process.exit(conn, :kill)
+      assert {:error, :postgrex_exception} = Repo.update(conn, changeset, Channel)
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -75,10 +75,10 @@ defmodule Realtime.DataCase do
     Postgrex.query!(
       conn,
       """
-      create policy select_authenticated_role
-      on realtime.channels for select
-      to authenticated
-      using ( realtime.channel_name() = '#{name}' );
+      CREATE POLICY select_authenticated_role
+      ON realtime.channels FOR SELECT
+      TO authenticated
+      USING ( realtime.channel_name() = '#{name}' )
       """,
       []
     )
@@ -88,10 +88,26 @@ defmodule Realtime.DataCase do
     Postgrex.query!(
       conn,
       """
-      create policy select_authenticated_role
-      on realtime.channels for select
-      to authenticated
-      using ( true );
+      CREATE POLICY select_authenticated_role
+      ON realtime.channels FOR SELECT
+      TO authenticated
+      USING ( true )
+      """,
+      []
+    )
+  end
+
+  def create_rls_policy(conn, :write_authenticated_role, %{name: name} = channel) do
+    create_rls_policy(conn, :select_authenticated_role_on_channel_name, channel)
+
+    Postgrex.query!(
+      conn,
+      """
+      CREATE POLICY write_authenticated_role
+      ON realtime.channels FOR UPDATE
+      TO authenticated
+      USING ( realtime.channel_name() = '#{name}' )
+      WITH CHECK ( realtime.channel_name() = '#{name}' )
       """,
       []
     )


### PR DESCRIPTION
Add write permissions checks for the Authorization modules.

It checks if a given user can write by trying to updating a column in the channels table. After done, reverts the change within the same transaction.

Also took the time to refactor a bit the code to use some helper functions previously built in the Repo module to avoid bare sql code and have a more structured approach.
