### PR TITLE
fix: Invalidate Cache on delete

### DIFF
--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -6,6 +6,7 @@ defmodule RealtimeWeb.TenantController do
 
   alias Realtime.Api
   alias Realtime.Api.Tenant
+  alias Realtime.Tenants.Cache
   alias Realtime.Helpers
   alias Realtime.PostgresCdc
   alias Realtime.Tenants
@@ -193,6 +194,7 @@ defmodule RealtimeWeb.TenantController do
           PostgresCdc.stop_all(tenant)
           Helpers.replication_slot_teardown(tenant)
           Api.delete_tenant_by_external_id(tenant_id)
+          Cache.invalidate_tenant_cache(tenant_id)
         end)
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.67",
+      version: "2.25.68",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Invalidates Tenant Cache on delete.

This needs to be done because if the client connects within the range of normal cache invalidation they will end up creating replication slot which will leave the database with a replication slot that will not be used and potentially block maintenance operations.