### PR TITLE
fix: Move from Logs to Telemetry on Subscription checks

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -21,7 +21,8 @@ defmodule Realtime.PromEx.Plugins.Tenant do
     # Event metrics definitions
     [
       channel_events(),
-      replication_metrics()
+      replication_metrics(),
+      subscription_metrics()
     ]
   end
 
@@ -84,8 +85,30 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           tags: [:tenant],
           unit: {:microsecond, :millisecond},
           reporter_options: [
-            buckets: [125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000]
+            buckets: [125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000]
           ]
+        )
+      ]
+    )
+  end
+
+  defp subscription_metrics() do
+    Event.build(
+      :realtime_tenant_channel_event_metrics,
+      [
+        sum(
+          [:realtime, :subscriptions_checker, :pid_not_found],
+          event_name: [:realtime, :subscriptions_checker, :pid_not_found],
+          measurement: :sum,
+          description: "Sum of pids not found in Subscription tables.",
+          tags: [:tenant]
+        ),
+        sum(
+          [:realtime, :subscriptions_checker, :phantom_pid_detected],
+          event_name: [:realtime, :subscriptions_checker, :phantom_pid_detected],
+          measurement: :sum,
+          description: "Sum of phantom pids detected in Subscription tables.",
+          tags: [:tenant]
         )
       ]
     )

--- a/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
@@ -24,7 +24,7 @@ defmodule Realtime.PromEx.Plugins.Tenants do
         unit: {:microsecond, :millisecond},
         tags: [:tenant],
         reporter_options: [
-          buckets: [125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000]
+          buckets: [10, 50, 250, 1500, 6000, 30_000]
         ]
       )
     ])

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.62",
+      version: "2.25.63",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/extensions/cdc_rls/subscriptions_checker_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_checker_test.exs
@@ -55,7 +55,7 @@ defmodule SubscriptionsCheckerTest do
 
       :ets.insert(tid, test_data)
 
-      not_alive = Enum.sort(Checker.pop_not_alive_pids([:pid1], tid))
+      not_alive = Enum.sort(Checker.pop_not_alive_pids([:pid1], tid, "id"))
       expected = Enum.sort([UUID.string_to_binary!(uuid1), UUID.string_to_binary!(uuid2)])
       assert not_alive == expected
 
@@ -73,7 +73,7 @@ defmodule SubscriptionsCheckerTest do
       ]
 
       :ets.insert(tid, test_data)
-      assert Checker.pop_not_alive_pids([:pid1], tid) == [UUID.string_to_binary!(uuid1)]
+      assert Checker.pop_not_alive_pids([:pid1], tid, "id") == [UUID.string_to_binary!(uuid1)]
       assert :ets.tab2list(tid) == [{:pid2, "uuid", :ref, :node2}]
     end
   end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently logs were leading users to be concerned with their Realtime status when that does not reflect anything of concern since it's part of the normal flow of Realtime to remove phantom subscriptions and cleanup inactive pids from ETS.

As such we're moving this information from Logs to Telemetry so we avoid concerning our users but keep track of happens with the subscription table.