### PR TITLE
fix: Run migrations on Connect

### DIFF
--- a/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
+++ b/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
@@ -10,8 +10,6 @@ defmodule Extensions.PostgresCdcRls.WorkerSupervisor do
     SubscriptionsChecker
   }
 
-  alias Realtime.Tenants.Migrations
-
   def start_link(args) do
     name = PostgresCdcRls.supervisor_id(args["id"], args["region"])
     Supervisor.start_link(__MODULE__, args, name: {:via, :syn, name})
@@ -19,17 +17,9 @@ defmodule Extensions.PostgresCdcRls.WorkerSupervisor do
 
   @impl true
   def init(args) do
-    tid_args =
-      Map.merge(args, %{
-        "subscribers_tid" => :ets.new(__MODULE__, [:public, :bag])
-      })
+    tid_args = Map.merge(args, %{"subscribers_tid" => :ets.new(__MODULE__, [:public, :bag])})
 
     children = [
-      %{
-        id: Migrations,
-        start: {Migrations, :start_link, [args]},
-        restart: :transient
-      },
       %{
         id: ReplicationPoller,
         start: {ReplicationPoller, :start_link, [args]},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.66",
+      version: "2.25.67",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/channels_test.exs
+++ b/test/realtime/channels_test.exs
@@ -9,11 +9,6 @@ defmodule Realtime.ChannelsTest do
 
   setup do
     tenant = tenant_fixture()
-    settings = Realtime.PostgresCdc.filter_settings(@cdc, tenant.extensions)
-    settings = Map.put(settings, "id", tenant.external_id)
-    settings = Map.put(settings, "db_socket_opts", [:inet])
-
-    start_supervised!({Tenants.Migrations, settings})
     {:ok, conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
     clean_table(conn, "realtime", "channels")
 

--- a/test/realtime/channels_test.exs
+++ b/test/realtime/channels_test.exs
@@ -5,8 +5,6 @@ defmodule Realtime.ChannelsTest do
   alias Realtime.Api.Channel
   alias Realtime.Tenants
 
-  @cdc "postgres_cdc_rls"
-
   setup do
     tenant = tenant_fixture()
     {:ok, conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -6,20 +6,15 @@ defmodule Realtime.RepoTest do
   alias Realtime.Api.Channel
   alias Realtime.Repo
   alias Realtime.Tenants.Connect
-  alias Realtime.Tenants.Migrations
 
   @cdc "postgres_cdc_rls"
 
   setup do
     tenant = tenant_fixture()
+
     {:ok, conn} = Connect.lookup_or_start_connection(tenant.external_id)
-
-    settings = Realtime.PostgresCdc.filter_settings(@cdc, tenant.extensions)
-    settings = Map.put(settings, "id", tenant.external_id)
-    settings = Map.put(settings, "db_socket_opts", [:inet])
-
-    start_supervised!({Migrations, settings})
     clean_table(conn, "realtime", "channels")
+
     %{conn: conn, tenant: tenant}
   end
 

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -7,8 +7,6 @@ defmodule Realtime.RepoTest do
   alias Realtime.Repo
   alias Realtime.Tenants.Connect
 
-  @cdc "postgres_cdc_rls"
-
   setup do
     tenant = tenant_fixture()
 

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -12,11 +12,6 @@ defmodule Realtime.Tenants.AuthorizationTest do
   setup context do
     start_supervised!(CurrentTime.Mock)
     tenant = tenant_fixture()
-    settings = Realtime.PostgresCdc.filter_settings("postgres_cdc_rls", tenant.extensions)
-    settings = Map.put(settings, "id", tenant.external_id)
-    settings = Map.put(settings, "db_socket_opts", [:inet])
-
-    start_supervised!({Tenants.Migrations, settings})
 
     {:ok, db_conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
     clean_table(db_conn, "realtime", "channels")

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -1,6 +1,8 @@
 defmodule Realtime.Tenants.ConnectTest do
   use Realtime.DataCase, async: false
 
+  import Mock
+
   alias Realtime.Tenants.Connect
   alias Realtime.UsersCounter
 
@@ -155,6 +157,25 @@ defmodule Realtime.Tenants.ConnectTest do
       send(check_db_connections_created(self(), tenant.external_id), :check)
       :timer.sleep(5000)
       refute_receive :too_many_connections
+    end
+
+    test "on migrations failure, process is alive", %{tenant: tenant} do
+      with_mock Ecto.Migrator, [:passthrough], run: fn _, _, _, _ -> nil end do
+        assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+        :timer.sleep(200)
+        assert_called(Ecto.Migrator.run(:_, :_, :_, :_))
+        assert Process.alive?(db_conn) == true
+      end
+    end
+
+    test "on migrations failure, stop the process", %{tenant: tenant} do
+      with_mock Ecto.Migrator, [], run: fn _, _, _, _ -> raise("error") end do
+        assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
+        :timer.sleep(200)
+        assert_called(Ecto.Migrator.run(:_, :_, :_, :_))
+        assert Process.alive?(db_conn) == false
+      end
     end
   end
 

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -162,7 +162,6 @@ defmodule Realtime.Tenants.ConnectTest do
     test "on migrations failure, process is alive", %{tenant: tenant} do
       with_mock Ecto.Migrator, [:passthrough], run: fn _, _, _, _ -> nil end do
         assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-        :timer.sleep(200)
         assert_called(Ecto.Migrator.run(:_, :_, :_, :_))
         assert Process.alive?(db_conn) == true
       end
@@ -170,11 +169,10 @@ defmodule Realtime.Tenants.ConnectTest do
 
     test "on migrations failure, stop the process", %{tenant: tenant} do
       with_mock Ecto.Migrator, [], run: fn _, _, _, _ -> raise("error") end do
-        assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+        assert {:error, :tenant_database_unavailable} =
+                 Connect.lookup_or_start_connection(tenant.external_id)
 
-        :timer.sleep(200)
         assert_called(Ecto.Migrator.run(:_, :_, :_, :_))
-        assert Process.alive?(db_conn) == false
       end
     end
   end

--- a/test/realtime_web/controllers/channels_controller_test.exs
+++ b/test/realtime_web/controllers/channels_controller_test.exs
@@ -5,7 +5,6 @@ defmodule RealtimeWeb.ChannelsControllerTest do
 
   alias Realtime.GenCounter
   alias Realtime.Tenants
-  @cdc "postgres_cdc_rls"
 
   setup_with_mocks [
                      {GenCounter, [], new: fn _ -> :ok end},
@@ -18,13 +17,8 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     tenant = tenant_fixture()
 
     secret =
-      tenant.jwt_secret |> Realtime.Helpers.decrypt!(Application.get_env(:realtime, :db_enc_key))
+      Realtime.Helpers.decrypt!(tenant.jwt_secret, Application.get_env(:realtime, :db_enc_key))
 
-    settings = Realtime.PostgresCdc.filter_settings(@cdc, tenant.extensions)
-    settings = Map.put(settings, "id", tenant.external_id)
-    settings = Map.put(settings, "db_socket_opts", [:inet])
-
-    start_supervised!({Tenants.Migrations, settings})
     {:ok, db_conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
     clean_table(db_conn, "realtime", "channels")
 

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -7,7 +7,6 @@ defmodule RealtimeWeb.TenantControllerTest do
   import Mock
   import Realtime.Helpers, only: [encrypt!: 2]
 
-  alias Realtime.Api
   alias Realtime.Api.Tenant
   alias Realtime.Helpers
   alias RealtimeWeb.ChannelsAuthorization

--- a/test/realtime_web/plugs/rls_authorization_test.exs
+++ b/test/realtime_web/plugs/rls_authorization_test.exs
@@ -12,12 +12,6 @@ defmodule RealtimeWeb.RlsAuthorizationTest do
     start_supervised!(CurrentTime.Mock)
     tenant = tenant_fixture()
 
-    settings = Realtime.PostgresCdc.filter_settings("postgres_cdc_rls", tenant.extensions)
-    settings = Map.put(settings, "id", tenant.external_id)
-    settings = Map.put(settings, "db_socket_opts", [:inet])
-
-    start_supervised!({Tenants.Migrations, settings})
-
     {:ok, db_conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
 
     clean_table(db_conn, "realtime", "channels")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Running migrations on Connect will ensure that the tenant database will have the required tables for the new Realtime features. Plus it offloads this concern from the extensions and moves it to the Tenant domain of concerns.