### PR TITLE
fix: make tenant delete more robust

### DIFF
--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -48,10 +48,21 @@ defmodule Extensions.PostgresCdcRls do
     Endpoint.subscribe("realtime:postgres:" <> tenant, metadata)
   end
 
-  def handle_stop(tenant, timeout) do
+  @doc """
+  Stops the Supervision tree for a tenant.
+
+  Expects an `external_id` as the `tenant`.
+  """
+
+  @spec handle_stop(String.t(), non_neg_integer()) :: :ok
+  def handle_stop(tenant, timeout) when is_binary(tenant) do
     case :syn.whereis_name({__MODULE__, tenant}) do
-      :undefined -> Logger.warning("Database supervisor not found for tenant #{tenant}")
-      pid -> DynamicSupervisor.stop(pid, :shutdown, timeout)
+      :undefined ->
+        Logger.warning("Database supervisor not found for tenant #{tenant}")
+        :ok
+
+      pid ->
+        DynamicSupervisor.stop(pid, :shutdown, timeout)
     end
   end
 

--- a/lib/extensions/postgres_cdc_stream/cdc_stream.ex
+++ b/lib/extensions/postgres_cdc_stream/cdc_stream.ex
@@ -33,10 +33,21 @@ defmodule Extensions.PostgresCdcStream do
     end)
   end
 
-  def handle_stop(tenant, timeout) do
+  @doc """
+  Stops the Supervision tree for a tenant.
+
+  Expects an `external_id` as the `tenant`.
+  """
+
+  @spec handle_stop(String.t(), non_neg_integer()) :: :ok
+  def handle_stop(tenant, timeout) when is_binary(tenant) do
     case :syn.lookup(PostgresCdcStream, tenant) do
-      :undefined -> Logger.warning("Database supervisor not found for tenant #{tenant}")
-      {pid, _} -> DynamicSupervisor.stop(pid, :shutdown, timeout)
+      :undefined ->
+        Logger.warning("Database supervisor not found for tenant #{tenant}")
+        :ok
+
+      {pid, _} ->
+        DynamicSupervisor.stop(pid, :shutdown, timeout)
     end
   end
 

--- a/lib/realtime/tenants/cache.ex
+++ b/lib/realtime/tenants/cache.ex
@@ -26,7 +26,8 @@ defmodule Realtime.Tenants.Cache do
   @doc """
   Broadcasts a message to invalidate the tenant cache to all connected nodes
   """
-  def distributed_invalidate_tenant_cache(tenant_id) do
+  @spec distributed_invalidate_tenant_cache(String.t()) :: :ok
+  def distributed_invalidate_tenant_cache(tenant_id) when is_binary(tenant_id) do
     Phoenix.PubSub.broadcast!(
       Realtime.PubSub,
       "realtime:operations:invalidate_cache",

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -90,7 +90,7 @@ defmodule Realtime.Tenants.Connect do
   def init(%{tenant_id: tenant_id} = state) do
     Logger.metadata(external_id: tenant_id, project: tenant_id)
 
-    with tenant <- Tenants.Cache.get_tenant_by_external_id(tenant_id),
+    with %Tenant{} = tenant <- Tenants.get_tenant_by_external_id(tenant_id),
          res <- Helpers.check_tenant_connection(tenant, @application_name),
          [%{settings: settings} | _] <- tenant.extensions,
          {:ok, _} <- Migrations.run_migrations(settings) do

--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -1,4 +1,6 @@
 defmodule RealtimeWeb.TenantController do
+  alias RealtimeWeb.OpenApiSchemas.UnauthorizedResponse
+  alias RealtimeWeb.OpenApiSchemas.ErrorResponse
   use RealtimeWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
@@ -174,31 +176,35 @@ defmodule RealtimeWeb.TenantController do
     ],
     responses: %{
       204 => EmptyResponse.response(),
-      403 => EmptyResponse.response()
+      403 => UnauthorizedResponse.response(),
+      404 => NotFoundResponse.response(),
+      500 => ErrorResponse.response()
     }
   )
 
   def delete(conn, %{"tenant_id" => tenant_id}) do
     Logger.metadata(external_id: tenant_id, project: tenant_id)
 
-    case Api.get_tenant_by_external_id(tenant_id) do
+    subs_id = UserSocket.subscribers_id(tenant_id)
+
+    with %Tenant{} = tenant <- Api.get_tenant_by_external_id(tenant_id),
+         true <- Api.delete_tenant_by_external_id(tenant_id),
+         :ok <- Cache.distributed_invalidate_tenant_cache(tenant_id),
+         :ok <- PostgresCdc.stop_all(tenant, 1_000),
+         :ok <- Endpoint.broadcast(subs_id, "disconnect", %{}) do
+      send_resp(conn, 204, "")
+    else
       nil ->
         Logger.error("Tenant #{tenant_id} does not exist")
 
-      tenant ->
-        tenant_id
-        |> UserSocket.subscribers_id()
-        |> Endpoint.broadcast("disconnect", %{})
+        send_resp(conn, 404, "")
 
-        Task.async(fn ->
-          PostgresCdc.stop_all(tenant)
-          Helpers.replication_slot_teardown(tenant)
-          Api.delete_tenant_by_external_id(tenant_id)
-          Cache.distributed_invalidate_tenant_cache(tenant_id)
-        end)
+      err ->
+        msg = "Error deleting tenant: #{inspect(err)}"
+        Logger.error(msg)
+
+        conn |> put_status(500) |> json(%{error: msg}) |> halt()
     end
-
-    send_resp(conn, 204, "")
   end
 
   operation(:reload,

--- a/lib/realtime_web/open_api_schemas.ex
+++ b/lib/realtime_web/open_api_schemas.ex
@@ -378,6 +378,20 @@ defmodule RealtimeWeb.OpenApiSchemas do
     def response(), do: {"Not Found", "application/json", __MODULE__}
   end
 
+  defmodule ErrorResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        error: %Schema{type: :string, default: "error message"}
+      }
+    })
+
+    def response(), do: {"Error", "application/json", __MODULE__}
+  end
+
   defmodule UnauthorizedResponse do
     @moduledoc false
     require OpenApiSpex

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.25.69",
+      version: "2.26.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -175,7 +175,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     test "tenant doesn't exist", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
         conn = delete(conn, Routes.tenant_path(conn, :delete, "wrong_external_id"))
-        assert response(conn, 204)
+        assert response(conn, 404)
       end
     end
   end


### PR DESCRIPTION
Big things here:
- [x] times out `stop_all` in one second, otherwise responds with a 500
- [x] deletes tenant BEFORE invalidating the cache
- [x] tells all clients to disconnect AFTER everything else is done successfully 
- [x] ensures we actually have a tenant when Connect mod starts