### PR TITLE
fix: Change measures to maps to avoid deprecation warnings

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscriptions_checker.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions_checker.ex
@@ -143,17 +143,25 @@ defmodule Extensions.PostgresCdcRls.SubscriptionsChecker do
     Enum.reduce(pids, [], fn pid, acc ->
       case :ets.lookup(tid, pid) do
         [] ->
-          Telemetry.execute([:realtime, :subscriptions_checker, :pid_not_found], 1, %{
-            tenant_id: tenant_id
-          })
+          Telemetry.execute(
+            [:realtime, :subscriptions_checker, :pid_not_found],
+            %{quantity: 1},
+            %{
+              tenant_id: tenant_id
+            }
+          )
 
           acc
 
         results ->
           for {^pid, postgres_id, _ref, _node} <- results do
-            Telemetry.execute([:realtime, :subscriptions_checker, :phantom_pid_detected], 1, %{
-              tenant_id: tenant_id
-            })
+            Telemetry.execute(
+              [:realtime, :subscriptions_checker, :phantom_pid_detected],
+              %{quantity: 1},
+              %{
+                tenant_id: tenant_id
+              }
+            )
 
             :ets.delete(tid, pid)
             UUID.string_to_binary!(postgres_id)

--- a/lib/realtime/telemetry/telemetry.ex
+++ b/lib/realtime/telemetry/telemetry.ex
@@ -7,7 +7,7 @@ defmodule Realtime.Telemetry do
   Dispatches Telemetry events.
   """
 
-  @spec execute([atom, ...], number | map, map) :: :ok
+  @spec execute([atom, ...], map, map) :: :ok
   def execute(event, measurements, metadata \\ %{}) do
     :telemetry.execute(event, measurements, metadata)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.64",
+      version: "2.25.65",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Change measures to maps to avoid deprecation warnings
