### PR TITLE
fix: Check IP version on connect to avoid issues

### DIFF
--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -10,7 +10,6 @@ defmodule Extensions.PostgresCdcRls do
   alias Extensions.PostgresCdcRls, as: Rls
   alias Rls.Subscriptions
   alias Realtime.Rpc
-  alias Realtime.Helpers
 
   @spec handle_connect(map()) :: {:ok, {pid(), pid()}} | nil
   def handle_connect(args) do
@@ -89,13 +88,7 @@ defmodule Extensions.PostgresCdcRls do
   """
   @spec start(map()) :: :ok | {:error, :already_started | :reserved}
   def start(args) do
-    {:ok, addrtype} = Helpers.detect_ip_version(args["db_host"])
-
-    args =
-      Map.merge(args, %{
-        "db_socket_opts" => [addrtype],
-        "subs_pool_size" => Map.get(args, "subcriber_pool_size", 5)
-      })
+    args = Map.merge(args, %{"subs_pool_size" => Map.get(args, "subcriber_pool_size", 5)})
 
     Logger.debug("Starting postgres stream extension with args: #{inspect(args, pretty: true)}")
 

--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -8,7 +8,8 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
 
   require Logger
 
-  import Realtime.Helpers, only: [cancel_timer: 1, default_ssl_param: 1, connect_db: 10]
+  import Realtime.Helpers,
+    only: [cancel_timer: 1, default_ssl_param: 1, connect_db: 10, detect_ip_version: 1]
 
   alias DBConnection.Backoff
   alias Extensions.PostgresCdcRls.{Replications, MessageDispatcher}
@@ -22,7 +23,8 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
   @impl true
   def init(args) do
     tenant = args["id"]
-
+    {:ok, addrtype} = detect_ip_version(args["db_host"])
+    db_socket_opts = [addrtype]
     Logger.metadata(external_id: tenant, project: tenant)
 
     ssl_enforced = default_ssl_param(args)
@@ -34,7 +36,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
         args["db_name"],
         args["db_user"],
         args["db_password"],
-        args["db_socket_opts"],
+        db_socket_opts,
         1,
         @queue_target,
         ssl_enforced,
@@ -49,7 +51,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
       db_name: args["db_name"],
       db_user: args["db_user"],
       db_pass: args["db_password"],
-      db_socket_opts: args["db_socket_opts"],
+      db_socket_opts: db_socket_opts,
       max_changes: args["poll_max_changes"],
       max_record_bytes: args["poll_max_record_bytes"],
       poll_interval_ms: args["poll_interval_ms"],

--- a/lib/extensions/postgres_cdc_rls/subscription_manager.ex
+++ b/lib/extensions/postgres_cdc_rls/subscription_manager.ex
@@ -63,12 +63,13 @@ defmodule Extensions.PostgresCdcRls.SubscriptionManager do
       "db_name" => name,
       "db_user" => user,
       "db_password" => pass,
-      "db_socket_opts" => socket_opts,
       "subs_pool_size" => subs_pool_size
     } = args
 
     Logger.metadata(external_id: id, project: id)
 
+    {:ok, addrtype} = H.detect_ip_version(host)
+    socket_opts = [addrtype]
     ssl_enforced = H.default_ssl_param(args)
 
     {:ok, conn} =

--- a/lib/extensions/postgres_cdc_rls/subscriptions_checker.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions_checker.ex
@@ -43,9 +43,11 @@ defmodule Extensions.PostgresCdcRls.SubscriptionsChecker do
       "db_name" => name,
       "db_user" => user,
       "db_password" => pass,
-      "db_socket_opts" => socket_opts,
       "subscribers_tid" => subscribers_tid
     } = args
+
+    {:ok, addrtype} = H.detect_ip_version(host)
+    socket_opts = [addrtype]
 
     Logger.metadata(external_id: id, project: id)
 

--- a/lib/extensions/postgres_cdc_stream/cdc_stream.ex
+++ b/lib/extensions/postgres_cdc_stream/cdc_stream.ex
@@ -6,7 +6,6 @@ defmodule Extensions.PostgresCdcStream do
 
   alias Extensions.PostgresCdcStream, as: Stream
   alias Realtime.Rpc
-  alias Realtime.Helpers
 
   def handle_connect(opts) do
     Enum.reduce_while(1..5, nil, fn retry, acc ->
@@ -77,13 +76,6 @@ defmodule Extensions.PostgresCdcStream do
 
   @spec start(map()) :: :ok | {:error, :already_started | :reserved}
   def start(args) do
-    {:ok, addrtype} = Helpers.detect_ip_version(args["db_host"])
-
-    args =
-      Map.merge(args, %{
-        "db_socket_opts" => [addrtype]
-      })
-
     Logger.debug("Starting postgres stream extension with args: #{inspect(args, pretty: true)}")
 
     DynamicSupervisor.start_child(

--- a/lib/extensions/postgres_cdc_stream/replication.ex
+++ b/lib/extensions/postgres_cdc_stream/replication.ex
@@ -260,6 +260,8 @@ defmodule Extensions.PostgresCdcStream.Replication do
   defp current_time(), do: System.os_time(:microsecond) - @epoch
 
   def connection_opts(args) do
+    {:ok, addrtype} = H.detect_ip_version(args["db_host"])
+
     {host, port, name, user, pass} =
       H.decrypt_creds(
         args["db_host"],
@@ -274,7 +276,8 @@ defmodule Extensions.PostgresCdcStream.Replication do
       database: name,
       username: user,
       password: pass,
-      port: port
+      port: port,
+      socket_opts: addrtype
     ]
   end
 end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -125,10 +125,12 @@ defmodule Realtime.Tenants.Migrations do
            "db_port" => db_port,
            "db_name" => db_name,
            "db_user" => db_user,
-           "db_password" => db_password,
-           "db_socket_opts" => db_socket_opts
+           "db_password" => db_password
          } = args
        ) do
+    {:ok, addrtype} = H.detect_ip_version(db_host)
+    db_socket_opts = [addrtype]
+
     {host, port, name, user, pass} =
       H.decrypt_creds(
         db_host,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.60",
+      version: "2.25.61",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Checks the ip version before the process starts instead of using persisted state that was used on process startup.

This prevents issues when the Process is killed but the arguments used by the Supervisor to start it up are the same.
