### PR TITLE
feat: add jwks support

### DIFF
--- a/bench/secrets.exs
+++ b/bench/secrets.exs
@@ -12,7 +12,7 @@ string_to_decrypt = "A5mS7ggkPXm0FaKKoZtrsYNlZA3qZxFe9XA9w2YYqgU="
 
 Benchee.run(%{
   "authorize_jwt" => fn ->
-    {:ok, _} = ChannelsAuthorization.authorize_conn(jwt, jwt_secret)
+    {:ok, _} = ChannelsAuthorization.authorize_conn(jwt, jwt_secret, nil)
   end,
   "encrypt_string" => fn ->
     H.encrypt!(string_to_encrypt, secret_key)

--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -15,6 +15,7 @@ defmodule Realtime.Api.Tenant do
     field(:name, :string)
     field(:external_id, :string)
     field(:jwt_secret, :string)
+    field(:jwt_jwks, :map)
     field(:postgres_cdc_default, :string)
     field(:max_concurrent_users, :integer, default: 200)
     field(:max_events_per_second, :integer, default: 100)
@@ -65,6 +66,7 @@ defmodule Realtime.Api.Tenant do
       :name,
       :external_id,
       :jwt_secret,
+      :jwt_jwks,
       :max_concurrent_users,
       :max_events_per_second,
       :postgres_cdc_default,

--- a/lib/realtime_web/channels/auth/channels_authorization.ex
+++ b/lib/realtime_web/channels/auth/channels_authorization.ex
@@ -4,20 +4,20 @@ defmodule RealtimeWeb.ChannelsAuthorization do
   """
   require Logger
 
-  def authorize(token, secret) when is_binary(token) do
+  def authorize(token, jwt_secret, jwt_jwks) when is_binary(token) do
     token
     |> clean_token()
-    |> RealtimeWeb.JwtVerification.verify(secret)
+    |> RealtimeWeb.JwtVerification.verify(jwt_secret, jwt_jwks)
   end
 
-  def authorize(_token, _secret), do: :error
+  def authorize(_token, _jwt_secret, _jwt_jwks), do: :error
 
   defp clean_token(token) do
     Regex.replace(~r/\s|\n/, URI.decode(token), "")
   end
 
-  def authorize_conn(token, secret) do
-    case authorize(token, secret) do
+  def authorize_conn(token, jwt_secret, jwt_jwks) do
+    case authorize(token, jwt_secret, jwt_jwks) do
       {:ok, claims} ->
         required = MapSet.new(["role", "exp"])
         claims_keys = claims |> Map.keys() |> MapSet.new()

--- a/lib/realtime_web/channels/auth/jwt_verification.ex
+++ b/lib/realtime_web/channels/auth/jwt_verification.ex
@@ -25,18 +25,21 @@ defmodule RealtimeWeb.JwtVerification do
   end
 
   @hs_algorithms ["HS256", "HS384", "HS512"]
+  @rs_algorithms ["RS256", "RS384", "RS512"]
+  @es_algorithms ["ES256", "ES384", "ES512"]
+  @ed_algorithms ["Ed25519", "Ed448"]
 
-  def verify(token, secret) when is_binary(token) do
+  def verify(token, jwt_secret, jwt_jwks) when is_binary(token) do
     with {:ok, _claims} <- check_claims_format(token),
          {:ok, header} <- check_header_format(token),
-         {:ok, signer} <- generate_signer(header, secret) do
+         {:ok, signer} <- generate_signer(header, jwt_secret, jwt_jwks) do
       JwtAuthToken.verify_and_validate(token, signer)
     else
       {:error, _e} = error -> error
     end
   end
 
-  def verify(_token, _secret), do: {:error, :not_a_string}
+  def verify(_token, _jwt_secret, _jwt_jwks), do: {:error, :not_a_string}
 
   defp check_header_format(token) do
     case Joken.peek_header(token) do
@@ -52,9 +55,63 @@ defmodule RealtimeWeb.JwtVerification do
     end
   end
 
-  defp generate_signer(%{"typ" => "JWT", "alg" => alg}, jwt_secret) when alg in @hs_algorithms do
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg, "kid" => kid}, _jwt_secret, %{
+         "keys" => keys
+       })
+       when is_binary(kid) and alg in @rs_algorithms do
+    jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "RSA" and jwk["kid"] == kid end)
+
+    case jwk do
+      nil -> {:error, :error_generating_signer}
+      _ -> {:ok, Joken.Signer.create(alg, jwk)}
+    end
+  end
+
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg, "kid" => kid}, _jwt_secret, %{
+         "keys" => keys
+       })
+       when is_binary(kid) and alg in @es_algorithms do
+    jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "EC" and jwk["kid"] == kid end)
+
+    case jwk do
+      nil -> {:error, :error_generating_signer}
+      _ -> {:ok, Joken.Signer.create(alg, jwk)}
+    end
+  end
+
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg, "kid" => kid}, _jwt_secret, %{
+         "keys" => keys
+       })
+       when is_binary(kid) and alg in @ed_algorithms do
+    jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "OKP" and jwk["kid"] == kid end)
+
+    case jwk do
+      nil -> {:error, :error_generating_signer}
+      _ -> {:ok, Joken.Signer.create(alg, jwk)}
+    end
+  end
+
+  # Most Supabase Auth JWTs fall in this case, as they're usually signed with
+  # HS256, have a kid header, but there's no JWK as this is sensitive. In this
+  # case, the jwt_secret should be used.
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg, "kid" => kid}, jwt_secret, %{
+         "keys" => keys
+       })
+       when is_binary(kid) and alg in @hs_algorithms do
+    jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "oct" and jwk["kid"] == kid end)
+
+    case jwk do
+      # If there's no JWK, and HS* is being used, instead of erroring, try
+      # the jwt_secret instead.
+      nil -> {:ok, Joken.Signer.create(alg, jwt_secret)}
+      _ -> {:ok, Joken.Signer.create(alg, jwk)}
+    end
+  end
+
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg}, jwt_secret, _jwt_jwks)
+       when alg in @hs_algorithms do
     {:ok, Joken.Signer.create(alg, jwt_secret)}
   end
 
-  defp generate_signer(_header, _secret), do: {:error, :error_generating_signer}
+  defp generate_signer(_header, _jwt_secret, _jwt_jwks), do: {:error, :error_generating_signer}
 end

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -454,11 +454,10 @@ defmodule RealtimeWeb.RealtimeChannel do
     assign(socket, :access_token, tenant_token)
   end
 
-  defp confirm_token(%{
-         assigns:
-           %{jwt_secret: jwt_secret, jwt_jwks: jwt_jwks, access_token: access_token} = assigns
-       }) do
+  defp confirm_token(%{assigns: assigns}) do
     secure_key = Application.fetch_env!(:realtime, :db_enc_key)
+    %{jwt_secret: jwt_secret, access_token: access_token} = assigns
+    jwt_jwks = Map.get(assigns, :jwt_jwks)
 
     with jwt_secret_dec <- Helpers.decrypt!(jwt_secret, secure_key),
          {:ok, %{"exp" => exp} = claims} when is_integer(exp) <-

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -454,12 +454,15 @@ defmodule RealtimeWeb.RealtimeChannel do
     assign(socket, :access_token, tenant_token)
   end
 
-  defp confirm_token(%{assigns: %{jwt_secret: jwt_secret, access_token: access_token} = assigns}) do
+  defp confirm_token(%{
+         assigns:
+           %{jwt_secret: jwt_secret, jwt_jwks: jwt_jwks, access_token: access_token} = assigns
+       }) do
     secure_key = Application.fetch_env!(:realtime, :db_enc_key)
 
     with jwt_secret_dec <- Helpers.decrypt!(jwt_secret, secure_key),
          {:ok, %{"exp" => exp} = claims} when is_integer(exp) <-
-           ChannelsAuthorization.authorize_conn(access_token, jwt_secret_dec),
+           ChannelsAuthorization.authorize_conn(access_token, jwt_secret_dec, jwt_jwks),
          exp_diff when exp_diff > 0 <- exp - Joken.current_time() do
       if ref = assigns[:confirm_token_ref], do: Helpers.cancel_timer(ref)
 

--- a/lib/realtime_web/channels/realtime_channel/assign.ex
+++ b/lib/realtime_web/channels/realtime_channel/assign.ex
@@ -14,6 +14,7 @@ defmodule RealtimeWeb.RealtimeChannel.Assigns do
     :postgres_extension,
     :claims,
     :jwt_secret,
+    :jwt_jwks,
     :tenant_token,
     :access_token,
     :postgres_cdc_module,
@@ -38,6 +39,7 @@ defmodule RealtimeWeb.RealtimeChannel.Assigns do
           postgres_extension: map(),
           claims: map(),
           jwt_secret: String.t(),
+          jwt_jwks: map(),
           tenant_token: String.t(),
           access_token: String.t(),
           channel_name: String.t()

--- a/lib/realtime_web/channels/user_socket.ex
+++ b/lib/realtime_web/channels/user_socket.ex
@@ -40,6 +40,7 @@ defmodule RealtimeWeb.UserSocket do
       with %Tenant{
              extensions: extensions,
              jwt_secret: jwt_secret,
+             jwt_jwks: jwt_jwks,
              max_concurrent_users: max_conn_users,
              max_events_per_second: max_events_per_second,
              max_bytes_per_second: max_bytes_per_second,
@@ -49,11 +50,12 @@ defmodule RealtimeWeb.UserSocket do
            } <- Tenants.Cache.get_tenant_by_external_id(external_id),
            token when is_binary(token) <- access_token(params, headers),
            jwt_secret_dec <- decrypt!(jwt_secret, secure_key),
-           {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec),
+           {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec, jwt_jwks),
            {:ok, postgres_cdc_module} <- PostgresCdc.driver(postgres_cdc_default) do
         assigns = %RealtimeChannel.Assigns{
           claims: claims,
           jwt_secret: jwt_secret,
+          jwt_jwks: jwt_jwks,
           limits: %{
             max_concurrent_users: max_conn_users,
             max_events_per_second: max_events_per_second,

--- a/lib/realtime_web/open_api_schemas.ex
+++ b/lib/realtime_web/open_api_schemas.ex
@@ -64,6 +64,20 @@ defmodule RealtimeWeb.OpenApiSchemas do
             external_id: %Schema{type: :string, description: "External ID"},
             name: %Schema{type: :string, description: "Tenant name"},
             jwt_secret: %Schema{type: :string, description: "JWT secret"},
+            jwt_jwks: %Schema{
+              type: :object,
+              description: "JWKS for verifying JWTs",
+              properties: %{
+                keys: %Schema{
+                  type: :array,
+                  description: "Set of JWKs",
+                  items: %Schema{
+                    type: :object,
+                    description: "JWK"
+                  }
+                }
+              }
+            },
             max_concurrent_users: %Schema{
               type: :number,
               description: "Maximum connected concurrent clients"
@@ -174,6 +188,20 @@ defmodule RealtimeWeb.OpenApiSchemas do
         max_joins_per_second: %Schema{
           type: :number,
           description: "Maximum number of channel joins permitted for all connected clients"
+        },
+        jwt_jwks: %Schema{
+          type: :object,
+          description: "JWKS for verifying JWTs",
+          properties: %{
+            keys: %Schema{
+              type: :array,
+              description: "Set of JWKs",
+              items: %Schema{
+                type: :object,
+                description: "JWK"
+              }
+            }
+          }
         },
         inserted_at: %Schema{type: :string, format: "date-time", description: "Insert timestamp"},
         extensions: %Schema{

--- a/lib/realtime_web/plugs/auth_tenant.ex
+++ b/lib/realtime_web/plugs/auth_tenant.ex
@@ -15,10 +15,10 @@ defmodule RealtimeWeb.AuthTenant do
   def call(%{assigns: %{tenant: tenant}} = conn, _opts) do
     secure_key = Application.get_env(:realtime, :db_enc_key)
 
-    with %Tenant{jwt_secret: jwt_secret} <- tenant,
+    with %Tenant{jwt_secret: jwt_secret, jwt_jwks: jwt_jwks} <- tenant,
          token when is_binary(token) <- access_token(conn),
          jwt_secret_dec <- decrypt!(jwt_secret, secure_key),
-         {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec) do
+         {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec, jwt_jwks) do
       Logger.metadata(external_id: tenant.external_id, project: tenant.external_id)
 
       conn

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -3,7 +3,7 @@ defmodule RealtimeWeb.Router do
 
   require Logger
 
-  import RealtimeWeb.ChannelsAuthorization, only: [authorize: 2]
+  import RealtimeWeb.ChannelsAuthorization, only: [authorize: 3]
 
   pipeline :browser do
     plug(:accepts, ["html"])
@@ -143,7 +143,7 @@ defmodule RealtimeWeb.Router do
     secret = Application.fetch_env!(:realtime, secret_key)
 
     with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
-         {:ok, _claims} <- authorize(token, secret) do
+         {:ok, _claims} <- authorize(token, secret, nil) do
       conn
     else
       _ ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.26.5",
+      version: "2.27.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20240306114423_add_tenant_jwt_jwks.exs
+++ b/priv/repo/migrations/20240306114423_add_tenant_jwt_jwks.exs
@@ -1,0 +1,9 @@
+defmodule Realtime.Repo.Migrations.AdddTenantJwtJwksColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenants) do
+      add :jwt_jwks, :map, default: nil
+    end
+  end
+end

--- a/test/api_jwt_secret_test.exs
+++ b/test/api_jwt_secret_test.exs
@@ -10,7 +10,7 @@ defmodule RealtimeWeb.ApiJwtSecretTest do
   end
 
   test "api key is right", %{conn: conn} do
-    with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+    with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
       jwt = "jwt_token"
 
       conn =

--- a/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
+++ b/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
@@ -41,7 +41,7 @@ defmodule Realtime.Extensions.CdcRlsTest do
     with_mocks([
       {ChannelsAuthorization, [],
        [
-         authorize_conn: fn _, _ ->
+         authorize_conn: fn _, _, _ ->
            {:ok, %{"exp" => Joken.current_time() + 1_000, "role" => "postgres"}}
          end
        ]}

--- a/test/realtime_web/channels/auth/channels_authorization_test.exs
+++ b/test/realtime_web/channels/auth/channels_authorization_test.exs
@@ -7,26 +7,26 @@ defmodule RealtimeWeb.ChannelsAuthorizationTest do
 
   @secret ""
 
-  test "authorize/1 when token is authorized" do
+  test "authorize/3 when token is authorized" do
     input_token = "\n token %20 1 %20 2 %20 3   "
     expected_token = "token123"
 
     with_mock JwtVerification,
-      verify: fn token, @secret ->
+      verify: fn token, @secret, _jwks ->
         assert token == expected_token
         {:ok, %{}}
       end do
-      assert {:ok, %{}} = ChannelsAuthorization.authorize(input_token, @secret)
+      assert {:ok, %{}} = ChannelsAuthorization.authorize(input_token, @secret, nil)
     end
   end
 
-  test "authorize/1 when token is unauthorized" do
-    with_mock JwtVerification, verify: fn _token, _secret -> :error end do
-      assert :error = ChannelsAuthorization.authorize("bad_token", @secret)
+  test "authorize/3 when token is unauthorized" do
+    with_mock JwtVerification, verify: fn _token, _secret, _jwks -> :error end do
+      assert :error = ChannelsAuthorization.authorize("bad_token", @secret, nil)
     end
   end
 
-  test "authorize/1 when token is not a string" do
-    assert :error = ChannelsAuthorization.authorize([], @secret)
+  test "authorize/3 when token is not a string" do
+    assert :error = ChannelsAuthorization.authorize([], @secret, nil)
   end
 end

--- a/test/realtime_web/channels/auth/jwt_verification_test.exs
+++ b/test/realtime_web/channels/auth/jwt_verification_test.exs
@@ -17,77 +17,78 @@ defmodule RealtimeWeb.JwtVerificationTest do
     :ok
   end
 
-  test "verify/1 when token is not a string" do
-    assert {:error, :not_a_string} = JwtVerification.verify([], @jwt_secret)
+  test "verify/3 when token is not a string" do
+    assert {:error, :not_a_string} = JwtVerification.verify([], @jwt_secret, nil)
   end
 
-  test "verify/1 when token has invalid format" do
+  test "verify/3 when token has invalid format" do
     invalid_token = Base.encode64("{}")
 
-    assert {:error, :expected_claims_map} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, :expected_claims_map} =
+             JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token header is not a map" do
+  test "verify/3 when token header is not a map" do
     invalid_token =
       Base.encode64("[]") <> "." <> Base.encode64("{}") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token claims is not a map" do
+  test "verify/3 when token claims is not a map" do
     invalid_token =
       Base.encode64("{}") <> "." <> Base.encode64("[]") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token header does not have typ or alg" do
+  test "verify/3 when token header does not have typ or alg" do
     invalid_token =
       Base.encode64("{\"typ\": \"JWT\"}") <>
         "." <> Base.encode64("{}") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
 
     invalid_token =
       Base.encode64("{\"alg\": \"HS256\"}") <>
         "." <> Base.encode64("{}") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token header alg is not allowed" do
+  test "verify/3 when token header alg is not allowed" do
     invalid_token =
       Base.encode64("{\"typ\": \"JWT\", \"alg\": \"ZZ999\"}") <>
         "." <> Base.encode64("{}") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token is valid and alg is HS256" do
+  test "verify/3 when token is valid and alg is HS256" do
     signer = Joken.Signer.create("HS256", @jwt_secret)
 
     token = Joken.generate_and_sign!(%{}, %{}, signer)
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token is valid and alg is HS384" do
+  test "verify/3 when token is valid and alg is HS384" do
     signer = Joken.Signer.create("HS384", @jwt_secret)
 
     token = Joken.generate_and_sign!(%{}, %{}, signer)
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token is valid and alg is HS512" do
+  test "verify/3 when token is valid and alg is HS512" do
     signer = Joken.Signer.create("HS512", @jwt_secret)
 
     token = Joken.generate_and_sign!(%{}, %{}, signer)
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token has expired" do
+  test "verify/3 when token has expired" do
     signer = Joken.Signer.create(@alg, @jwt_secret)
 
     current_time = 1_610_086_801
@@ -103,7 +104,7 @@ defmodule RealtimeWeb.JwtVerificationTest do
       )
 
     assert {:error, [message: "Invalid token", claim: "exp", claim_val: 1_610_086_801]} =
-             JwtVerification.verify(token, @jwt_secret)
+             JwtVerification.verify(token, @jwt_secret, nil)
 
     token =
       Joken.generate_and_sign!(
@@ -115,10 +116,10 @@ defmodule RealtimeWeb.JwtVerificationTest do
       )
 
     assert {:error, [message: "Invalid token", claim: "exp", claim_val: 1_610_086_800]} =
-             JwtVerification.verify(token, @jwt_secret)
+             JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token has not expired" do
+  test "verify/3 when token has not expired" do
     signer = Joken.Signer.create(@alg, @jwt_secret)
 
     Mock.freeze()
@@ -133,10 +134,10 @@ defmodule RealtimeWeb.JwtVerificationTest do
         signer
       )
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token claims match expected claims from :jwt_claim_validators config" do
+  test "verify/3 when token claims match expected claims from :jwt_claim_validators config" do
     Application.put_env(:realtime, :jwt_claim_validators, %{
       "iss" => "Tester",
       "aud" => "www.test.com"
@@ -159,10 +160,10 @@ defmodule RealtimeWeb.JwtVerificationTest do
         signer
       )
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token claims do not match expected claims from :jwt_claim_validators config" do
+  test "verify/3 when token claims do not match expected claims from :jwt_claim_validators config" do
     Application.put_env(:realtime, :jwt_claim_validators, %{
       "iss" => "Issuer",
       "aud" => "www.test.com"
@@ -186,6 +187,6 @@ defmodule RealtimeWeb.JwtVerificationTest do
       )
 
     assert {:error, [message: "Invalid token", claim: "iss", claim_val: "Tester"]} =
-             JwtVerification.verify(token, @jwt_secret)
+             JwtVerification.verify(token, @jwt_secret, nil)
   end
 end

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -34,7 +34,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time() + 1_000, "role" => "postgres"}}
            end
          ]}
@@ -50,7 +50,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time() + 1_000, "role" => "postgres"}}
            end
          ]}
@@ -77,7 +77,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time() + 1, "role" => "postgres"}}
            end
          ]}
@@ -92,7 +92,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time(), "role" => "postgres"}}
            end
          ]}
@@ -106,7 +106,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time() - 1, "role" => "postgres"}}
            end
          ]}
@@ -122,7 +122,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
   describe "checks tenant db connectivity" do
     setup_with_mocks([
       {ChannelsAuthorization, [],
-       authorize_conn: fn _, _ ->
+       authorize_conn: fn _, _, _ ->
          {:ok, %{"exp" => Joken.current_time() + 1_000, "role" => "postgres"}}
        end}
     ]) do

--- a/test/realtime_web/controllers/metrics_controller_test.exs
+++ b/test/realtime_web/controllers/metrics_controller_test.exs
@@ -16,7 +16,7 @@ defmodule RealtimeWeb.MetricsControllerTest do
   end
 
   test "exporting metrics", %{conn: conn} do
-    with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+    with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
       conn = get(conn, Routes.metrics_path(conn, :index))
       assert conn.status == 200
       lines = String.split(conn.resp_body, "\n") |> length()

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -63,7 +63,7 @@ defmodule RealtimeWeb.TenantControllerTest do
 
   describe "create tenant" do
     test "renders tenant when data is valid", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         ext_id = @default_tenant_attrs["external_id"]
         conn = put(conn, Routes.tenant_path(conn, :update, ext_id), tenant: @default_tenant_attrs)
         assert %{"id" => _id, "external_id" => ^ext_id} = json_response(conn, 201)["data"]
@@ -77,7 +77,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     end
 
     test "encrypt creds", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         ext_id = @default_tenant_attrs["external_id"]
         conn = put(conn, Routes.tenant_path(conn, :update, ext_id), tenant: @default_tenant_attrs)
         [%{"settings" => settings}] = json_response(conn, 201)["data"]["extensions"]
@@ -90,7 +90,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         conn = post(conn, Routes.tenant_path(conn, :create), tenant: @invalid_attrs)
         assert json_response(conn, 422)["errors"] != %{}
       end
@@ -104,7 +104,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       conn: conn,
       tenant: %Tenant{id: id, external_id: ext_id} = _tenant
     } do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         conn = put(conn, Routes.tenant_path(conn, :update, ext_id), tenant: @update_attrs)
         assert %{"id" => ^id, "external_id" => ^ext_id} = json_response(conn, 200)["data"]
         conn = get(conn, Routes.tenant_path(conn, :show, ext_id))
@@ -117,7 +117,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, tenant: tenant} do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         conn =
           put(conn, Routes.tenant_path(conn, :update, tenant.external_id), tenant: @invalid_attrs)
 
@@ -138,7 +138,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     end
 
     test "deletes chosen tenant", %{conn: conn, tenant: tenant} do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         assert Cache.get_tenant_by_external_id(tenant.external_id)
 
         {:ok, db_conn} = Helpers.check_tenant_connection(tenant, "realtime_test")
@@ -173,7 +173,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     end
 
     test "tenant doesn't exist", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         conn = delete(conn, Routes.tenant_path(conn, :delete, "wrong_external_id"))
         assert response(conn, 404)
       end
@@ -184,7 +184,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     setup [:create_tenant]
 
     test "reload when tenant does exist", %{conn: conn, tenant: tenant} do
-      with_mock ChannelsAuthorization, authorize: fn _, _ -> {:ok, %{}} end do
+      with_mock ChannelsAuthorization, authorize: fn _, _, _ -> {:ok, %{}} end do
         Routes.tenant_path(conn, :reload, tenant.external_id)
         %{status: status} = post(conn, Routes.tenant_path(conn, :reload, "wrong_external_id"))
         assert status == 404
@@ -192,7 +192,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     end
 
     test "reload when tenant does not exist", %{conn: conn} do
-      with_mock ChannelsAuthorization, authorize: fn _, _ -> {:ok, %{}} end do
+      with_mock ChannelsAuthorization, authorize: fn _, _, _ -> {:ok, %{}} end do
         Routes.tenant_path(conn, :reload, "wrong_external_id")
         %{status: status} = post(conn, Routes.tenant_path(conn, :reload, "wrong_external_id"))
         assert status == 404
@@ -204,7 +204,7 @@ defmodule RealtimeWeb.TenantControllerTest do
     setup [:create_tenant]
 
     test "health check when tenant does not exist", %{conn: conn} do
-      with_mock ChannelsAuthorization, authorize: fn _, _ -> {:ok, %{}} end do
+      with_mock ChannelsAuthorization, authorize: fn _, _, _ -> {:ok, %{}} end do
         Routes.tenant_path(conn, :reload, "wrong_external_id")
         %{status: status} = get(conn, Routes.tenant_path(conn, :health, "wrong_external_id"))
         assert status == 404
@@ -215,7 +215,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       conn: conn,
       tenant: %Tenant{external_id: ext_id}
     } do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         conn = get(conn, Routes.tenant_path(conn, :health, ext_id))
         data = json_response(conn, 200)["data"]
         assert %{"healthy" => true, "db_connected" => false, "connected_cluster" => 0} = data
@@ -226,7 +226,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       conn: conn,
       tenant: %Tenant{external_id: ext_id}
     } do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         # Fake adding a connected client here
         # No connection to the tenant database
         UsersCounter.add(self(), ext_id)
@@ -242,7 +242,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       conn: conn,
       tenant: %Tenant{external_id: ext_id}
     } do
-      with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         # Fake adding a connected client here
         UsersCounter.add(self(), ext_id)
 

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -26,7 +26,8 @@ defmodule Generators do
         }
       ],
       "postgres_cdc_default" => "postgres_cdc_rls",
-      "jwt_secret" => "new secret"
+      "jwt_secret" => "new secret",
+      "jwt_jwks" => nil
     }
 
     override = override |> Enum.map(fn {k, v} -> {"#{k}", v} end) |> Map.new()


### PR DESCRIPTION
Adds support for verifying end-user JWTs using JWKS in addition to the JWT secret. This means that third-party authentication systems that use asymmetric JWTs can be used with Realtime.

WIP