### PR TITLE
fix: Move socket opts to connect

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -8,8 +8,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
 
   require Logger
 
-  import Realtime.Helpers,
-    only: [cancel_timer: 1, default_ssl_param: 1, connect_db: 10, detect_ip_version: 1]
+  import Realtime.Helpers, only: [cancel_timer: 1, default_ssl_param: 1, connect_db: 9]
 
   alias DBConnection.Backoff
   alias Extensions.PostgresCdcRls.{Replications, MessageDispatcher}
@@ -23,10 +22,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
   @impl true
   def init(args) do
     tenant = args["id"]
-    {:ok, addrtype} = detect_ip_version(args["db_host"])
-    db_socket_opts = [addrtype]
     Logger.metadata(external_id: tenant, project: tenant)
-
     ssl_enforced = default_ssl_param(args)
 
     {:ok, conn} =
@@ -36,7 +32,6 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
         args["db_name"],
         args["db_user"],
         args["db_password"],
-        db_socket_opts,
         1,
         @queue_target,
         ssl_enforced,
@@ -51,7 +46,6 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
       db_name: args["db_name"],
       db_user: args["db_user"],
       db_pass: args["db_password"],
-      db_socket_opts: db_socket_opts,
       max_changes: args["poll_max_changes"],
       max_record_bytes: args["poll_max_record_bytes"],
       poll_interval_ms: args["poll_interval_ms"],

--- a/lib/extensions/postgres_cdc_rls/subscription_manager.ex
+++ b/lib/extensions/postgres_cdc_rls/subscription_manager.ex
@@ -68,8 +68,6 @@ defmodule Extensions.PostgresCdcRls.SubscriptionManager do
 
     Logger.metadata(external_id: id, project: id)
 
-    {:ok, addrtype} = H.detect_ip_version(host)
-    socket_opts = [addrtype]
     ssl_enforced = H.default_ssl_param(args)
 
     {:ok, conn} =
@@ -79,7 +77,6 @@ defmodule Extensions.PostgresCdcRls.SubscriptionManager do
         name,
         user,
         pass,
-        socket_opts,
         1,
         5_000,
         ssl_enforced,
@@ -93,7 +90,6 @@ defmodule Extensions.PostgresCdcRls.SubscriptionManager do
         name,
         user,
         pass,
-        socket_opts,
         subs_pool_size,
         5_000,
         ssl_enforced,

--- a/lib/extensions/postgres_cdc_rls/subscriptions_checker.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions_checker.ex
@@ -46,9 +46,6 @@ defmodule Extensions.PostgresCdcRls.SubscriptionsChecker do
       "subscribers_tid" => subscribers_tid
     } = args
 
-    {:ok, addrtype} = H.detect_ip_version(host)
-    socket_opts = [addrtype]
-
     Logger.metadata(external_id: id, project: id)
 
     ssl_enforced = H.default_ssl_param(args)
@@ -60,7 +57,6 @@ defmodule Extensions.PostgresCdcRls.SubscriptionsChecker do
         name,
         user,
         pass,
-        socket_opts,
         1,
         5_000,
         ssl_enforced,

--- a/lib/extensions/postgres_cdc_stream/replication.ex
+++ b/lib/extensions/postgres_cdc_stream/replication.ex
@@ -260,8 +260,6 @@ defmodule Extensions.PostgresCdcStream.Replication do
   defp current_time(), do: System.os_time(:microsecond) - @epoch
 
   def connection_opts(args) do
-    {:ok, addrtype} = H.detect_ip_version(args["db_host"])
-
     {host, port, name, user, pass} =
       H.decrypt_creds(
         args["db_host"],
@@ -271,13 +269,15 @@ defmodule Extensions.PostgresCdcStream.Replication do
         args["db_password"]
       )
 
+    {:ok, addrtype} = H.detect_ip_version(host)
+
     [
       hostname: host,
       database: name,
       username: user,
       password: pass,
       port: port,
-      socket_opts: addrtype
+      socket_opts: [addrtype]
     ]
   end
 end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -128,9 +128,6 @@ defmodule Realtime.Tenants.Migrations do
            "db_password" => db_password
          } = args
        ) do
-    {:ok, addrtype} = H.detect_ip_version(db_host)
-    db_socket_opts = [addrtype]
-
     {host, port, name, user, pass} =
       H.decrypt_creds(
         db_host,
@@ -140,6 +137,7 @@ defmodule Realtime.Tenants.Migrations do
         db_password
       )
 
+    {:ok, addrtype} = H.detect_ip_version(host)
     ssl_enforced = H.default_ssl_param(args)
 
     [
@@ -149,10 +147,8 @@ defmodule Realtime.Tenants.Migrations do
       password: pass,
       username: user,
       pool_size: 2,
-      socket_options: db_socket_opts,
-      parameters: [
-        application_name: "realtime_migrations"
-      ],
+      socket_options: [addrtype],
+      parameters: [application_name: "realtime_migrations"],
       backoff_type: :stop
     ]
     |> H.maybe_enforce_ssl_config(ssl_enforced)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.61",
+      version: "2.25.62",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

We only use socket opts to set ipv4 or ipv6 as such we move that logic into the connect_db code to prevent old state from impacting connect_db logic.
