### PR TITLE
fix: Add proper policies around Channel Controller

### DIFF
--- a/.github/workflows/staging_linter.yml
+++ b/.github/workflows/staging_linter.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Run dialyzer
         run: mix dialyzer
       - name: Run tests
-        run: mix test
+        run: mix test --trace

--- a/lib/realtime/channels.ex
+++ b/lib/realtime/channels.ex
@@ -26,25 +26,33 @@ defmodule Realtime.Channels do
     Repo.one(conn, query, Channel)
   end
 
+  @spec create_channel(
+          map(),
+          DBConnection.t(),
+          Postgrex.option() | Keyword.t()
+        ) :: {:error, any()} | {:ok, any()}
   @doc """
   Creates a channel and supporting tables for a given channel in the tenant database using a given DBConnection.
 
   This tables will be used for to set Authorizations. Please read more at Realtime.Tenants.Authorization
   """
-  @spec create_channel(map(), DBConnection.conn()) :: {:ok, Channel.t()} | {:error, any()}
-  def create_channel(attrs, conn) do
+  def create_channel(attrs, conn, opts \\ []) do
     channel = Channel.changeset(%Channel{}, attrs)
 
-    Postgrex.transaction(conn, fn transaction_conn ->
-      with {:ok, channel} <- Repo.insert(transaction_conn, channel, Channel),
-           changeset = Broadcast.changeset(%Broadcast{}, %{channel_id: channel.id}),
-           {:ok, _} <- Repo.insert(transaction_conn, changeset, Broadcast) do
-        channel
-      else
-        {:error, changeset} ->
-          Postgrex.rollback(transaction_conn, changeset)
-      end
-    end)
+    result =
+      Postgrex.transaction(conn, fn transaction_conn ->
+        with {:ok, %Channel{} = channel} <- Repo.insert(transaction_conn, channel, Channel, opts),
+             changeset = Broadcast.changeset(%Broadcast{}, %{channel_id: channel.id}),
+             {:ok, _} <- Repo.insert(transaction_conn, changeset, Broadcast, opts) do
+          channel
+        end
+      end)
+
+    case result do
+      {:ok, %Ecto.Changeset{valid?: false} = error} -> {:error, error}
+      {:ok, {:error, error}} -> {:error, error}
+      result -> result
+    end
   end
 
   @doc """

--- a/lib/realtime/channels.ex
+++ b/lib/realtime/channels.ex
@@ -36,7 +36,7 @@ defmodule Realtime.Channels do
 
   This tables will be used for to set Authorizations. Please read more at Realtime.Tenants.Authorization
   """
-  def create_channel(attrs, conn, opts \\ []) do
+  def create_channel(attrs, conn, opts \\ [mode: :savepoint]) do
     channel = Channel.changeset(%Channel{}, attrs)
 
     result =

--- a/lib/realtime/repo.ex
+++ b/lib/realtime/repo.ex
@@ -54,7 +54,7 @@ defmodule Realtime.Repo do
           DBConnection.conn(),
           Ecto.Changeset.t(),
           module(),
-          Postgrex.option() | []
+          Postgrex.option() | Keyword.t()
         ) ::
           {:ok, struct()} | {:error, any()} | Ecto.Changeset.t()
   def insert(conn, changeset, result_struct, opts \\ []) do

--- a/lib/realtime/repo.ex
+++ b/lib/realtime/repo.ex
@@ -34,24 +34,34 @@ defmodule Realtime.Repo do
   @doc """
   Fetches one record for a given query and converts it into a given struct
   """
-  @spec one(DBConnection.conn(), Ecto.Query.t(), module()) ::
-          {:ok, struct()} | {:ok, nil} | {:error, any()}
-  def one(conn, query, result_struct) do
+  @spec one(
+          DBConnection.conn(),
+          Ecto.Query.t(),
+          module(),
+          Postgrex.option() | Keyword.t()
+        ) ::
+          {:error, any()} | {:ok, struct()} | Ecto.Changeset.t()
+  def one(conn, query, result_struct, opts \\ []) do
     conn
-    |> run_all_query(query)
-    |> result_to_single_struct(result_struct)
+    |> run_all_query(query, opts)
+    |> result_to_single_struct(result_struct, nil)
   end
 
   @doc """
   Inserts a given changeset into the database and converts the result into a given struct
   """
-  @spec insert(DBConnection.conn(), Ecto.Changeset.t(), module()) ::
+  @spec insert(
+          DBConnection.conn(),
+          Ecto.Changeset.t(),
+          module(),
+          Postgrex.option() | []
+        ) ::
           {:ok, struct()} | {:error, any()} | Ecto.Changeset.t()
-  def insert(conn, changeset, result_struct) do
+  def insert(conn, changeset, result_struct, opts \\ []) do
     with {:ok, {query, args}} <- insert_query_from_changeset(changeset) do
       conn
-      |> run_query_with_trap(query, args)
-      |> result_to_single_struct(result_struct)
+      |> run_query_with_trap(query, args, opts)
+      |> result_to_single_struct(result_struct, changeset)
     end
   end
 
@@ -75,19 +85,28 @@ defmodule Realtime.Repo do
     with {:ok, {query, args}} <- update_query_from_changeset(changeset) do
       conn
       |> run_query_with_trap(query, args, opts)
-      |> result_to_single_struct(result_struct)
+      |> result_to_single_struct(result_struct, changeset)
     end
   end
 
-  defp result_to_single_struct({:error, _} = error, _), do: error
+  defp result_to_single_struct(
+         {:error,
+          %Postgrex.Error{postgres: %{code: :unique_violation, constraint: "channels_name_index"}}},
+         _struct,
+         changeset
+       ) do
+    Ecto.Changeset.add_error(changeset, :name, "has already been taken")
+  end
 
-  defp result_to_single_struct({:ok, %Postgrex.Result{rows: []}}, _), do: {:error, :not_found}
+  defp result_to_single_struct({:error, _} = error, _, _), do: error
 
-  defp result_to_single_struct({:ok, %Postgrex.Result{rows: [row], columns: columns}}, struct) do
+  defp result_to_single_struct({:ok, %Postgrex.Result{rows: []}}, _, _), do: {:error, :not_found}
+
+  defp result_to_single_struct({:ok, %Postgrex.Result{rows: [row], columns: columns}}, struct, _) do
     {:ok, load(struct, Enum.zip(columns, row))}
   end
 
-  defp result_to_single_struct({:ok, %Postgrex.Result{num_rows: num_rows}}, _) do
+  defp result_to_single_struct({:ok, %Postgrex.Result{num_rows: num_rows}}, _, _) do
     raise("expected at most one result but got #{num_rows} in result")
   end
 
@@ -133,7 +152,7 @@ defmodule Realtime.Repo do
     {:ok, to_sql(:update_all, query)}
   end
 
-  defp run_all_query(conn, query, opts \\ []) do
+  defp run_all_query(conn, query, opts) do
     {query, args} = to_sql(:all, query)
     run_query_with_trap(conn, query, args, opts)
   end

--- a/lib/realtime/tenants/authorization/permissions/broadcast_policies.ex
+++ b/lib/realtime/tenants/authorization/permissions/broadcast_policies.ex
@@ -31,10 +31,10 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPolicies do
   def check_read_policies(conn, %Policies{} = policies, %Authorization{
         channel: %Channel{id: channel_id}
       }) do
-    query = from(b in Broadcast, where: b.channel_id == ^channel_id)
-
     Postgrex.transaction(conn, fn transaction_conn ->
-      case Repo.one(conn, query, Broadcast) do
+      query = from(b in Broadcast, where: b.channel_id == ^channel_id)
+
+      case Repo.one(conn, query, Broadcast, mode: :savepoint) do
         {:ok, %Broadcast{}} ->
           Policies.update_policies(policies, :broadcast, :read, true)
 
@@ -60,10 +60,10 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPolicies do
   def check_write_policies(conn, policies, %Authorization{
         channel: %Channel{id: channel_id}
       }) do
-    query = from(b in Broadcast, where: b.channel_id == ^channel_id)
-
     Postgrex.transaction(conn, fn transaction_conn ->
-      case Repo.one(conn, query, Broadcast) do
+      query = from(b in Broadcast, where: b.channel_id == ^channel_id)
+
+      case Repo.one(conn, query, Broadcast, mode: :savepoint) do
         {:ok, %Broadcast{} = broadcast} ->
           changeset = Broadcast.check_changeset(broadcast, %{check: true})
 

--- a/lib/realtime/tenants/authorization/permissions/channel_policies.ex
+++ b/lib/realtime/tenants/authorization/permissions/channel_policies.ex
@@ -12,6 +12,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPolicies do
   import Ecto.Query
 
   alias Realtime.Api.Channel
+  alias Realtime.Channels
   alias Realtime.Repo
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
@@ -70,31 +71,56 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPolicies do
   end
 
   @impl true
-  def check_write_policies(_conn, policies, %Authorization{channel: nil}) do
+  def check_write_policies(_conn, policies, %Authorization{
+        channel: nil,
+        channel_name: nil
+      }) do
     {:ok, Policies.update_policies(policies, :channel, :write, false)}
+  end
+
+  def check_write_policies(conn, policies, %Authorization{
+        channel: nil,
+        channel_name: channel_name
+      }) do
+    Postgrex.transaction(conn, fn transaction_conn ->
+      case Channels.create_channel(%{name: channel_name}, transaction_conn, mode: :savepoint) do
+        {:ok, %{id: id}} ->
+          Channels.delete_channel_by_id(id, transaction_conn)
+          Policies.update_policies(policies, :channel, :write, true)
+
+        {:error, %Postgrex.Error{postgres: %{code: :insufficient_privilege}}} ->
+          Policies.update_policies(policies, :channel, :write, false)
+
+        {:error, error} ->
+          Logger.error("Error getting channel write policies for connection: #{inspect(error)}")
+          Postgrex.rollback(transaction_conn, error)
+      end
+    end)
   end
 
   def check_write_policies(conn, policies, %Authorization{channel: channel}) do
     changeset = Channel.check_changeset(channel, %{check: true})
 
-    case Repo.update(conn, changeset, Channel, mode: :savepoint) do
-      {:ok, %Channel{check: true} = channel} ->
-        revert_changeset = Channel.check_changeset(channel, %{check: false})
-        {:ok, _} = Repo.update(conn, revert_changeset, Channel)
-        {:ok, Policies.update_policies(policies, :channel, :write, true)}
+    Postgrex.transaction(conn, fn transaction_conn ->
+      case Repo.update(transaction_conn, changeset, Channel, mode: :savepoint) do
+        {:ok, %Channel{check: true} = channel} ->
+          revert_changeset = Channel.check_changeset(channel, %{check: false})
+          {:ok, _} = Repo.update(transaction_conn, revert_changeset, Channel)
+          Policies.update_policies(policies, :channel, :write, true)
 
-      {:ok, _} ->
-        {:ok, Policies.update_policies(policies, :channel, :write, false)}
+        {:ok, _} ->
+          Policies.update_policies(policies, :channel, :write, false)
 
-      {:error, %Postgrex.Error{postgres: %{code: :insufficient_privilege}}} ->
-        {:ok, Policies.update_policies(policies, :channel, :write, false)}
+        {:error, %Postgrex.Error{postgres: %{code: :insufficient_privilege}}} ->
+          Policies.update_policies(policies, :channel, :write, false)
 
-      {:error, :not_found} ->
-        {:ok, Policies.update_policies(policies, :channel, :write, false)}
+        {:error, :not_found} ->
+          Policies.update_policies(policies, :channel, :write, false)
 
-      {:error, error} ->
-        Logger.error("Error getting channel write policies for connection: #{inspect(error)}")
-        {:error, error}
-    end
+        {:error, error} ->
+          Logger.error("Error getting channel write policies for connection: #{inspect(error)}")
+          Postgrex.rollback(transaction_conn, error)
+      end
+    end)
   end
 end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -44,7 +44,8 @@ defmodule Realtime.Tenants.Migrations do
     EnableChannelsRls,
     AddChannelsColumnForWriteCheck,
     AddUpdateGrantToChannels,
-    AddBroadcastsPoliciesTable
+    AddBroadcastsPoliciesTable,
+    AddInsertAndDeleteGrantToChannels
   }
 
   alias Realtime.Helpers
@@ -87,7 +88,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_231_204_144_025, EnableChannelsRls},
     {20_240_108_234_812, AddChannelsColumnForWriteCheck},
     {20_240_109_165_339, AddUpdateGrantToChannels},
-    {20_240_227_174_441, AddBroadcastsPoliciesTable}
+    {20_240_227_174_441, AddBroadcastsPoliciesTable},
+    {20_240_311_171_622, AddInsertAndDeleteGrantToChannels}
   ]
 
   @spec run_migrations(map()) :: {:ok, [integer()]} | {:error, any()}

--- a/lib/realtime/tenants/repo/migrations/20240311171622_add_insert_and_delete_grant_to_channels.ex
+++ b/lib/realtime/tenants/repo/migrations/20240311171622_add_insert_and_delete_grant_to_channels.ex
@@ -1,0 +1,19 @@
+defmodule Realtime.Tenants.Migrations.AddInsertAndDeleteGrantToChannels do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    GRANT INSERT, DELETE ON realtime.channels TO postgres, anon, authenticated, service_role
+    """)
+
+    execute("""
+    GRANT INSERT ON realtime.broadcasts TO postgres, anon, authenticated, service_role
+    """)
+
+    execute("""
+    GRANT USAGE ON SEQUENCE realtime.broadcasts_id_seq TO postgres, anon, authenticated, service_role
+    """)
+  end
+end

--- a/lib/realtime_web/controllers/channels_controller.ex
+++ b/lib/realtime_web/controllers/channels_controller.ex
@@ -118,7 +118,15 @@ defmodule RealtimeWeb.ChannelsController do
     }
   )
 
-  def create(%{assigns: %{tenant: tenant}} = conn, params) do
+  def create(
+        %{
+          assigns: %{
+            tenant: tenant,
+            policies: %Policies{channel: %ChannelPolicies{write: true}}
+          }
+        } = conn,
+        params
+      ) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id),
          {:ok, channel} <- Channels.create_channel(params, db_conn) do
       conn
@@ -126,6 +134,8 @@ defmodule RealtimeWeb.ChannelsController do
       |> json(channel)
     end
   end
+
+  def create(_conn, _params), do: {:error, :unauthorized}
 
   operation(:delete,
     summary: "Deletes a channel",
@@ -152,12 +162,22 @@ defmodule RealtimeWeb.ChannelsController do
     }
   )
 
-  def delete(%{assigns: %{tenant: tenant}} = conn, %{"id" => id}) do
+  def delete(
+        %{
+          assigns: %{
+            tenant: tenant,
+            policies: %Policies{channel: %ChannelPolicies{write: true}}
+          }
+        } = conn,
+        %{"id" => id}
+      ) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id),
          :ok <- Channels.delete_channel_by_id(id, db_conn) do
       send_resp(conn, :accepted, "")
     end
   end
+
+  def delete(_conn, _params), do: {:error, :unauthorized}
 
   operation(:update,
     summary: "Update user channel",
@@ -185,7 +205,15 @@ defmodule RealtimeWeb.ChannelsController do
     }
   )
 
-  def update(%{assigns: %{tenant: tenant}} = conn, %{"id" => id} = params) do
+  def update(
+        %{
+          assigns: %{
+            tenant: tenant,
+            policies: %Policies{channel: %ChannelPolicies{write: true}}
+          }
+        } = conn,
+        %{"id" => id} = params
+      ) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id),
          {:ok, channel} <- Channels.update_channel_by_id(id, params, db_conn) do
       conn
@@ -193,4 +221,6 @@ defmodule RealtimeWeb.ChannelsController do
       |> json(channel)
     end
   end
+
+  def update(_conn, _params), do: {:error, :unauthorized}
 end

--- a/lib/realtime_web/controllers/fallback_controller.ex
+++ b/lib/realtime_web/controllers/fallback_controller.ex
@@ -20,7 +20,7 @@ defmodule RealtimeWeb.FallbackController do
     |> render("error.json", message: "Not found")
   end
 
-  def call(conn, {:error, :unauthorized}) do
+  def call(conn, {:error, _}) do
     conn
     |> put_status(:unauthorized)
     |> put_view(RealtimeWeb.ErrorView)

--- a/lib/realtime_web/plugs/rls_authorization.ex
+++ b/lib/realtime_web/plugs/rls_authorization.ex
@@ -27,7 +27,8 @@ defmodule RealtimeWeb.RlsAuthorization do
          {:ok, conn} <- Authorization.get_authorizations(conn, db_conn, params) do
       conn
     else
-      error -> conn |> FallbackController.call(error) |> halt()
+      error ->
+        conn |> FallbackController.call(error) |> halt()
     end
   end
 
@@ -38,7 +39,7 @@ defmodule RealtimeWeb.RlsAuthorization do
 
     params =
       cond do
-        conn.method == "POST" && Map.get(body_params, "name", nil) ->
+        Map.get(body_params, "name", nil) ->
           name = Map.fetch!(body_params, "name")
           Map.put(params, :channel_name, name)
 

--- a/lib/realtime_web/plugs/rls_authorization.ex
+++ b/lib/realtime_web/plugs/rls_authorization.ex
@@ -10,6 +10,7 @@ defmodule RealtimeWeb.RlsAuthorization do
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Connect
 
+  alias RealtimeWeb.FallbackController
   def init(opts), do: opts
 
   def call(%Plug.Conn{assigns: %{tenant: tenant}} = conn, _opts) do
@@ -26,21 +27,32 @@ defmodule RealtimeWeb.RlsAuthorization do
          {:ok, conn} <- Authorization.get_authorizations(conn, db_conn, params) do
       conn
     else
-      error ->
-        Logger.error("Error authorizing connection: #{inspect(error)}")
-        unauthorized(conn)
+      error -> conn |> FallbackController.call(error) |> halt()
     end
   end
 
   def call(conn, _opts), do: unauthorized(conn) |> halt()
 
-  defp set_channel_params_for_authorization_check(%{path_params: path_params}, db_conn, params) do
+  defp set_channel_params_for_authorization_check(conn, db_conn, params) do
+    %{path_params: path_params, body_params: body_params} = conn
+
+    params =
+      cond do
+        conn.method == "POST" && Map.get(body_params, "name", nil) ->
+          name = Map.get(body_params, "name")
+          Map.put(params, :channel_name, name)
+
+        true ->
+          params
+      end
+
     with {:ok, id} <- Map.fetch(path_params, "id"),
          {:ok, channel} <- Channels.get_channel_by_id(id, db_conn) do
-      Map.put(params, :channel, channel)
+      params
+      |> Map.put(:channel, channel)
+      |> Map.put(:channel_name, channel.name)
     else
-      _ ->
-        Map.put(params, :channel, nil)
+      _ -> Map.put(params, :channel, nil)
     end
   end
 

--- a/lib/realtime_web/plugs/rls_authorization.ex
+++ b/lib/realtime_web/plugs/rls_authorization.ex
@@ -39,7 +39,7 @@ defmodule RealtimeWeb.RlsAuthorization do
     params =
       cond do
         conn.method == "POST" && Map.get(body_params, "name", nil) ->
-          name = Map.get(body_params, "name")
+          name = Map.fetch!(body_params, "name")
           Map.put(params, :channel_name, name)
 
         true ->

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -109,7 +109,7 @@ defmodule RealtimeWeb.Router do
   scope "/v3/api", RealtimeWeb do
     pipe_through([:open_cors, :tenant_api, :secure_tenant_api, :channel_rls_authorization])
 
-    resources("/channels", ChannelsController, only: [:index, :show])
+    resources("/channels", ChannelsController, only: [:index, :show, :create, :update, :delete])
   end
 
   # Enables LiveDashboard only for development

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.26.6",
+      version: "2.26.7",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -225,8 +225,8 @@ defmodule Realtime.Integration.RtChannelTest do
   test "private broadcast with valid channel with permissions sends message" do
     [tenant] = Repo.all(Tenant)
 
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-    on_exit(fn -> Process.exit(db_conn, :normal) end)
+    start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
+    {:ok, db_conn} = Connect.get_status(tenant.external_id)
 
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
@@ -265,7 +265,9 @@ defmodule Realtime.Integration.RtChannelTest do
   test "private broadcast with valid channel no write permissions won't send message" do
     [tenant] = Repo.all(Tenant)
 
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
+    {:ok, db_conn} = Connect.get_status(tenant.external_id)
+
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
 
@@ -304,7 +306,9 @@ defmodule Realtime.Integration.RtChannelTest do
   test "private broadcast with valid channel but no read permissions on broadcast does not connect" do
     [tenant] = Repo.all(Tenant)
 
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
+    {:ok, db_conn} = Connect.get_status(tenant.external_id)
+
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
 
@@ -335,7 +339,9 @@ defmodule Realtime.Integration.RtChannelTest do
   test "private broadcast with valid channel but no read permissions on channel does not connect" do
     [tenant] = Repo.all(Tenant)
 
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
+    {:ok, db_conn} = Connect.get_status(tenant.external_id)
+
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
 
@@ -365,7 +371,9 @@ defmodule Realtime.Integration.RtChannelTest do
   test "private broadcast with non existing channel fails to join" do
     [tenant] = Repo.all(Tenant)
 
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
+    {:ok, db_conn} = Connect.get_status(tenant.external_id)
+
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
 

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -1,7 +1,8 @@
 Code.require_file("../support/websocket_client.exs", __DIR__)
 
 defmodule Realtime.Integration.RtChannelTest do
-  use RealtimeWeb.ConnCase
+  # async: false due to the fact that multiple operations against the database will use the same connection
+  use RealtimeWeb.ConnCase, async: false
   import ExUnit.CaptureLog
 
   require Logger

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -226,6 +226,8 @@ defmodule Realtime.Integration.RtChannelTest do
     [tenant] = Repo.all(Tenant)
 
     {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    on_exit(fn -> Process.exit(db_conn, :normal) end)
+
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
 

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -232,7 +232,17 @@ defmodule Realtime.Integration.RtChannelTest do
     clean_table(db_conn, "realtime", "channels")
 
     channel = channel_fixture(tenant)
-    create_rls_policies(db_conn, [:read_channel, :read_broadcast, :write_broadcast], channel)
+
+    create_rls_policies(
+      db_conn,
+      [
+        :authenticated_read_channel,
+        :authenticated_read_broadcast,
+        :authenticated_write_broadcast
+      ],
+      channel
+    )
+
     socket = get_connection("authenticated")
     config = %{broadcast: %{self: true, public: false}}
     topic = "realtime:#{channel.name}"
@@ -272,7 +282,13 @@ defmodule Realtime.Integration.RtChannelTest do
     clean_table(db_conn, "realtime", "channels")
 
     channel = channel_fixture(tenant)
-    create_rls_policies(db_conn, [:read_channel, :read_broadcast], channel)
+
+    create_rls_policies(
+      db_conn,
+      [:authenticated_read_channel, :authenticated_read_broadcast],
+      channel
+    )
+
     socket = get_connection("authenticated")
     config = %{broadcast: %{self: true, public: false}}
     topic = "realtime:#{channel.name}"
@@ -313,7 +329,7 @@ defmodule Realtime.Integration.RtChannelTest do
     clean_table(db_conn, "realtime", "channels")
 
     channel = channel_fixture(tenant)
-    create_rls_policies(db_conn, [:read_channel], channel)
+    create_rls_policies(db_conn, [:authenticated_read_channel], channel)
     socket = get_connection("authenticated")
     config = %{broadcast: %{self: true, public: false}}
     topic = "realtime:#{channel.name}"
@@ -346,7 +362,7 @@ defmodule Realtime.Integration.RtChannelTest do
     clean_table(db_conn, "realtime", "channels")
 
     channel = channel_fixture(tenant)
-    create_rls_policies(db_conn, [:read_broadcast], channel)
+    create_rls_policies(db_conn, [:authenticated_read_broadcast], channel)
     socket = get_connection("authenticated")
     config = %{broadcast: %{self: true, public: false}}
     topic = "realtime:#{channel.name}"

--- a/test/realtime/channels/cache_test.exs
+++ b/test/realtime/channels/cache_test.exs
@@ -8,6 +8,7 @@ defmodule Realtime.Channels.CacheTest do
     tenant = tenant_fixture()
     channel = channel_fixture(tenant)
     {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    on_exit(fn -> Process.exit(db_conn, :normal) end)
     %{channel: channel, db_conn: db_conn}
   end
 

--- a/test/realtime/channels/cache_test.exs
+++ b/test/realtime/channels/cache_test.exs
@@ -7,8 +7,10 @@ defmodule Realtime.Channels.CacheTest do
   setup do
     tenant = tenant_fixture()
     channel = channel_fixture(tenant)
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-    on_exit(fn -> Process.exit(db_conn, :normal) end)
+
+    start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
+    {:ok, db_conn} = Connect.get_status(tenant.external_id)
+
     %{channel: channel, db_conn: db_conn}
   end
 

--- a/test/realtime/channels_test.exs
+++ b/test/realtime/channels_test.exs
@@ -40,7 +40,7 @@ defmodule Realtime.ChannelsTest do
     end
   end
 
-  describe "create/2" do
+  describe "create_channel/2" do
     test "creates a channel and a broadcast entry in tenant database", %{conn: conn} do
       name = random_string()
 
@@ -55,6 +55,16 @@ defmodule Realtime.ChannelsTest do
                Channels.create_channel(%{}, conn)
 
       assert ^errors = [name: {"can't be blank", [validation: :required]}]
+    end
+
+    test "already repeating channel returns changeset", %{conn: conn} do
+      name = random_string()
+      Channels.create_channel(%{name: name}, conn)
+
+      assert {:error, %Ecto.Changeset{valid?: false, errors: errors}} =
+               Channels.create_channel(%{name: name}, conn)
+
+      assert ^errors = [name: {"has already been taken", []}]
     end
   end
 

--- a/test/realtime/channels_test.exs
+++ b/test/realtime/channels_test.exs
@@ -2,17 +2,20 @@ defmodule Realtime.ChannelsTest do
   # async: false due to the fact that multiple operations against the database will use the same connection
   use Realtime.DataCase, async: false
 
-  alias Realtime.Channels
   alias Realtime.Api.Broadcast
   alias Realtime.Api.Channel
-  alias Realtime.Tenants
+  alias Realtime.Channels
+  alias Realtime.Tenants.Connect
 
   setup do
     tenant = tenant_fixture()
-    {:ok, conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
+
+    {:ok, conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
     clean_table(conn, "realtime", "broadcasts")
     clean_table(conn, "realtime", "channels")
 
+    on_exit(fn -> Process.exit(conn, :normal) end)
     %{conn: conn, tenant: tenant}
   end
 

--- a/test/realtime/channels_test.exs
+++ b/test/realtime/channels_test.exs
@@ -10,7 +10,9 @@ defmodule Realtime.ChannelsTest do
   setup do
     tenant = tenant_fixture()
 
-    {:ok, conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    {:ok, pid} = Connect.connect(tenant.external_id)
+    Process.link(pid)
+    {:ok, conn} = Connect.get_status(tenant.external_id)
 
     clean_table(conn, "realtime", "broadcasts")
     clean_table(conn, "realtime", "channels")

--- a/test/realtime/channels_test.exs
+++ b/test/realtime/channels_test.exs
@@ -1,4 +1,5 @@
 defmodule Realtime.ChannelsTest do
+  # async: false due to the fact that multiple operations against the database will use the same connection
   use Realtime.DataCase, async: false
 
   alias Realtime.Channels

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -11,11 +11,13 @@ defmodule Realtime.RepoTest do
   setup do
     tenant = tenant_fixture()
 
-    {:ok, conn} = Connect.lookup_or_start_connection(tenant.external_id)
-    clean_table(conn, "realtime", "channels")
-    clean_table(conn, "realtime", "broadcasts")
+    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
 
-    %{conn: conn, tenant: tenant}
+    clean_table(db_conn, "realtime", "channels")
+    clean_table(db_conn, "realtime", "broadcasts")
+
+    on_exit(fn -> Process.exit(db_conn, :normal) end)
+    %{db_conn: db_conn, tenant: tenant}
   end
 
   describe "with_dynamic_repo/2" do
@@ -130,129 +132,129 @@ defmodule Realtime.RepoTest do
   end
 
   describe "all/3" do
-    test "fetches multiple entries and loads a given struct", %{conn: conn, tenant: tenant} do
+    test "fetches multiple entries and loads a given struct", %{db_conn: db_conn, tenant: tenant} do
       channel_1 = channel_fixture(tenant)
       channel_2 = channel_fixture(tenant)
 
-      assert {:ok, [^channel_1, ^channel_2] = res} = Repo.all(conn, Channel, Channel)
+      assert {:ok, [^channel_1, ^channel_2] = res} = Repo.all(db_conn, Channel, Channel)
       assert Enum.all?(res, &(Ecto.get_meta(&1, :state) == :loaded))
     end
 
-    test "handles exceptions", %{conn: conn} do
-      Process.exit(conn, :kill)
-      assert {:error, :postgrex_exception} = Repo.all(conn, from(c in Channel), Channel)
+    test "handles exceptions", %{db_conn: db_conn} do
+      Process.exit(db_conn, :kill)
+      assert {:error, :postgrex_exception} = Repo.all(db_conn, from(c in Channel), Channel)
     end
   end
 
   describe "one/3" do
-    test "fetches one entry and loads a given struct", %{conn: conn, tenant: tenant} do
+    test "fetches one entry and loads a given struct", %{db_conn: db_conn, tenant: tenant} do
       channel_1 = channel_fixture(tenant)
       _channel_2 = channel_fixture(tenant)
       query = from c in Channel, where: c.id == ^channel_1.id
-      assert {:ok, ^channel_1} = Repo.one(conn, query, Channel)
+      assert {:ok, ^channel_1} = Repo.one(db_conn, query, Channel)
       assert Ecto.get_meta(channel_1, :state) == :loaded
     end
 
-    test "raises exception on multiple results", %{conn: conn, tenant: tenant} do
+    test "raises exception on multiple results", %{db_conn: db_conn, tenant: tenant} do
       _channel_1 = channel_fixture(tenant)
       _channel_2 = channel_fixture(tenant)
 
       assert_raise RuntimeError, "expected at most one result but got 2 in result", fn ->
-        Repo.one(conn, Channel, Channel)
+        Repo.one(db_conn, Channel, Channel)
       end
     end
 
-    test "if not found, returns not found error", %{conn: conn} do
+    test "if not found, returns not found error", %{db_conn: db_conn} do
       query = from c in Channel, where: c.name == "potato"
-      assert {:error, :not_found} = Repo.one(conn, query, Channel)
+      assert {:error, :not_found} = Repo.one(db_conn, query, Channel)
     end
 
-    test "handles exceptions", %{conn: conn} do
-      Process.exit(conn, :kill)
+    test "handles exceptions", %{db_conn: db_conn} do
+      Process.exit(db_conn, :kill)
       query = from c in Channel, where: c.name == "potato"
-      assert {:error, :postgrex_exception} = Repo.one(conn, query, Channel)
+      assert {:error, :postgrex_exception} = Repo.one(db_conn, query, Channel)
     end
   end
 
   describe "insert/3" do
-    test "inserts a new entry with a given changeset and returns struct", %{conn: conn} do
+    test "inserts a new entry with a given changeset and returns struct", %{db_conn: db_conn} do
       changeset = Channel.changeset(%Channel{}, %{name: "foo"})
-      assert {:ok, %Channel{}} = Repo.insert(conn, changeset, Channel)
+      assert {:ok, %Channel{}} = Repo.insert(db_conn, changeset, Channel)
     end
 
-    test "returns changeset if changeset is invalid", %{conn: conn} do
+    test "returns changeset if changeset is invalid", %{db_conn: db_conn} do
       changeset = Channel.changeset(%Channel{}, %{})
-      res = Repo.insert(conn, changeset, Channel)
+      res = Repo.insert(db_conn, changeset, Channel)
       assert {:error, %Ecto.Changeset{valid?: false}} = res
     end
 
-    test "returns a Changeset on Changeset error", %{conn: conn} do
+    test "returns a Changeset on Changeset error", %{db_conn: db_conn} do
       changeset = Channel.changeset(%Channel{}, %{name: "foo"})
-      assert {:ok, _} = Repo.insert(conn, changeset, Channel)
+      assert {:ok, _} = Repo.insert(db_conn, changeset, Channel)
 
       assert %Ecto.Changeset{valid?: false, errors: [name: {"has already been taken", []}]} =
-               Repo.insert(conn, changeset, Channel)
+               Repo.insert(db_conn, changeset, Channel)
     end
 
-    test "handles exceptions", %{conn: conn} do
-      Process.exit(conn, :kill)
+    test "handles exceptions", %{db_conn: db_conn} do
+      Process.exit(db_conn, :kill)
       changeset = Channel.changeset(%Channel{}, %{name: "foo"})
-      assert {:error, :postgrex_exception} = Repo.insert(conn, changeset, Channel)
+      assert {:error, :postgrex_exception} = Repo.insert(db_conn, changeset, Channel)
     end
   end
 
   describe "del/3" do
-    test "deletes all from query entry", %{conn: conn, tenant: tenant} do
+    test "deletes all from query entry", %{db_conn: db_conn, tenant: tenant} do
       Stream.repeatedly(fn -> channel_fixture(tenant) end) |> Enum.take(3)
-      assert {:ok, 3} = Repo.del(conn, Channel)
+      assert {:ok, 3} = Repo.del(db_conn, Channel)
     end
 
-    test "raises error on bad queries", %{conn: conn} do
+    test "raises error on bad queries", %{db_conn: db_conn} do
       # wrong id type
       query = from c in Channel, where: c.id == "potato"
 
       assert_raise Ecto.QueryError, fn ->
-        Repo.del(conn, query)
+        Repo.del(db_conn, query)
       end
     end
 
-    test "handles exceptions", %{conn: conn} do
-      Process.exit(conn, :kill)
-      assert {:error, :postgrex_exception} = Repo.del(conn, Channel)
+    test "handles exceptions", %{db_conn: db_conn} do
+      Process.exit(db_conn, :kill)
+      assert {:error, :postgrex_exception} = Repo.del(db_conn, Channel)
     end
   end
 
   describe "update/3" do
     test "updates a new entry with a given changeset and returns struct", %{
-      conn: conn,
+      db_conn: db_conn,
       tenant: tenant
     } do
       channel = channel_fixture(tenant)
       changeset = Channel.changeset(channel, %{name: "foo"})
-      assert {:ok, %Channel{}} = Repo.update(conn, changeset, Channel)
+      assert {:ok, %Channel{}} = Repo.update(db_conn, changeset, Channel)
     end
 
-    test "returns changeset if changeset is invalid", %{conn: conn, tenant: tenant} do
+    test "returns changeset if changeset is invalid", %{db_conn: db_conn, tenant: tenant} do
       channel = channel_fixture(tenant)
       changeset = Channel.changeset(channel, %{name: 0})
-      res = Repo.update(conn, changeset, Channel)
+      res = Repo.update(db_conn, changeset, Channel)
       assert {:error, %Ecto.Changeset{valid?: false}} = res
     end
 
-    test "returns an Changeset on Changeset error", %{conn: conn, tenant: tenant} do
+    test "returns an Changeset on Changeset error", %{db_conn: db_conn, tenant: tenant} do
       channel = channel_fixture(tenant)
       channel_to_update = channel_fixture(tenant)
 
       changeset = Channel.changeset(channel_to_update, %{name: channel.name})
 
       assert %Ecto.Changeset{valid?: false, errors: [name: {"has already been taken", []}]} =
-               Repo.update(conn, changeset, Channel)
+               Repo.update(db_conn, changeset, Channel)
     end
 
-    test "handles exceptions", %{tenant: tenant, conn: conn} do
+    test "handles exceptions", %{tenant: tenant, db_conn: db_conn} do
       changeset = Channel.changeset(channel_fixture(tenant), %{name: "foo"})
-      Process.exit(conn, :kill)
-      assert {:error, :postgrex_exception} = Repo.update(conn, changeset, Channel)
+      Process.exit(db_conn, :kill)
+      assert {:error, :postgrex_exception} = Repo.update(db_conn, changeset, Channel)
     end
   end
 

--- a/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
@@ -3,10 +3,10 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
   use Realtime.DataCase, async: false
 
   alias Realtime.Api.Broadcast
-  alias Realtime.Tenants
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Connect
 
   alias RealtimeWeb.Joken.CurrentTime
 
@@ -143,7 +143,8 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
     start_supervised!(CurrentTime.Mock)
     tenant = tenant_fixture()
 
-    {:ok, db_conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
+    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
     clean_table(db_conn, "realtime", "channels")
     clean_table(db_conn, "realtime", "broadcasts")
     channel = channel_fixture(tenant)

--- a/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
@@ -1,5 +1,6 @@
 defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
-  use Realtime.DataCase
+  # async: false due to the fact that multiple operations against the database will use the same connection
+  use Realtime.DataCase, async: false
 
   alias Realtime.Api.Broadcast
   alias Realtime.Tenants

--- a/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
@@ -13,7 +13,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
   describe "check_read_policies/3" do
     setup [:rls_context]
 
-    @tag role: "authenticated", policies: [:read_broadcast]
+    @tag role: "authenticated", policies: [:authenticated_read_broadcast]
     test "authenticated user has read policies", context do
       Postgrex.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, context.authorization_context)
@@ -29,7 +29,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
       end)
     end
 
-    @tag role: "anon", policies: [:read_broadcast]
+    @tag role: "anon", policies: [:authenticated_read_broadcast]
     test "anon user has read policies", context do
       Postgrex.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, context.authorization_context)
@@ -83,7 +83,8 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
   describe "check_write_policies/3" do
     setup [:rls_context]
 
-    @tag role: "authenticated", policies: [:read_broadcast, :write_broadcast]
+    @tag role: "authenticated",
+         policies: [:authenticated_read_broadcast, :authenticated_write_broadcast]
     test "authenticated user has write policies and reverts check", context do
       query = from(b in Broadcast, where: b.channel_id == ^context.channel.id)
       {:ok, %Broadcast{check: check}} = Repo.one(context.db_conn, query, Broadcast)
@@ -105,7 +106,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
       assert {:ok, %{check: ^check}} = Repo.one(context.db_conn, query, Broadcast)
     end
 
-    @tag role: "anon", policies: [:read_broadcast, :write_broadcast]
+    @tag role: "anon", policies: [:authenticated_read_broadcast, :authenticated_write_broadcast]
     test "anon user has no write policies", context do
       Postgrex.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, context.authorization_context)

--- a/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
@@ -7,10 +7,10 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
   alias Realtime.Api.Channel
   alias Realtime.Channels
   alias Realtime.Repo
-  alias Realtime.Tenants
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
+  alias Realtime.Tenants.Connect
 
   alias RealtimeWeb.Joken.CurrentTime
 
@@ -218,7 +218,9 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
   def rls_context(context) do
     start_supervised!(CurrentTime.Mock)
     tenant = tenant_fixture()
-    {:ok, db_conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
+
+    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
     clean_table(db_conn, "realtime", "channels")
     clean_table(db_conn, "realtime", "broadcasts")
 
@@ -240,6 +242,8 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
         role: claims.role,
         channel_name: channel.name
       })
+
+    on_exit(fn -> Process.exit(db_conn, :normal) end)
 
     %{
       channel: channel,

--- a/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
@@ -89,6 +89,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
     test "handles database errors", context do
       Postgrex.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, context.authorization_context)
+        Process.unlink(context.db_conn)
         Process.exit(context.db_conn, :kill)
 
         assert {:error, _} =
@@ -219,7 +220,8 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
     start_supervised!(CurrentTime.Mock)
     tenant = tenant_fixture()
 
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    {:ok, _} = start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
+    {:ok, db_conn} = Connect.get_status(tenant.external_id)
 
     clean_table(db_conn, "realtime", "channels")
     clean_table(db_conn, "realtime", "broadcasts")

--- a/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
@@ -17,133 +17,134 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
   describe "check_read_policies/3" do
     setup [:rls_context]
 
-    @tag role: "authenticated", policies: [:read_channel]
+    @tag role: "authenticated", policies: [:authenticated_read_channel]
     test "authenticated user has read policies", context do
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
-        Authorization.set_conn_config(transaction_conn, context.authorization_context)
+      assert {:ok, result} =
+               Postgrex.transaction(context.db_conn, fn transaction_conn ->
+                 Authorization.set_conn_config(transaction_conn, context.authorization_context)
 
-        assert {:ok, policies} =
                  ChannelPolicies.check_read_policies(
                    transaction_conn,
                    %Policies{},
                    context.authorization_context
                  )
+               end)
 
-        assert policies == %Policies{channel: %ChannelPolicies{read: true}}
-      end)
+      assert {:ok, %Policies{channel: %ChannelPolicies{read: true}}} = result
     end
 
-    @tag role: "anon", policies: [:read_channel]
+    @tag role: "anon", policies: [:authenticated_read_channel]
     test "anon user has no read policies", context do
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
-        Authorization.set_conn_config(transaction_conn, context.authorization_context)
+      assert {:ok, result} =
+               Postgrex.transaction(context.db_conn, fn transaction_conn ->
+                 Authorization.set_conn_config(transaction_conn, context.authorization_context)
 
-        assert {:ok, result} =
                  ChannelPolicies.check_read_policies(
                    transaction_conn,
                    %Policies{},
                    context.authorization_context
                  )
+               end)
 
-        assert result == %Policies{channel: %ChannelPolicies{read: false}}
-      end)
+      assert {:ok, %Policies{channel: %ChannelPolicies{read: false}}} = result
     end
 
-    @tag role: "authenticated", policies: [:read_all_channels]
+    @tag role: "authenticated", policies: [:authenticated_all_channels_read]
     test "no channel with authenticated and all channels returns true", context do
       authorization_context = %{context.authorization_context | channel: nil}
 
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
-        Authorization.set_conn_config(transaction_conn, context.authorization_context)
+      assert {:ok, result} =
+               Postgrex.transaction(context.db_conn, fn transaction_conn ->
+                 Authorization.set_conn_config(transaction_conn, context.authorization_context)
 
-        assert {:ok, result} =
                  ChannelPolicies.check_read_policies(
                    transaction_conn,
                    %Policies{},
                    authorization_context
                  )
+               end)
 
-        assert result == %Policies{channel: %ChannelPolicies{read: true}}
-      end)
+      assert {:ok, %Policies{channel: %ChannelPolicies{read: true}}} = result
     end
 
-    @tag role: "anon", policies: [:read_all_channels]
+    @tag role: "anon", policies: [:authenticated_all_channels_read]
     test "no channel with anon in context returns false", context do
       authorization_context = %{context.authorization_context | channel: nil}
 
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
-        Authorization.set_conn_config(transaction_conn, context.authorization_context)
+      assert {:ok, result} =
+               Postgrex.transaction(context.db_conn, fn transaction_conn ->
+                 Authorization.set_conn_config(transaction_conn, context.authorization_context)
 
-        assert {:ok, result} =
                  ChannelPolicies.check_read_policies(
                    transaction_conn,
                    %Policies{},
                    authorization_context
                  )
+               end)
 
-        assert result == %Policies{channel: %ChannelPolicies{read: false}}
-      end)
+      assert {:ok, %Policies{channel: %ChannelPolicies{read: false}}} = result
     end
 
     @tag role: "anon", policies: []
     test "handles database errors", context do
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
-        Authorization.set_conn_config(transaction_conn, context.authorization_context)
-        Process.unlink(context.db_conn)
-        Process.exit(context.db_conn, :kill)
+      assert {:error, :rollback} =
+               Postgrex.transaction(context.db_conn, fn transaction_conn ->
+                 Authorization.set_conn_config(transaction_conn, context.authorization_context)
+                 Process.unlink(context.db_conn)
+                 Process.exit(context.db_conn, :kill)
 
-        assert {:error, _} =
                  ChannelPolicies.check_read_policies(
                    transaction_conn,
                    %Policies{},
                    context.authorization_context
                  )
-      end)
+               end)
     end
   end
 
   describe "check_write_policies/3" do
     setup [:rls_context]
 
-    @tag role: "authenticated", policies: [:read_channel, :write_channel]
+    @tag role: "authenticated",
+         policies: [:authenticated_read_channel, :authenticated_write_channel]
     test "authenticated user has write policies and reverts check", context do
       query = from(c in Channel, where: c.id == ^context.channel.id)
       {:ok, %Channel{check: check}} = Repo.one(context.db_conn, query, Channel)
 
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
-        Authorization.set_conn_config(transaction_conn, context.authorization_context)
+      assert {:ok, result} =
+               Postgrex.transaction(context.db_conn, fn transaction_conn ->
+                 Authorization.set_conn_config(transaction_conn, context.authorization_context)
 
-        assert {:ok, result} =
                  ChannelPolicies.check_write_policies(
                    transaction_conn,
                    %Policies{},
                    context.authorization_context
                  )
+               end)
 
-        assert result == %Policies{channel: %ChannelPolicies{write: true}}
-      end)
-
+      assert {:ok, %Policies{channel: %ChannelPolicies{write: true}}} = result
       # Ensure check stays with the initial value
       assert {:ok, %{check: ^check}} = Repo.one(context.db_conn, query, Channel)
     end
 
-    @tag role: "anon", policies: [:read_channel, :write_channel]
+    @tag role: "anon", policies: [:authenticated_read_channel, :authenticated_write_channel]
     test "anon user has no write policies", context do
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
-        Authorization.set_conn_config(transaction_conn, context.authorization_context)
+      assert {:ok, result} =
+               Postgrex.transaction(context.db_conn, fn transaction_conn ->
+                 Authorization.set_conn_config(transaction_conn, context.authorization_context)
 
-        assert {:ok, result} =
                  ChannelPolicies.check_write_policies(
                    transaction_conn,
                    %Policies{},
                    context.authorization_context
                  )
+               end)
 
-        assert result == %Policies{channel: %ChannelPolicies{write: false}}
-      end)
+      assert {:ok, %Policies{channel: %ChannelPolicies{write: false}}} = result
     end
 
-    @tag role: "anon", policies: [:read_all_channels, :write_all_channels]
+    @tag role: "anon",
+         policies: [:authenticated_all_channels_read, :authenticated_all_channels_insert]
     test "no channel and authenticated returns false", context do
       authorization_context = %{
         context.authorization_context
@@ -151,28 +152,27 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
           channel_name: nil
       }
 
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
-        Authorization.set_conn_config(transaction_conn, authorization_context)
+      assert {:ok, result} =
+               Postgrex.transaction(context.db_conn, fn transaction_conn ->
+                 Authorization.set_conn_config(transaction_conn, authorization_context)
 
-        assert {:ok, result} =
                  ChannelPolicies.check_write_policies(
                    transaction_conn,
                    %Policies{},
                    authorization_context
                  )
+               end)
 
-        assert result == %Policies{channel: %ChannelPolicies{write: false}}
-      end)
+      assert {:ok, %Policies{channel: %ChannelPolicies{write: false}}} = result
     end
 
-    @tag role: "service_role",
+    @tag role: "authenticated",
          policies: [
-           :service_role_all_channels_read,
-           :service_role_all_channels_write,
-           :service_role_all_channels_delete,
-           :service_role_all_broadcasts_write
+           :authenticated_all_channels_read,
+           :authenticated_all_channels_insert
          ]
-    test "no channel, channel name in context and service_role returns true", context do
+    test "no channel, channel name in context, allow policy and channel does not exist returns true",
+         context do
       channel_name = random_string()
 
       authorization_context = %{
@@ -197,7 +197,40 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
       end)
     end
 
-    @tag role: "anon", policies: [:read_all_channels, :write_all_channels]
+    @tag role: "authenticated",
+         policies: [
+           :authenticated_all_channels_read,
+           :authenticated_all_channels_insert
+         ]
+    test "no channel, channel name in context, allow policy and channel exists returns true",
+         context do
+      channel_name = random_string()
+      channel_fixture(context.tenant, %{name: channel_name})
+
+      authorization_context = %{
+        context.authorization_context
+        | channel: nil,
+          channel_name: channel_name
+      }
+
+      Postgrex.transaction(context.db_conn, fn transaction_conn ->
+        Authorization.set_conn_config(transaction_conn, authorization_context)
+
+        assert {:ok, result} =
+                 ChannelPolicies.check_write_policies(
+                   transaction_conn,
+                   %Policies{},
+                   authorization_context
+                 )
+
+        assert result == %Policies{channel: %ChannelPolicies{write: true}}
+
+        assert {:ok, _} = Channels.get_channel_by_name(channel_name, transaction_conn)
+      end)
+    end
+
+    @tag role: "anon",
+         policies: [:authenticated_all_channels_read, :authenticated_all_channels_insert]
     test "no channel and anon returns false", context do
       authorization_context = %{context.authorization_context | channel: nil}
 
@@ -232,7 +265,6 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
 
     claims = %{sub: random_string(), role: context.role, exp: Joken.current_time() + 1_000}
     signer = Joken.Signer.create("HS256", "secret")
-
     jwt = Joken.generate_and_sign!(%{}, claims, signer)
 
     authorization_context =
@@ -248,6 +280,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
     on_exit(fn -> Process.exit(db_conn, :normal) end)
 
     %{
+      tenant: tenant,
       channel: channel,
       db_conn: db_conn,
       authorization_context: authorization_context

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -16,7 +16,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
 
   describe "get_authorizations for Plug.Conn" do
     @tag role: "authenticated",
-         policies: [:read_channel, :read_broadcast]
+         policies: [:authenticated_read_channel, :authenticated_read_broadcast]
     test "authenticated user has expected policies", context do
       {:ok, conn} =
         Authorization.get_authorizations(
@@ -32,7 +32,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
     end
 
     @tag role: "anon",
-         policies: [:read_channel, :write_channel, :read_broadcast, :write_broadcast]
+         policies: [
+           :authenticated_read_channel,
+           :authenticated_write_channel,
+           :authenticated_read_broadcast,
+           :authenticated_write_broadcast
+         ]
     test "anon user has no policies", context do
       {:ok, conn} =
         Authorization.get_authorizations(
@@ -50,7 +55,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
 
   describe "get_authorizations for Phoenix.Socket" do
     @tag role: "authenticated",
-         policies: [:read_channel, :write_channel, :read_broadcast, :write_broadcast]
+         policies: [
+           :authenticated_read_channel,
+           :authenticated_write_channel,
+           :authenticated_read_broadcast,
+           :authenticated_write_broadcast
+         ]
     test "authenticated user has expected policies", context do
       {:ok, conn} =
         Authorization.get_authorizations(
@@ -66,7 +76,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
     end
 
     @tag role: "anon",
-         policies: [:read_channel, :write_channel, :read_broadcast, :write_broadcast]
+         policies: [
+           :authenticated_read_channel,
+           :authenticated_write_channel,
+           :authenticated_read_broadcast,
+           :authenticated_write_broadcast
+         ]
     test "anon user has no policies", context do
       {:ok, conn} =
         Authorization.get_authorizations(
@@ -83,7 +98,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
   end
 
   @tag role: "non_existant",
-       policies: [:read_channel, :write_channel, :read_broadcast, :write_broadcast]
+       policies: [
+         :authenticated_read_channel,
+         :authenticated_write_channel,
+         :authenticated_read_broadcast,
+         :authenticated_write_broadcast
+       ]
   test "on error return error and unauthorized on channel", %{db_conn: db_conn} do
     authorization_context =
       Authorization.build_authorization_params(%{

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -1,7 +1,7 @@
 defmodule Realtime.Tenants.AuthorizationTest do
   # Needs to be false due to some conflicts when fetching connection from the pool since this use Postgrex directly
-
   use RealtimeWeb.ConnCase, async: false
+
   require Phoenix.ChannelTest
 
   alias Realtime.Tenants
@@ -94,12 +94,13 @@ defmodule Realtime.Tenants.AuthorizationTest do
         role: "non_existant"
       })
 
-    {:error, :unauthorized} =
-      Authorization.get_authorizations(
-        Phoenix.ConnTest.build_conn(),
-        db_conn,
-        authorization_context
-      )
+    assert {:error,
+            %DBConnection.TransactionError{status: :error, message: "transaction is aborted"}} =
+             Authorization.get_authorizations(
+               Phoenix.ConnTest.build_conn(),
+               db_conn,
+               authorization_context
+             )
   end
 
   def rls_context(context) do

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -4,11 +4,11 @@ defmodule Realtime.Tenants.AuthorizationTest do
 
   require Phoenix.ChannelTest
 
-  alias Realtime.Tenants
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
   alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
+  alias Realtime.Tenants.Connect
 
   alias RealtimeWeb.Joken.CurrentTime
 
@@ -107,7 +107,8 @@ defmodule Realtime.Tenants.AuthorizationTest do
     start_supervised!(CurrentTime.Mock)
     tenant = tenant_fixture()
 
-    {:ok, db_conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
+    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
     channel = channel_fixture(tenant)
@@ -127,6 +128,8 @@ defmodule Realtime.Tenants.AuthorizationTest do
         headers: [{"header-1", "value-1"}],
         role: claims.role
       })
+
+    on_exit(fn -> Process.exit(db_conn, :normal) end)
 
     %{
       channel: channel,

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -1,4 +1,5 @@
 defmodule Realtime.Tenants.ConnectTest do
+  # async: false due to the fact that multiple operations against the database will use the same connection
   use Realtime.DataCase, async: false
 
   import Mock

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -14,16 +14,23 @@ defmodule Realtime.Tenants.ConnectTest do
     end
 
     test "if tenant exists and connected, returns the db connection", %{tenant: tenant} do
-      assert {:ok, conn} = Connect.lookup_or_start_connection(tenant.external_id)
-      assert is_pid(conn)
+      assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
+      on_exit(fn -> Process.exit(db_conn, :normal) end)
+
+      assert is_pid(db_conn)
     end
 
     test "on database disconnect, returns new connection", %{tenant: tenant} do
       assert {:ok, old_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
       GenServer.stop(old_conn)
       :timer.sleep(1000)
 
       assert {:ok, new_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
+      on_exit(fn -> Process.exit(new_conn, :normal) end)
+
       assert new_conn != old_conn
     end
 
@@ -48,12 +55,12 @@ defmodule Realtime.Tenants.ConnectTest do
 
       tenant = tenant_fixture(%{"extensions" => extensions})
 
-      assert Connect.lookup_or_start_connection(tenant.external_id) ==
-               {:error, :tenant_database_unavailable}
+      assert {:error, :tenant_database_unavailable} =
+               Connect.lookup_or_start_connection(tenant.external_id)
     end
 
     test "if tenant does not exist, returns error" do
-      assert Connect.lookup_or_start_connection("none") == {:error, :tenant_not_found}
+      assert {:error, :tenant_not_found} = Connect.lookup_or_start_connection("none")
     end
 
     test "if no users are connected to a tenant channel, stop the connection", %{
@@ -80,6 +87,8 @@ defmodule Realtime.Tenants.ConnectTest do
       {:ok, db_conn} =
         Connect.lookup_or_start_connection(tenant_id, check_connected_user_interval: 10)
 
+      on_exit(fn -> Process.exit(db_conn, :normal) end)
+
       assert {pid, %{conn: conn_pid}} = :syn.lookup(Connect, tenant_id)
       :timer.sleep(300)
       assert {^pid, %{conn: ^conn_pid}} = :syn.lookup(Connect, tenant_id)
@@ -105,7 +114,7 @@ defmodule Realtime.Tenants.ConnectTest do
     test "error if tenant is suspended" do
       tenant = tenant_fixture(suspend: true)
 
-      assert {:error, :tenant_suspended} == Connect.lookup_or_start_connection(tenant.external_id)
+      assert {:error, :tenant_suspended} = Connect.lookup_or_start_connection(tenant.external_id)
     end
 
     test "handles tenant suspension and unsuspension in a reactive way" do
@@ -118,13 +127,16 @@ defmodule Realtime.Tenants.ConnectTest do
       :timer.sleep(100)
 
       assert {:error, :tenant_suspended} = Connect.lookup_or_start_connection(tenant.external_id)
+
       assert Process.alive?(db_conn) == false
 
       Realtime.Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
 
       :timer.sleep(100)
 
-      assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
+      assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
+      on_exit(fn -> Process.exit(db_conn, :normal) end)
     end
 
     test "properly handles of failing calls by avoid creating too many connections" do
@@ -163,6 +175,7 @@ defmodule Realtime.Tenants.ConnectTest do
     test "on migrations failure, process is alive", %{tenant: tenant} do
       with_mock Ecto.Migrator, [:passthrough], run: fn _, _, _, _ -> nil end do
         assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+
         assert_called(Ecto.Migrator.run(:_, :_, :_, :_))
         assert Process.alive?(db_conn) == true
       end

--- a/test/realtime_web/controllers/channels_controller_test.exs
+++ b/test/realtime_web/controllers/channels_controller_test.exs
@@ -15,6 +15,9 @@ defmodule RealtimeWeb.ChannelsControllerTest do
       Realtime.Helpers.decrypt!(tenant.jwt_secret, Application.get_env(:realtime, :db_enc_key))
 
     {:ok, db_conn} = Tenants.Connect.lookup_or_start_connection(tenant.external_id)
+
+    on_exit(fn -> Process.exit(db_conn, :normal) end)
+
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
 

--- a/test/realtime_web/controllers/channels_controller_test.exs
+++ b/test/realtime_web/controllers/channels_controller_test.exs
@@ -1,18 +1,13 @@
 defmodule RealtimeWeb.ChannelsControllerTest do
+  # async: false due to the fact that multiple operations against the database will use the same connection
   use RealtimeWeb.ConnCase, async: false
 
-  import Mock
-
-  alias Realtime.GenCounter
+  alias Realtime.Channels
   alias Realtime.Tenants
 
-  setup_with_mocks [
-                     {GenCounter, [], new: fn _ -> :ok end},
-                     {GenCounter, [], add: fn _ -> :ok end},
-                     {GenCounter, [], put: fn _, _ -> :ok end},
-                     {GenCounter, [], get: fn _ -> {:ok, 0} end}
-                   ],
-                   %{conn: conn} = context do
+  setup %{conn: conn} = context do
+    start_supervised(Realtime.RateCounter.DynamicSupervisor)
+    start_supervised(Realtime.GenCounter.DynamicSupervisor)
     start_supervised(RealtimeWeb.Joken.CurrentTime.Mock)
     tenant = tenant_fixture()
 
@@ -23,7 +18,16 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     clean_table(db_conn, "realtime", "broadcasts")
     clean_table(db_conn, "realtime", "channels")
 
-    create_rls_policies(db_conn, [:read_all_channels], nil)
+    create_rls_policies(
+      db_conn,
+      [
+        :service_role_all_channels_read,
+        :service_role_all_channels_write,
+        :service_role_all_channels_delete,
+        :service_role_all_broadcasts_write
+      ],
+      nil
+    )
 
     claims = %{sub: random_string(), role: context.role, exp: Joken.current_time() + 1_000}
     signer = Joken.Signer.create("HS256", secret)
@@ -36,11 +40,11 @@ defmodule RealtimeWeb.ChannelsControllerTest do
       |> put_req_header("authorization", "Bearer #{jwt}")
       |> then(&%{&1 | host: "#{tenant.external_id}.supabase.com"})
 
-    {:ok, conn: conn, tenant: tenant}
+    {:ok, conn: conn, db_conn: db_conn, tenant: tenant}
   end
 
   describe "index" do
-    @tag role: "authenticated"
+    @tag role: "service_role"
     test "lists tenant channels", %{conn: conn, tenant: tenant} do
       expected =
         Stream.repeatedly(fn -> channel_fixture(tenant) end)
@@ -56,7 +60,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
       assert res == expected
     end
 
-    @tag role: "anon"
+    @tag role: "authenticated"
     test "returns 401 if unauthorized", %{conn: conn} do
       conn = get(conn, ~p"/v3/api/channels")
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
@@ -64,7 +68,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
   end
 
   describe "show" do
-    @tag role: "authenticated"
+    @tag role: "service_role"
     test "lists tenant channels", %{conn: conn, tenant: tenant} do
       [channel | _] =
         Stream.repeatedly(fn -> channel_fixture(tenant) end)
@@ -77,7 +81,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
       assert res == expected
     end
 
-    @tag role: "authenticated"
+    @tag role: "service_role"
     test "returns not found if id doesn't exist", %{conn: conn, tenant: tenant} do
       Stream.repeatedly(fn -> channel_fixture(tenant) end)
       |> Enum.take(10)
@@ -86,60 +90,81 @@ defmodule RealtimeWeb.ChannelsControllerTest do
       assert json_response(conn, 404) == %{"message" => "Not found"}
     end
 
-    @tag role: "anon"
+    @tag role: "authenticated"
     test "returns 401 if unauthorized", %{conn: conn} do
       conn = get(conn, ~p"/v3/api/channels/0")
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end
 
-  # describe "create" do
-  #   test "creates a channel", %{conn: conn} do
-  #     name = random_string()
-  #     conn = post(conn, ~p"/v3/api/channels", %{name: name})
-  #     res = json_response(conn, 201)
-  #     assert name == res["name"]
-  #   end
+  describe "create" do
+    @tag role: "service_role"
+    test "creates a channel", %{conn: conn} do
+      name = random_string()
+      conn = post(conn, ~p"/v3/api/channels", %{"name" => name})
+      res = json_response(conn, 201)
+      assert name == res["name"]
+    end
 
-  #   test "422 if params are invalid", %{conn: conn} do
-  #     conn = post(conn, ~p"/v3/api/channels", %{})
-  #     assert json_response(conn, 422) == %{"errors" => %{"name" => ["can't be blank"]}}
-  #   end
-  # end
+    @tag role: "service_role"
+    test "422 if params are invalid", %{conn: conn, db_conn: db_conn} do
+      name = random_string()
+      Channels.create_channel(%{"name" => name}, db_conn)
+      conn = post(conn, ~p"/v3/api/channels", %{"name" => name})
+      assert json_response(conn, 422) == %{"errors" => %{"name" => ["has already been taken"]}}
+    end
 
-  # describe "delete" do
-  #   test "deletes a channel", %{conn: conn, tenant: tenant} do
-  #     channel = channel_fixture(tenant)
-  #     conn = delete(conn, ~p"/v3/api/channels/#{channel.id}")
-  #     assert conn.status == 202
-  #   end
+    @tag role: "authenticated"
+    test "returns 401 if unauthorized", %{conn: conn} do
+      conn = post(conn, ~p"/v3/api/channels", %{name: random_string()})
+      assert json_response(conn, 401) == %{"message" => "Unauthorized"}
+    end
+  end
 
-  #   test "returns not found if id doesn't exist", %{conn: conn} do
-  #     conn = delete(conn, ~p"/v3/api/channels/0")
-  #     assert conn.status == 404
-  #   end
-  # end
+  describe "delete" do
+    @tag role: "service_role"
+    test "deletes a channel", %{conn: conn, tenant: tenant} do
+      channel = channel_fixture(tenant)
+      conn = delete(conn, ~p"/v3/api/channels/#{channel.id}")
+      assert conn.status == 202
+    end
 
-  # describe "update" do
-  #   test "updates a channel", %{conn: conn, tenant: tenant} do
-  #     channel = channel_fixture(tenant)
-  #     name = random_string()
-  #     conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{name: name})
-  #     res = json_response(conn, 202)
-  #     assert name == res["name"]
+    @tag role: "service_role"
+    test "returns unauthorized if id doesn't exist", %{conn: conn} do
+      conn = delete(conn, ~p"/v3/api/channels/0")
+      assert conn.status == 401
+    end
 
-  #     name = random_string()
-  #     conn = patch(conn, ~p"/v3/api/channels/#{channel.id}", %{name: name})
-  #     res = json_response(conn, 202)
-  #     assert name == res["name"]
-  #   end
+    @tag role: "authenticated"
+    test "returns 401 if unauthorized", %{conn: conn, tenant: tenant} do
+      channel = channel_fixture(tenant)
+      conn = delete(conn, ~p"/v3/api/channels/#{channel.id}")
+      assert json_response(conn, 401) == %{"message" => "Unauthorized"}
+    end
+  end
 
-  #   test "422 if params are invalid", %{conn: conn, tenant: tenant} do
-  #     channel = channel_fixture(tenant)
-  #     conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{name: 1})
-  #     assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
-  #     conn = patch(conn, ~p"/v3/api/channels/#{channel.id}", %{name: 1})
-  #     assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
-  #   end
-  # end
+  describe "update" do
+    @tag role: "service_role"
+    test "updates a channel", %{conn: conn, tenant: tenant} do
+      channel = channel_fixture(tenant)
+      name = random_string()
+      conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{name: name})
+      res = json_response(conn, 202)
+      assert name == res["name"]
+
+      name = random_string()
+      conn = patch(conn, ~p"/v3/api/channels/#{channel.id}", %{name: name})
+      res = json_response(conn, 202)
+      assert name == res["name"]
+    end
+
+    @tag role: "service_role"
+    test "422 if params are invalid", %{conn: conn, tenant: tenant} do
+      channel = channel_fixture(tenant)
+      conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{"name" => 1})
+      assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
+      conn = patch(conn, ~p"/v3/api/channels/#{channel.id}", %{"name" => 1})
+      assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
+    end
+  end
 end

--- a/test/realtime_web/plugs/rls_authorization_test.exs
+++ b/test/realtime_web/plugs/rls_authorization_test.exs
@@ -24,6 +24,7 @@ defmodule RealtimeWeb.RlsAuthorizationTest do
     signer = Joken.Signer.create("HS256", "secret")
     jwt = Joken.generate_and_sign!(%{}, claims, signer)
 
+    on_exit(fn -> Process.exit(db_conn, :normal) end)
     %{jwt: jwt, claims: claims, tenant: tenant, channel: channel}
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -34,7 +34,7 @@ defmodule Realtime.DataCase do
       Sandbox.mode(Realtime.Repo, {:shared, self()})
     end
 
-    :ok
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 
   @doc """

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -41,6 +41,7 @@ defmodule Generators do
 
   def channel_fixture(tenant, override \\ %{}) do
     {:ok, conn} = Realtime.Tenants.Connect.lookup_or_start_connection(tenant.external_id)
+
     create_attrs = %{"name" => random_string()}
     override = override |> Enum.map(fn {k, v} -> {"#{k}", v} end) |> Map.new()
 
@@ -49,6 +50,7 @@ defmodule Generators do
       |> Map.merge(override)
       |> Realtime.Channels.create_channel(conn)
 
+    Process.exit(conn, :normal)
     channel
   end
 

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -99,54 +99,27 @@ defmodule Generators do
 
   def policy_query(query, params \\ nil)
 
-  def policy_query(:service_role_all_channels_read, _) do
+  def policy_query(:authenticated_all_channels_read, _) do
     """
-    CREATE POLICY service_role_all_channels_read
-    ON realtime.channels FOR SELECT
-    TO service_role
-    USING ( true );
-    """
-  end
-
-  def policy_query(:service_role_all_channels_write, _) do
-    """
-    CREATE POLICY service_role_all_channels_write
-    ON realtime.channels FOR INSERT
-    TO service_role
-    WITH CHECK ( true );
-    """
-  end
-
-  def policy_query(:service_role_all_channels_delete, _) do
-    """
-    CREATE POLICY service_role_all_channels_delete
-    ON realtime.channels FOR DELETE
-    TO service_role
-    USING ( true );
-    """
-  end
-
-  def policy_query(:service_role_all_broadcasts_write, _) do
-    """
-    CREATE POLICY service_role_all_broadcast_write
-    ON realtime.channels FOR INSERT
-    TO service_role
-    WITH CHECK ( true );
-    """
-  end
-
-  def policy_query(:read_all_channels, _) do
-    """
-    CREATE POLICY read_all_channels
+    CREATE POLICY authenticated_all_channels_read
     ON realtime.channels FOR SELECT
     TO authenticated
     USING ( true );
     """
   end
 
-  def policy_query(:write_all_channels, _) do
+  def policy_query(:authenticated_all_channels_insert, _) do
     """
-    CREATE POLICY write_all_channels
+    CREATE POLICY authenticated_all_channels_write
+    ON realtime.channels FOR INSERT
+    TO authenticated
+    WITH CHECK ( true );
+    """
+  end
+
+  def policy_query(:authenticated_all_channels_update, _) do
+    """
+    CREATE POLICY authenticated_all_channels_update
     ON realtime.channels FOR UPDATE
     TO authenticated
     USING ( true )
@@ -154,18 +127,27 @@ defmodule Generators do
     """
   end
 
-  def policy_query(:read_channel, %{name: name}) do
+  def policy_query(:authenticated_all_channels_delete, _) do
     """
-    CREATE POLICY read_channel
+    CREATE POLICY authenticated_all_channels_delete
+    ON realtime.channels FOR DELETE
+    TO authenticated
+    USING ( true );
+    """
+  end
+
+  def policy_query(:authenticated_read_channel, %{name: name}) do
+    """
+    CREATE POLICY authenticated_read_channel
     ON realtime.channels FOR SELECT
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' );
     """
   end
 
-  def policy_query(:write_channel, %{name: name}) do
+  def policy_query(:authenticated_write_channel, %{name: name}) do
     """
-    CREATE POLICY write_channel
+    CREATE POLICY authenticated_write_channel
     ON realtime.channels FOR UPDATE
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' )
@@ -173,18 +155,18 @@ defmodule Generators do
     """
   end
 
-  def policy_query(:read_broadcast, %{name: name}) do
+  def policy_query(:authenticated_read_broadcast, %{name: name}) do
     """
-    CREATE POLICY read_broadcast
+    CREATE POLICY authenticated_read_broadcast
     ON realtime.broadcasts FOR SELECT
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' );
     """
   end
 
-  def policy_query(:write_broadcast, %{name: name}) do
+  def policy_query(:authenticated_write_broadcast, %{name: name}) do
     """
-    CREATE POLICY write_broadcast
+    CREATE POLICY authenticated_write_broadcast
     ON realtime.broadcasts FOR UPDATE
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' )

--- a/test/support/tenant_connection.ex
+++ b/test/support/tenant_connection.ex
@@ -1,0 +1,14 @@
+defmodule TenantConnection do
+  @moduledoc """
+  Boilerplate code to handle Realtime.Tenants.Connect during tests
+  """
+  alias Realtime.Api.Tenant
+
+  def connect_child_spec(%Tenant{external_id: external_id}, connect_child_spec \\ []) do
+    {Realtime.Tenants.Connect, Keyword.merge(connect_child_spec, tenant_id: external_id)}
+  end
+
+  def tenant_connection(tenant) do
+    Realtime.Tenants.Connect.get_status(tenant.external_id)
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

To support API use case and SDK support we need to implement the required policies.

This adds a new Policy to ChannelPolicy that defines:
* If a channel name is in the request body of a post request, we add it to the authorization context
* If the user is able to Create a channel fully and Delete it fully we set it to write true

This will be used by the controller for the create and delete flows. Update flow already had a check since we are able to load a channel and the permissions will be more fine grained to that channel
