### PR TITLE
fix: move tenant primary check

### DIFF
--- a/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
+++ b/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
@@ -10,13 +10,18 @@ defmodule Extensions.PostgresCdcRls.WorkerSupervisor do
     SubscriptionsChecker
   }
 
+  alias Realtime.Api
+  alias Realtime.PostgresCdc.Exception
+
   def start_link(args) do
     name = PostgresCdcRls.supervisor_id(args["id"], args["region"])
     Supervisor.start_link(__MODULE__, args, name: {:via, :syn, name})
   end
 
   @impl true
-  def init(args) do
+  def init(%{"id" => tenant} = args) when is_binary(tenant) do
+    unless Api.get_tenant_by_external_id(tenant, :primary), do: raise(Exception)
+
     tid_args = Map.merge(args, %{"subscribers_tid" => :ets.new(__MODULE__, [:public, :bag])})
 
     children = [

--- a/lib/extensions/postgres_cdc_stream/worker_supervisor.ex
+++ b/lib/extensions/postgres_cdc_stream/worker_supervisor.ex
@@ -3,13 +3,18 @@ defmodule Extensions.PostgresCdcStream.WorkerSupervisor do
   use Supervisor
   alias Extensions.PostgresCdcStream, as: Stream
 
+  alias Realtime.Api
+  alias Realtime.PostgresCdc.Exception
+
   def start_link(args) do
     name = [name: {:via, :syn, {PostgresCdcStream, args["id"]}}]
     Supervisor.start_link(__MODULE__, args, name)
   end
 
   @impl true
-  def init(args) do
+  def init(%{"id" => tenant} = args) when is_binary(tenant) do
+    unless Api.get_tenant_by_external_id(tenant, :primary), do: raise(Exception)
+
     children = [
       %{
         id: Stream.Replication,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.26.4",
+      version: "2.26.5",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Tenant primary check must be in Extension inits because otherwise lots of db calls could happen when many clients connect at once, before syn has distributed process to the whole cluster.

Moving this check to the init ensures db is only called once per tenant when starting Extension supervision tree on only one node.

- [x] move tenant check to Extension inits