### PR TITLE
fix: Move methods to a Tenant Repo

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -50,6 +50,8 @@ defmodule Realtime.Application do
     region = Application.get_env(:realtime, :region)
     :syn.join(RegionNodes, region, self(), node: node())
 
+    :ets.new(Realtime.Tenants.TenantRepo, [:named_table, :set, :public, read_concurrency: true])
+
     children =
       [
         Realtime.ErlSysMon,

--- a/lib/realtime/channels.ex
+++ b/lib/realtime/channels.ex
@@ -4,7 +4,7 @@ defmodule Realtime.Channels do
   """
 
   alias Realtime.Api.Channel
-  alias Realtime.Repo
+  alias Realtime.Tenants.TenantRepo
 
   import Ecto.Query
 
@@ -13,7 +13,7 @@ defmodule Realtime.Channels do
   """
   @spec list_channels(DBConnection.conn()) :: {:error, any()} | {:ok, [struct()]}
   def list_channels(conn) do
-    Repo.all(conn, Channel, Channel)
+    TenantRepo.all(conn, Channel, Channel)
   end
 
   @doc """
@@ -22,7 +22,7 @@ defmodule Realtime.Channels do
   @spec get_channel_by_id(binary(), DBConnection.conn()) :: {:ok, Channel.t()} | {:error, any()}
   def get_channel_by_id(id, conn) do
     query = from c in Channel, where: c.id == ^id
-    Repo.one(conn, query, Channel)
+    TenantRepo.one(conn, query, Channel)
   end
 
   @doc """
@@ -32,7 +32,7 @@ defmodule Realtime.Channels do
   def create_channel(attrs, conn) do
     channel = Channel.changeset(%Channel{}, attrs)
 
-    Repo.insert(conn, channel, Channel)
+    TenantRepo.insert(conn, channel, Channel)
   end
 
   @doc """
@@ -42,7 +42,7 @@ defmodule Realtime.Channels do
           {:ok, Channel.t()} | {:error, any()}
   def get_channel_by_name(name, conn) do
     query = from c in Channel, where: c.name == ^name
-    Repo.one(conn, query, Channel)
+    TenantRepo.one(conn, query, Channel)
   end
 
   @doc """
@@ -53,7 +53,7 @@ defmodule Realtime.Channels do
   def delete_channel_by_id(id, conn) do
     query = from c in Channel, where: c.id == ^id
 
-    with {:ok, 1} <- Repo.del(conn, query) do
+    with {:ok, 1} <- TenantRepo.del(conn, query) do
       :ok
     else
       {:ok, 0} -> {:error, :not_found}
@@ -69,7 +69,7 @@ defmodule Realtime.Channels do
   def update_channel_by_id(id, attrs, conn) do
     with {:ok, channel} when not is_nil(channel) <- get_channel_by_id(id, conn) do
       channel = Channel.changeset(channel, attrs)
-      Repo.update(conn, channel, Channel)
+      TenantRepo.update(conn, channel, Channel)
     end
   end
 end

--- a/lib/realtime/repo.ex
+++ b/lib/realtime/repo.ex
@@ -1,11 +1,7 @@
 defmodule Realtime.Repo do
-  require Logger
-
   use Ecto.Repo,
     otp_app: :realtime,
     adapter: Ecto.Adapters.Postgres
-
-  import Ecto.Query
 
   def with_dynamic_repo(config, callback) do
     default_dynamic_repo = get_dynamic_repo()
@@ -16,144 +12,7 @@ defmodule Realtime.Repo do
       callback.(repo)
     after
       put_dynamic_repo(default_dynamic_repo)
-      Supervisor.stop(repo)
+    Supervisor.stop(repo)
     end
-  end
-
-  @doc """
-  Lists all records for a given query and converts them into a given struct
-  """
-  @spec all(DBConnection.conn(), Ecto.Queryable.t(), module(), [Postgrex.execute_option()]) ::
-          {:ok, list(struct())} | {:error, any()}
-  def all(conn, query, result_struct, opts \\ []) do
-    conn
-    |> run_all_query(query, opts)
-    |> result_to_structs(result_struct)
-  end
-
-  @doc """
-  Fetches one record for a given query and converts it into a given struct
-  """
-  @spec one(DBConnection.conn(), Ecto.Query.t(), module()) ::
-          {:ok, struct()} | {:ok, nil} | {:error, any()}
-  def one(conn, query, result_struct) do
-    conn
-    |> run_all_query(query)
-    |> result_to_single_struct(result_struct)
-  end
-
-  @doc """
-  Inserts a given changeset into the database and converts the result into a given struct
-  """
-  @spec insert(DBConnection.conn(), Ecto.Changeset.t(), module()) ::
-          {:ok, struct()} | {:error, any()} | Ecto.Changeset.t()
-  def insert(conn, changeset, result_struct) do
-    with {:ok, {query, args}} <- insert_query_from_changeset(changeset) do
-      conn
-      |> run_query_with_trap(query, args)
-      |> result_to_single_struct(result_struct)
-    end
-  end
-
-  @doc """
-  Deletes records for a given query and returns the number of deleted records
-  """
-  @spec del(DBConnection.conn(), Ecto.Queryable.t()) ::
-          {:ok, non_neg_integer()} | {:error, any()}
-  def del(conn, query) do
-    with {:ok, %Postgrex.Result{num_rows: num_rows}} <- run_delete_query(conn, query) do
-      {:ok, num_rows}
-    end
-  end
-
-  @doc """
-  Updates an entry based on the changeset and returns the updated entry
-  """
-  @spec update(DBConnection.conn(), Ecto.Changeset.t(), module()) ::
-          {:ok, struct()} | {:error, any()} | Ecto.Changeset.t()
-  def update(conn, changeset, result_struct, opts \\ []) do
-    with {:ok, {query, args}} <- update_query_from_changeset(changeset) do
-      conn
-      |> run_query_with_trap(query, args, opts)
-      |> result_to_single_struct(result_struct)
-    end
-  end
-
-  defp result_to_single_struct({:error, _} = error, _), do: error
-
-  defp result_to_single_struct({:ok, %Postgrex.Result{rows: []}}, _), do: {:error, :not_found}
-
-  defp result_to_single_struct({:ok, %Postgrex.Result{rows: [row], columns: columns}}, struct) do
-    {:ok, load(struct, Enum.zip(columns, row))}
-  end
-
-  defp result_to_single_struct({:ok, %Postgrex.Result{num_rows: num_rows}}, _) do
-    raise("expected at most one result but got #{num_rows} in result")
-  end
-
-  defp result_to_structs({:error, _} = error, _), do: error
-
-  defp result_to_structs({:ok, %Postgrex.Result{rows: rows, columns: columns}}, struct) do
-    {:ok, Enum.map(rows, &load(struct, Enum.zip(columns, &1)))}
-  end
-
-  defp insert_query_from_changeset(%{valid?: false} = changeset), do: {:error, changeset}
-
-  defp insert_query_from_changeset(changeset) do
-    schema = changeset.data.__struct__
-    source = schema.__schema__(:source)
-    prefix = schema.__schema__(:prefix)
-    acc = %{header: [], rows: []}
-
-    %{header: header, rows: rows} =
-      Enum.reduce(changeset.changes, acc, fn {field, row}, %{header: header, rows: rows} ->
-        %{
-          header: [Atom.to_string(field) | header],
-          rows: [row | rows]
-        }
-      end)
-
-    table = "\"#{prefix}\".\"#{source}\""
-    header = "(#{header |> Enum.map(&"\"#{&1}\"") |> Enum.join(",")})"
-
-    arg_index =
-      rows
-      |> Enum.with_index(1)
-      |> Enum.map(fn {_, index} -> "$#{index}" end)
-      |> Enum.join(",")
-
-    {:ok, {"INSERT INTO #{table} #{header} VALUES (#{arg_index}) RETURNING *", rows}}
-  end
-
-  defp update_query_from_changeset(%{valid?: false} = changeset), do: {:error, changeset}
-
-  defp update_query_from_changeset(changeset) do
-    %Ecto.Changeset{data: %{id: id, __struct__: struct}, changes: changes} = changeset
-    changes = Keyword.new(changes)
-    query = from(c in struct, where: c.id == ^id, select: c, update: [set: ^changes])
-    {:ok, to_sql(:update_all, query)}
-  end
-
-  defp run_all_query(conn, query, opts \\ []) do
-    {query, args} = to_sql(:all, query)
-    run_query_with_trap(conn, query, args, opts)
-  end
-
-  defp run_delete_query(conn, query) do
-    {query, args} = to_sql(:delete_all, query)
-    run_query_with_trap(conn, query, args)
-  end
-
-  defp run_query_with_trap(conn, query, args, opts \\ []) do
-    Postgrex.query(conn, query, args, opts)
-  rescue
-    exception ->
-      Logger.error("Postgrex exception: #{inspect(exception)}")
-      {:error, :postgrex_exception}
-  catch
-    :exit, reason ->
-      Logger.error("Postgrex exit: #{inspect(reason)}")
-
-      {:error, :postgrex_exception}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.56",
+      version: "2.25.57",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -1,9 +1,6 @@
 defmodule Realtime.RepoTest do
   use Realtime.DataCase, async: false
 
-  import Ecto.Query
-
-  alias Realtime.Api.Channel
   alias Realtime.Repo
   alias Realtime.Tenants.Connect
   alias Realtime.Tenants.Migrations
@@ -131,129 +128,6 @@ defmodule Realtime.RepoTest do
       assert Process.alive?(repo_pid) == true
       :timer.sleep(300)
       assert Process.alive?(repo_pid) == false
-    end
-  end
-
-  describe "all/3" do
-    test "fetches multiple entries and loads a given struct", %{conn: conn, tenant: tenant} do
-      channel_1 = channel_fixture(tenant)
-      channel_2 = channel_fixture(tenant)
-
-      assert {:ok, [^channel_1, ^channel_2] = res} = Repo.all(conn, Channel, Channel)
-      assert Enum.all?(res, &(Ecto.get_meta(&1, :state) == :loaded))
-    end
-
-    test "handles exceptions", %{conn: conn} do
-      Process.exit(conn, :kill)
-      assert {:error, :postgrex_exception} = Repo.all(conn, from(c in Channel), Channel)
-    end
-  end
-
-  describe "one/3" do
-    test "fetches one entry and loads a given struct", %{conn: conn, tenant: tenant} do
-      channel_1 = channel_fixture(tenant)
-      _channel_2 = channel_fixture(tenant)
-      query = from c in Channel, where: c.id == ^channel_1.id
-      assert {:ok, ^channel_1} = Repo.one(conn, query, Channel)
-      assert Ecto.get_meta(channel_1, :state) == :loaded
-    end
-
-    test "raises exception on multiple results", %{conn: conn, tenant: tenant} do
-      _channel_1 = channel_fixture(tenant)
-      _channel_2 = channel_fixture(tenant)
-
-      assert_raise RuntimeError, "expected at most one result but got 2 in result", fn ->
-        Repo.one(conn, Channel, Channel)
-      end
-    end
-
-    test "if not found, returns not found error", %{conn: conn} do
-      query = from c in Channel, where: c.name == "potato"
-      assert {:error, :not_found} = Repo.one(conn, query, Channel)
-    end
-
-    test "handles exceptions", %{conn: conn} do
-      Process.exit(conn, :kill)
-      query = from c in Channel, where: c.name == "potato"
-      assert {:error, :postgrex_exception} = Repo.one(conn, query, Channel)
-    end
-  end
-
-  describe "insert/3" do
-    test "inserts a new entry with a given changeset and returns struct", %{conn: conn} do
-      changeset = Channel.changeset(%Channel{}, %{name: "foo"})
-      assert {:ok, %Channel{}} = Repo.insert(conn, changeset, Channel)
-    end
-
-    test "returns changeset if changeset is invalid", %{conn: conn} do
-      changeset = Channel.changeset(%Channel{}, %{})
-      res = Repo.insert(conn, changeset, Channel)
-      assert {:error, %Ecto.Changeset{valid?: false}} = res
-    end
-
-    test "returns an error on Postgrex error", %{conn: conn} do
-      changeset = Channel.changeset(%Channel{}, %{name: "foo"})
-      assert {:ok, _} = Repo.insert(conn, changeset, Channel)
-      assert {:error, _} = Repo.insert(conn, changeset, Channel)
-    end
-
-    test "handles exceptions", %{conn: conn} do
-      Process.exit(conn, :kill)
-      changeset = Channel.changeset(%Channel{}, %{name: "foo"})
-      assert {:error, :postgrex_exception} = Repo.insert(conn, changeset, Channel)
-    end
-  end
-
-  describe "del/3" do
-    test "deletes all from query entry", %{conn: conn, tenant: tenant} do
-      Stream.repeatedly(fn -> channel_fixture(tenant) end) |> Enum.take(3)
-      assert {:ok, 3} = Repo.del(conn, Channel)
-    end
-
-    test "raises error on bad queries", %{conn: conn} do
-      # wrong id type
-      query = from c in Channel, where: c.id == "potato"
-
-      assert_raise Ecto.QueryError, fn ->
-        Repo.del(conn, query)
-      end
-    end
-
-    test "handles exceptions", %{conn: conn} do
-      Process.exit(conn, :kill)
-      assert {:error, :postgrex_exception} = Repo.del(conn, Channel)
-    end
-  end
-
-  describe "update/3" do
-    test "updates a new entry with a given changeset and returns struct", %{
-      conn: conn,
-      tenant: tenant
-    } do
-      channel = channel_fixture(tenant)
-      changeset = Channel.changeset(channel, %{name: "foo"})
-      assert {:ok, %Channel{}} = Repo.update(conn, changeset, Channel)
-    end
-
-    test "returns changeset if changeset is invalid", %{conn: conn, tenant: tenant} do
-      channel = channel_fixture(tenant)
-      changeset = Channel.changeset(channel, %{name: 0})
-      res = Repo.update(conn, changeset, Channel)
-      assert {:error, %Ecto.Changeset{valid?: false}} = res
-    end
-
-    test "returns an error on Postgrex error", %{conn: conn, tenant: tenant} do
-      channel = channel_fixture(tenant)
-      channel_to_update = channel_fixture(tenant)
-
-      changeset = Channel.changeset(channel_to_update, %{name: channel.name})
-      assert {:error, _} = Repo.update(conn, changeset, Channel)
-    end
-
-    test "handles exceptions", %{tenant: tenant, conn: conn} do
-      changeset = Channel.changeset(channel_fixture(tenant), %{name: "foo"})
-      Process.exit(conn, :kill)
-      assert {:error, :postgrex_exception} = Repo.update(conn, changeset, Channel)
     end
   end
 

--- a/test/realtime/tenants/tenant_repo_test.exs
+++ b/test/realtime/tenants/tenant_repo_test.exs
@@ -1,0 +1,148 @@
+defmodule Realtime.Tenants.TenantRepoTest do
+  use Realtime.DataCase, async: false
+  import Ecto.Query
+
+  alias Realtime.Api.Channel
+
+  alias Realtime.Tenants.Connect
+  alias Realtime.Tenants.Migrations
+  alias Realtime.Tenants.TenantRepo
+
+  @cdc "postgres_cdc_rls"
+
+  setup do
+    tenant = tenant_fixture()
+    {:ok, conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
+    settings = Realtime.PostgresCdc.filter_settings(@cdc, tenant.extensions)
+    settings = Map.put(settings, "id", tenant.external_id)
+    settings = Map.put(settings, "db_socket_opts", [:inet])
+
+    start_supervised!({Migrations, settings})
+    clean_table(conn, "realtime", "channels")
+    %{conn: conn, tenant: tenant}
+  end
+
+  describe "all/3" do
+    test "fetches multiple entries and loads a given struct", %{conn: conn, tenant: tenant} do
+      channel_1 = channel_fixture(tenant)
+      channel_2 = channel_fixture(tenant)
+
+      assert {:ok, [^channel_1, ^channel_2] = res} = TenantRepo.all(conn, Channel, Channel)
+      assert Enum.all?(res, &(Ecto.get_meta(&1, :state) == :loaded))
+    end
+
+    test "handles exceptions", %{conn: conn} do
+      Process.exit(conn, :kill)
+      assert {:error, :postgrex_exception} = TenantRepo.all(conn, from(c in Channel), Channel)
+    end
+  end
+
+  describe "one/3" do
+    test "fetches one entry and loads a given struct", %{conn: conn, tenant: tenant} do
+      channel_1 = channel_fixture(tenant)
+      _channel_2 = channel_fixture(tenant)
+      query = from c in Channel, where: c.id == ^channel_1.id
+      assert {:ok, ^channel_1} = TenantRepo.one(conn, query, Channel)
+      assert Ecto.get_meta(channel_1, :state) == :loaded
+    end
+
+    test "raises exception on multiple results", %{conn: conn, tenant: tenant} do
+      _channel_1 = channel_fixture(tenant)
+      _channel_2 = channel_fixture(tenant)
+
+      assert_raise RuntimeError, "expected at most one result but got 2 in result", fn ->
+        TenantRepo.one(conn, Channel, Channel)
+      end
+    end
+
+    test "if not found, returns not found error", %{conn: conn} do
+      query = from c in Channel, where: c.name == "potato"
+      assert {:error, :not_found} = TenantRepo.one(conn, query, Channel)
+    end
+
+    test "handles exceptions", %{conn: conn} do
+      Process.exit(conn, :kill)
+      query = from c in Channel, where: c.name == "potato"
+      assert {:error, :postgrex_exception} = TenantRepo.one(conn, query, Channel)
+    end
+  end
+
+  describe "insert/3" do
+    test "inserts a new entry with a given changeset and returns struct", %{conn: conn} do
+      changeset = Channel.changeset(%Channel{}, %{name: "foo"})
+      assert {:ok, %Channel{}} = TenantRepo.insert(conn, changeset, Channel)
+    end
+
+    test "returns changeset if changeset is invalid", %{conn: conn} do
+      changeset = Channel.changeset(%Channel{}, %{})
+      res = TenantRepo.insert(conn, changeset, Channel)
+      assert {:error, %Ecto.Changeset{valid?: false}} = res
+    end
+
+    test "returns an error on Postgrex error", %{conn: conn} do
+      changeset = Channel.changeset(%Channel{}, %{name: "foo"})
+      assert {:ok, _} = TenantRepo.insert(conn, changeset, Channel)
+      assert {:error, _} = TenantRepo.insert(conn, changeset, Channel)
+    end
+
+    test "handles exceptions", %{conn: conn} do
+      Process.exit(conn, :kill)
+      changeset = Channel.changeset(%Channel{}, %{name: "foo"})
+      assert {:error, :postgrex_exception} = TenantRepo.insert(conn, changeset, Channel)
+    end
+  end
+
+  describe "del/3" do
+    test "deletes all from query entry", %{conn: conn, tenant: tenant} do
+      Stream.repeatedly(fn -> channel_fixture(tenant) end) |> Enum.take(3)
+      assert {:ok, 3} = TenantRepo.del(conn, Channel)
+    end
+
+    test "raises error on bad queries", %{conn: conn} do
+      # wrong id type
+      query = from c in Channel, where: c.id == "potato"
+
+      assert_raise Ecto.QueryError, fn ->
+        TenantRepo.del(conn, query)
+      end
+    end
+
+    test "handles exceptions", %{conn: conn} do
+      Process.exit(conn, :kill)
+      assert {:error, :postgrex_exception} = TenantRepo.del(conn, Channel)
+    end
+  end
+
+  describe "update/3" do
+    test "updates a new entry with a given changeset and returns struct", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      channel = channel_fixture(tenant)
+      changeset = Channel.changeset(channel, %{name: "foo"})
+      assert {:ok, %Channel{}} = TenantRepo.update(conn, changeset, Channel)
+    end
+
+    test "returns changeset if changeset is invalid", %{conn: conn, tenant: tenant} do
+      channel = channel_fixture(tenant)
+      changeset = Channel.changeset(channel, %{name: 0})
+      res = TenantRepo.update(conn, changeset, Channel)
+      assert {:error, %Ecto.Changeset{valid?: false}} = res
+    end
+
+    test "returns an error on Postgrex error", %{conn: conn, tenant: tenant} do
+      channel = channel_fixture(tenant)
+      channel_to_update = channel_fixture(tenant)
+
+      changeset = Channel.changeset(channel_to_update, %{name: channel.name})
+      assert {:error, _} = TenantRepo.update(conn, changeset, Channel)
+    end
+
+    test "handles exceptions", %{tenant: tenant, conn: conn} do
+      changeset = Channel.changeset(channel_fixture(tenant), %{name: "foo"})
+      Process.exit(conn, :kill)
+      assert {:error, :postgrex_exception} = TenantRepo.update(conn, changeset, Channel)
+    end
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Attempt at moving some of the existing methods to a new module focused on Tenants

This module won't use Ecto.Repo since it has the intent to use mostly Postgrex queries directly
