### PR TITLE
fix: Distributed Tenant Cache invalidation

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -222,7 +222,7 @@ defmodule Realtime.Tenants do
   defp broadcast_operation_event(action, external_id) do
     Phoenix.PubSub.broadcast!(
       Realtime.PubSub,
-      "realtime:operations:suspend_tenant",
+      "realtime:operations:invalidate_cache",
       {action, external_id}
     )
   end

--- a/lib/realtime/tenants/cache.ex
+++ b/lib/realtime/tenants/cache.ex
@@ -16,8 +16,22 @@ defmodule Realtime.Tenants.Cache do
 
   def get_tenant_by_external_id(keyword), do: apply_repo_fun(__ENV__.function, [keyword])
 
+  @doc """
+    Invalidates the cache for a tenant in the local node
+  """
   def invalidate_tenant_cache(tenant_id) do
     Cachex.del(__MODULE__, {{:get_tenant_by_external_id, 1}, [tenant_id]})
+  end
+
+  @doc """
+  Broadcasts a message to invalidate the tenant cache to all connected nodes
+  """
+  def distributed_invalidate_tenant_cache(tenant_id) do
+    Phoenix.PubSub.broadcast!(
+      Realtime.PubSub,
+      "realtime:operations:invalidate_cache",
+      {:invalidate_cache, tenant_id}
+    )
   end
 
   defp apply_repo_fun(arg1, arg2) do

--- a/lib/realtime/tenants/cache_pub_sub_handler.ex
+++ b/lib/realtime/tenants/cache_pub_sub_handler.ex
@@ -20,7 +20,7 @@ defmodule Realtime.Tenants.CachePubSubHandler do
 
   @impl true
   def handle_info({action, tenant_id}, state)
-      when action in [:suspend_tenant, :unsuspend_tenant] do
+      when action in [:suspend_tenant, :unsuspend_tenant, :invalidate_cache] do
     Logger.warn("Triggering cache invalidation", external_id: tenant_id)
     Cache.invalidate_tenant_cache(tenant_id)
     {:noreply, state}

--- a/lib/realtime/tenants/cache_supervisor.ex
+++ b/lib/realtime/tenants/cache_supervisor.ex
@@ -14,7 +14,7 @@ defmodule Realtime.Tenants.CacheSupervisor do
   @impl true
   def init(_init_arg) do
     children = [
-      {CachePubSubHandler, topics: ["realtime:operations:suspend_tenant"]},
+      {CachePubSubHandler, topics: ["realtime:operations:invalidate_cache"]},
       Cache
     ]
 

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -117,7 +117,7 @@ defmodule Realtime.Tenants.Connect do
           connected_users_bucket: connected_users_bucket
         } = state
       ) do
-    :ok = Phoenix.PubSub.subscribe(Realtime.PubSub, "realtime:operations:suspend_tenant")
+    :ok = Phoenix.PubSub.subscribe(Realtime.PubSub, "realtime:operations:invalidate_cache")
     send_connected_user_check_message(connected_users_bucket, check_connected_user_interval)
 
     {:noreply, state}

--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -194,7 +194,7 @@ defmodule RealtimeWeb.TenantController do
           PostgresCdc.stop_all(tenant)
           Helpers.replication_slot_teardown(tenant)
           Api.delete_tenant_by_external_id(tenant_id)
-          Cache.invalidate_tenant_cache(tenant_id)
+          Cache.distributed_invalidate_tenant_cache(tenant_id)
         end)
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.68",
+      version: "2.25.69",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/cache_supervisor_test.exs
+++ b/test/realtime/tenants/cache_supervisor_test.exs
@@ -21,7 +21,7 @@ defmodule Realtime.Tenants.CacheSupervisorTest do
     # PubSub message
     Phoenix.PubSub.broadcast(
       Realtime.PubSub,
-      "realtime:operations:suspend_tenant",
+      "realtime:operations:invalidate_cache",
       {:suspend_tenant, external_id}
     )
 

--- a/test/realtime/tenants/cache_test.exs
+++ b/test/realtime/tenants/cache_test.exs
@@ -38,4 +38,22 @@ defmodule Realtime.Tenants.CacheTest do
       assert %Api.Tenant{suspend: true} = Tenants.Cache.get_tenant_by_external_id(external_id)
     end
   end
+
+  describe "distributed_invalidate_tenant_cache/1" do
+    test "invalidates the cache given a tenant_id", %{tenant: tenant} do
+      external_id = tenant.external_id
+      assert %Api.Tenant{suspend: false} = Tenants.Cache.get_tenant_by_external_id(external_id)
+
+      # Delete tenant
+      Realtime.Repo.delete(tenant)
+
+      # Cache showing non existing tenant
+      assert %Api.Tenant{suspend: false} = Tenants.Cache.get_tenant_by_external_id(external_id)
+
+      # Invalidate cache
+      Tenants.Cache.distributed_invalidate_tenant_cache(external_id)
+      :timer.sleep(500)
+      refute Tenants.Cache.get_tenant_by_external_id(external_id)
+    end
+  end
 end

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -42,7 +42,7 @@ defmodule Realtime.TenantsTest do
   describe "suspend_tenant_by_external_id/1" do
     setup do
       tenant = tenant_fixture()
-      topic = "realtime:operations:suspend_tenant"
+      topic = "realtime:operations:invalidate_cache"
       Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
       %{topic: topic, tenant: tenant}
     end
@@ -57,7 +57,7 @@ defmodule Realtime.TenantsTest do
   describe "unsuspend_tenant_by_external_id/1" do
     setup do
       tenant = tenant_fixture()
-      topic = "realtime:operations:suspend_tenant"
+      topic = "realtime:operations:invalidate_cache"
       Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
       %{topic: topic, tenant: tenant}
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Creates a new method to emit a cache invalidation message to all connected nodes. Also using it in the delete action of Tenant Controller since this could create issues with replication_slots

