### PR TITLE
fix: Improve IP version inference

### DIFF
--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -89,7 +89,7 @@ defmodule Extensions.PostgresCdcRls do
   """
   @spec start(map()) :: :ok | {:error, :already_started | :reserved}
   def start(args) do
-    addrtype = Helpers.detect_ip_version(args["db_host"])
+    {:ok, addrtype} = Helpers.detect_ip_version(args["db_host"])
 
     args =
       Map.merge(args, %{

--- a/lib/extensions/postgres_cdc_stream/cdc_stream.ex
+++ b/lib/extensions/postgres_cdc_stream/cdc_stream.ex
@@ -77,7 +77,7 @@ defmodule Extensions.PostgresCdcStream do
 
   @spec start(map()) :: :ok | {:error, :already_started | :reserved}
   def start(args) do
-    addrtype = Helpers.detect_ip_version(args["db_host"])
+    {:ok, addrtype} = Helpers.detect_ip_version(args["db_host"])
 
     args =
       Map.merge(args, %{

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.58",
+      version: "2.25.59",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added proper check for ipv6 and errors for scenarios where the host was not able to be found to avoid false positives
