### PR TITLE
fix: use primary sometimes

### DIFF
--- a/lib/realtime/api.ex
+++ b/lib/realtime/api.ex
@@ -159,13 +159,18 @@ defmodule Realtime.Api do
     Tenant.changeset(tenant, attrs)
   end
 
-  @spec get_tenant_by_external_id(String.t()) :: Tenant.t() | nil
-  def get_tenant_by_external_id(external_id) do
-    repo_replica = Replica.replica()
+  @spec get_tenant_by_external_id(String.t(), atom()) :: Tenant.t() | nil
+  def get_tenant_by_external_id(external_id, repo \\ :replica)
+      when repo in [:primary, :replica] do
+    repo =
+      case repo do
+        :primary -> Repo
+        :replica -> Replica.replica()
+      end
 
     Tenant
-    |> repo_replica.get_by(external_id: external_id)
-    |> repo_replica.preload(:extensions)
+    |> repo.get_by(external_id: external_id)
+    |> repo.preload(:extensions)
   end
 
   def list_extensions(type \\ "postgres_cdc_rls") do

--- a/lib/realtime/postgres_cdc.ex
+++ b/lib/realtime/postgres_cdc.ex
@@ -8,6 +8,10 @@ defmodule Realtime.PostgresCdc do
   @timeout 10_000
   @extensions Application.compile_env(:realtime, :extensions)
 
+  defmodule Exception do
+    defexception message: "PostgresCdc error!"
+  end
+
   def connect(module, opts) do
     apply(module, :handle_connect, [opts])
   end

--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -188,7 +188,7 @@ defmodule RealtimeWeb.TenantController do
 
     subs_id = UserSocket.subscribers_id(tenant_id)
 
-    with %Tenant{} = tenant <- Api.get_tenant_by_external_id(tenant_id),
+    with %Tenant{} = tenant <- Api.get_tenant_by_external_id(tenant_id, :primary),
          true <- Api.delete_tenant_by_external_id(tenant_id),
          :ok <- Cache.distributed_invalidate_tenant_cache(tenant_id),
          :ok <- PostgresCdc.stop_all(tenant, stop_all_timeout),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.26.3",
+      version: "2.26.4",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- [x] adds an option to get tenant from :primary or :replica
- [x] gets tenant from primary on delete tenant
- [x] ensures tenant exists on primary when starting PostgresCdcRls and PostgresCdcStream extensions