### PR TITLE
fix: Refactor Realtime Channel

### DIFF
--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -385,6 +385,14 @@ defmodule Realtime.Helpers do
       iex> Realtime.Helpers.detect_ip_version("ipv6.google.com")
       {:ok, :inet6}
 
+      # Using 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+      iex> Realtime.Helpers.detect_ip_version("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+      {:ok, :inet6}
+
+      # Using 127.0.0.1
+      iex> Realtime.Helpers.detect_ip_version("127.0.0.1")
+      {:ok, :inet}
+
       # Using invalid domain
       iex> Realtime.Helpers.detect_ip_version("potato")
       {:error, :nxdomain}

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -439,7 +439,7 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   defp confirm_token(%{assigns: %{jwt_secret: jwt_secret, access_token: access_token} = assigns}) do
-    secure_key = Application.get_env(:realtime, :db_enc_key)
+    secure_key = Application.fetch_env!(:realtime, :db_enc_key)
 
     with jwt_secret_dec <- Helpers.decrypt!(jwt_secret, secure_key),
          {:ok, %{"exp" => exp} = claims} when is_integer(exp) <-

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -6,13 +6,12 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   require Logger
 
-  alias Realtime.Helpers
-
   alias DBConnection.Backoff
 
   alias Phoenix.Tracker.Shard
 
   alias Realtime.GenCounter
+  alias Realtime.Helpers
   alias Realtime.PostgresCdc
   alias Realtime.RateCounter
   alias Realtime.SignalHandler
@@ -20,8 +19,9 @@ defmodule RealtimeWeb.RealtimeChannel do
   alias Realtime.Tenants.Connect
 
   alias RealtimeWeb.ChannelsAuthorization
-  alias RealtimeWeb.Endpoint
   alias RealtimeWeb.Presence
+  alias RealtimeWeb.RealtimeChannel.BroadcastHandler
+  alias RealtimeWeb.RealtimeChannel.PresenceHandler
 
   @confirm_token_ms_interval 1_000 * 60 * 5
 
@@ -45,9 +45,9 @@ defmodule RealtimeWeb.RealtimeChannel do
     start_db_rate_counter(tenant)
 
     with false <- SignalHandler.shutdown_in_progress?(),
-         :ok <- limit_joins(socket),
+         :ok <- limit_joins(socket.assigns),
          :ok <- limit_channels(socket),
-         :ok <- limit_max_users(socket),
+         :ok <- limit_max_users(socket.assigns),
          {:ok, claims, confirm_token_ref} <- confirm_token(socket),
          {:ok, _} <- Connect.lookup_or_start_connection(tenant),
          is_new_api <- is_new_api(params) do
@@ -288,42 +288,12 @@ defmodule RealtimeWeb.RealtimeChannel do
     end
   end
 
-  def handle_in(
-        "broadcast" = type,
-        payload,
-        %{
-          assigns: %{
-            is_new_api: true,
-            ack_broadcast: ack_broadcast,
-            self_broadcast: self_broadcast,
-            tenant_topic: tenant_topic
-          }
-        } = socket
-      ) do
-    socket = count(socket)
-
-    if self_broadcast do
-      Endpoint.broadcast(tenant_topic, type, payload)
-    else
-      Endpoint.broadcast_from(self(), tenant_topic, type, payload)
-    end
-
-    if ack_broadcast do
-      {:reply, :ok, socket}
-    else
-      {:noreply, socket}
-    end
+  def handle_in("broadcast", payload, socket) do
+    BroadcastHandler.call(payload, socket)
   end
 
-  def handle_in(
-        "presence",
-        %{"event" => event} = payload,
-        %{assigns: %{is_new_api: true, presence_key: _, tenant_topic: _}} = socket
-      ) do
-    socket = count(socket)
-    result = handle_presence_event(event, payload, socket)
-
-    {:reply, result, socket}
+  def handle_in("presence", payload, socket) do
+    PresenceHandler.call(payload, socket)
   end
 
   def handle_in(type, payload, socket) do
@@ -337,39 +307,11 @@ defmodule RealtimeWeb.RealtimeChannel do
     {:noreply, socket}
   end
 
-  defp handle_presence_event(event, payload, socket) do
-    %{assigns: %{presence_key: presence_key, tenant_topic: tenant_topic}} = socket
-
-    case String.downcase(event) do
-      "track" ->
-        with payload <- Map.get(payload, "payload", %{}),
-             {:error, {:already_tracked, _, _, _}} <-
-               Presence.track(self(), tenant_topic, presence_key, payload),
-             {:ok, _} <- Presence.update(self(), tenant_topic, presence_key, payload) do
-          :ok
-        else
-          {:ok, _} -> :ok
-          {:error, _} -> :error
-        end
-
-      "untrack" ->
-        Presence.untrack(self(), tenant_topic, presence_key)
-
-      _ ->
-        :error
-    end
-  end
-
   @impl true
   def terminate(reason, _state) do
     Logger.debug("Channel terminated with reason: " <> inspect(reason))
     :telemetry.execute([:prom_ex, :plugin, :realtime, :disconnected], %{})
     :ok
-  end
-
-  defp decrypt_jwt_secret(secret) do
-    secure_key = Application.get_env(:realtime, :db_enc_key)
-    Helpers.decrypt!(secret, secure_key)
   end
 
   defp postgres_subscribe(min \\ 1, max \\ 5) do
@@ -381,7 +323,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     wait
   end
 
-  def limit_joins(%{assigns: %{tenant: tenant, limits: limits}}) do
+  def limit_joins(%{tenant: tenant, limits: limits}) do
     id = Tenants.joins_per_second_key(tenant)
     GenCounter.new(id)
 
@@ -421,16 +363,12 @@ defmodule RealtimeWeb.RealtimeChannel do
     end
   end
 
-  defp limit_max_users(%{
-         assigns: %{limits: %{max_concurrent_users: max_conn_users}, tenant: tenant}
-       }) do
+  defp limit_max_users(%{limits: %{max_concurrent_users: max_conn_users}, tenant: tenant}) do
     conns = Realtime.UsersCounter.tenant_users(tenant)
 
-    if conns < max_conn_users do
-      :ok
-    else
-      {:error, :too_many_connections}
-    end
+    if conns < max_conn_users,
+      do: :ok,
+      else: {:error, :too_many_connections}
   end
 
   defp assign_counter(%{assigns: %{tenant: tenant, limits: limits}} = socket) do
@@ -474,8 +412,7 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   defp presence_key(params) do
-    with key when is_binary(key) <- params["config"]["presence"]["key"],
-         true <- String.length(key) > 0 do
+    with key when is_binary(key) and key != "" <- params["config"]["presence"]["key"] do
       key
     else
       _ -> UUID.uuid1()
@@ -502,7 +439,9 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   defp confirm_token(%{assigns: %{jwt_secret: jwt_secret, access_token: access_token} = assigns}) do
-    with jwt_secret_dec <- decrypt_jwt_secret(jwt_secret),
+    secure_key = Application.get_env(:realtime, :db_enc_key)
+
+    with jwt_secret_dec <- Helpers.decrypt!(jwt_secret, secure_key),
          {:ok, %{"exp" => exp} = claims} when is_integer(exp) <-
            ChannelsAuthorization.authorize_conn(access_token, jwt_secret_dec),
          exp_diff when exp_diff > 0 <- exp - Joken.current_time() do
@@ -536,7 +475,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     })
   end
 
-  def presence_dirty_list(topic) do
+  defp presence_dirty_list(topic) do
     [{:pool_size, size}] = :ets.lookup(Presence, :pool_size)
 
     Presence

--- a/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
@@ -1,0 +1,47 @@
+defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
+  @moduledoc """
+  Handles the Broadcast feature from Realtime
+  """
+  import Phoenix.Socket, only: [assign: 3]
+
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
+
+  alias RealtimeWeb.Endpoint
+
+  @event_type "broadcast"
+  @spec call(map(), Phoenix.Socket.t()) ::
+          {:reply, :ok, Phoenix.Socket.t()} | {:noreply, Phoenix.Socket.t()}
+  def call(
+        payload,
+        %{
+          assigns: %{
+            is_new_api: true,
+            ack_broadcast: ack_broadcast,
+            self_broadcast: self_broadcast,
+            tenant_topic: tenant_topic
+          }
+        } = socket
+      ) do
+    socket = count(socket)
+
+    if self_broadcast,
+      do: Endpoint.broadcast(tenant_topic, @event_type, payload),
+      else: Endpoint.broadcast_from(self(), tenant_topic, @event_type, payload)
+
+    if ack_broadcast,
+      do: {:reply, :ok, socket},
+      else: {:noreply, socket}
+  end
+
+  def call(_payload, socket) do
+    {:noreply, socket}
+  end
+
+  defp count(%{assigns: %{rate_counter: counter}} = socket) do
+    GenCounter.add(counter.id)
+    {:ok, rate_counter} = RateCounter.get(counter.id)
+
+    assign(socket, :rate_counter, rate_counter)
+  end
+end

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -1,0 +1,57 @@
+defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
+  @moduledoc """
+  Handles the Presence feature from Realtime
+  """
+  import Phoenix.Socket, only: [assign: 3]
+
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
+
+  alias RealtimeWeb.Presence
+
+  @spec call(map(), Phoenix.Socket.t()) ::
+          {:noreply, Phoenix.Socket.t()} | {:reply, :error | :ok, Phoenix.Socket.t()}
+  def call(
+        %{"event" => event} = payload,
+        %{assigns: %{is_new_api: true, presence_key: _, tenant_topic: _}} = socket
+      ) do
+    socket = count(socket)
+    result = handle_presence_event(event, payload, socket)
+
+    {:reply, result, socket}
+  end
+
+  def call(_payload, socket) do
+    {:noreply, socket}
+  end
+
+  defp handle_presence_event(event, payload, socket) do
+    %{assigns: %{presence_key: presence_key, tenant_topic: tenant_topic}} = socket
+
+    case String.downcase(event) do
+      "track" ->
+        with payload <- Map.get(payload, "payload", %{}),
+             {:error, {:already_tracked, _, _, _}} <-
+               Presence.track(self(), tenant_topic, presence_key, payload),
+             {:ok, _} <- Presence.update(self(), tenant_topic, presence_key, payload) do
+          :ok
+        else
+          {:ok, _} -> :ok
+          {:error, _} -> :error
+        end
+
+      "untrack" ->
+        Presence.untrack(self(), tenant_topic, presence_key)
+
+      _ ->
+        :error
+    end
+  end
+
+  defp count(%{assigns: %{rate_counter: counter}} = socket) do
+    GenCounter.add(counter.id)
+    {:ok, rate_counter} = RateCounter.get(counter.id)
+
+    assign(socket, :rate_counter, rate_counter)
+  end
+end

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -106,7 +106,7 @@ defmodule RealtimeWeb.Router do
     post("/broadcast", BroadcastController, :broadcast)
   end
 
-  scope "/api", RealtimeWeb do
+  scope "/v3/api", RealtimeWeb do
     pipe_through([:open_cors, :tenant_api, :secure_tenant_api, :channel_rls_authorization])
 
     resources("/channels", ChannelsController, only: [:index, :show])

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.63",
+      version: "2.25.64",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/channels_controller_test.exs
+++ b/test/realtime_web/controllers/channels_controller_test.exs
@@ -57,7 +57,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
         |> Jason.encode!()
         |> Jason.decode!()
 
-      conn = get(conn, ~p"/api/channels")
+      conn = get(conn, ~p"/v3/api/channels")
       res = json_response(conn, 200)
 
       res = Enum.sort_by(res, fn %{"id" => id} -> id end)
@@ -67,7 +67,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
 
     @tag role: "anon"
     test "returns 401 if unauthorized", %{conn: conn} do
-      conn = get(conn, ~p"/api/channels")
+      conn = get(conn, ~p"/v3/api/channels")
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end
@@ -81,7 +81,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
 
       expected = channel |> Jason.encode!() |> Jason.decode!()
 
-      conn = get(conn, ~p"/api/channels/#{channel.id}")
+      conn = get(conn, ~p"/v3/api/channels/#{channel.id}")
       res = json_response(conn, 200)
       assert res == expected
     end
@@ -91,13 +91,13 @@ defmodule RealtimeWeb.ChannelsControllerTest do
       Stream.repeatedly(fn -> channel_fixture(tenant) end)
       |> Enum.take(10)
 
-      conn = get(conn, ~p"/api/channels/0")
+      conn = get(conn, ~p"/v3/api/channels/0")
       assert json_response(conn, 404) == %{"message" => "Not found"}
     end
 
     @tag role: "anon"
     test "returns 401 if unauthorized", %{conn: conn} do
-      conn = get(conn, ~p"/api/channels/0")
+      conn = get(conn, ~p"/v3/api/channels/0")
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end
@@ -105,13 +105,13 @@ defmodule RealtimeWeb.ChannelsControllerTest do
   # describe "create" do
   #   test "creates a channel", %{conn: conn} do
   #     name = random_string()
-  #     conn = post(conn, ~p"/api/channels", %{name: name})
+  #     conn = post(conn, ~p"/v3/api/channels", %{name: name})
   #     res = json_response(conn, 201)
   #     assert name == res["name"]
   #   end
 
   #   test "422 if params are invalid", %{conn: conn} do
-  #     conn = post(conn, ~p"/api/channels", %{})
+  #     conn = post(conn, ~p"/v3/api/channels", %{})
   #     assert json_response(conn, 422) == %{"errors" => %{"name" => ["can't be blank"]}}
   #   end
   # end
@@ -119,12 +119,12 @@ defmodule RealtimeWeb.ChannelsControllerTest do
   # describe "delete" do
   #   test "deletes a channel", %{conn: conn, tenant: tenant} do
   #     channel = channel_fixture(tenant)
-  #     conn = delete(conn, ~p"/api/channels/#{channel.id}")
+  #     conn = delete(conn, ~p"/v3/api/channels/#{channel.id}")
   #     assert conn.status == 202
   #   end
 
   #   test "returns not found if id doesn't exist", %{conn: conn} do
-  #     conn = delete(conn, ~p"/api/channels/0")
+  #     conn = delete(conn, ~p"/v3/api/channels/0")
   #     assert conn.status == 404
   #   end
   # end
@@ -133,21 +133,21 @@ defmodule RealtimeWeb.ChannelsControllerTest do
   #   test "updates a channel", %{conn: conn, tenant: tenant} do
   #     channel = channel_fixture(tenant)
   #     name = random_string()
-  #     conn = put(conn, ~p"/api/channels/#{channel.id}", %{name: name})
+  #     conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{name: name})
   #     res = json_response(conn, 202)
   #     assert name == res["name"]
 
   #     name = random_string()
-  #     conn = patch(conn, ~p"/api/channels/#{channel.id}", %{name: name})
+  #     conn = patch(conn, ~p"/v3/api/channels/#{channel.id}", %{name: name})
   #     res = json_response(conn, 202)
   #     assert name == res["name"]
   #   end
 
   #   test "422 if params are invalid", %{conn: conn, tenant: tenant} do
   #     channel = channel_fixture(tenant)
-  #     conn = put(conn, ~p"/api/channels/#{channel.id}", %{name: 1})
+  #     conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{name: 1})
   #     assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
-  #     conn = patch(conn, ~p"/api/channels/#{channel.id}", %{name: 1})
+  #     conn = patch(conn, ~p"/v3/api/channels/#{channel.id}", %{name: 1})
   #     assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
   #   end
   # end


### PR DESCRIPTION
## What kind of change does this PR introduce?

In preparation to add Authorization, we're separating concerns out of the module RealtimeChannel which had most of the logic within the same module.

This will make it easier to extend the Broadcast and Presence features.

We're also moving the Channels endpoints to a v3 route