### PR TITLE
feat: add jwks support

### DIFF
--- a/bench/secrets.exs
+++ b/bench/secrets.exs
@@ -12,7 +12,7 @@ string_to_decrypt = "A5mS7ggkPXm0FaKKoZtrsYNlZA3qZxFe9XA9w2YYqgU="
 
 Benchee.run(%{
   "authorize_jwt" => fn ->
-    {:ok, _} = ChannelsAuthorization.authorize_conn(jwt, jwt_secret)
+    {:ok, _} = ChannelsAuthorization.authorize_conn(jwt, jwt_secret, nil)
   end,
   "encrypt_string" => fn ->
     H.encrypt!(string_to_encrypt, secret_key)

--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -15,6 +15,7 @@ defmodule Realtime.Api.Tenant do
     field(:name, :string)
     field(:external_id, :string)
     field(:jwt_secret, :string)
+    field(:jwt_jwks, :map)
     field(:postgres_cdc_default, :string)
     field(:max_concurrent_users, :integer, default: 200)
     field(:max_events_per_second, :integer, default: 100)
@@ -65,6 +66,7 @@ defmodule Realtime.Api.Tenant do
       :name,
       :external_id,
       :jwt_secret,
+      :jwt_jwks,
       :max_concurrent_users,
       :max_events_per_second,
       :postgres_cdc_default,

--- a/lib/realtime_web/channels/auth/channels_authorization.ex
+++ b/lib/realtime_web/channels/auth/channels_authorization.ex
@@ -4,20 +4,20 @@ defmodule RealtimeWeb.ChannelsAuthorization do
   """
   require Logger
 
-  def authorize(token, secret) when is_binary(token) do
+  def authorize(token, jwt_secret, jwt_jwks) when is_binary(token) do
     token
     |> clean_token()
-    |> RealtimeWeb.JwtVerification.verify(secret)
+    |> RealtimeWeb.JwtVerification.verify(jwt_secret, jwt_jwks)
   end
 
-  def authorize(_token, _secret), do: :error
+  def authorize(_token, _jwt_secret, _jwt_jwks), do: :error
 
   defp clean_token(token) do
     Regex.replace(~r/\s|\n/, URI.decode(token), "")
   end
 
-  def authorize_conn(token, secret) do
-    case authorize(token, secret) do
+  def authorize_conn(token, jwt_secret, jwt_jwks) do
+    case authorize(token, jwt_secret, jwt_jwks) do
       {:ok, claims} ->
         required = MapSet.new(["role", "exp"])
         claims_keys = claims |> Map.keys() |> MapSet.new()

--- a/lib/realtime_web/channels/auth/jwt_verification.ex
+++ b/lib/realtime_web/channels/auth/jwt_verification.ex
@@ -25,18 +25,21 @@ defmodule RealtimeWeb.JwtVerification do
   end
 
   @hs_algorithms ["HS256", "HS384", "HS512"]
+  @rs_algorithms ["RS256", "RS384", "RS512"]
+  @es_algorithms ["ES256", "ES384", "ES512"]
+  @ed_algorithms ["Ed25519", "Ed448"]
 
-  def verify(token, secret) when is_binary(token) do
+  def verify(token, jwt_secret, jwt_jwks) when is_binary(token) do
     with {:ok, _claims} <- check_claims_format(token),
          {:ok, header} <- check_header_format(token),
-         {:ok, signer} <- generate_signer(header, secret) do
+         {:ok, signer} <- generate_signer(header, jwt_secret, jwt_jwks) do
       JwtAuthToken.verify_and_validate(token, signer)
     else
       {:error, _e} = error -> error
     end
   end
 
-  def verify(_token, _secret), do: {:error, :not_a_string}
+  def verify(_token, _jwt_secret, _jwt_jwks), do: {:error, :not_a_string}
 
   defp check_header_format(token) do
     case Joken.peek_header(token) do
@@ -52,9 +55,63 @@ defmodule RealtimeWeb.JwtVerification do
     end
   end
 
-  defp generate_signer(%{"typ" => "JWT", "alg" => alg}, jwt_secret) when alg in @hs_algorithms do
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg, "kid" => kid}, _jwt_secret, %{
+         "keys" => keys
+       })
+       when is_binary(kid) and alg in @rs_algorithms do
+    jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "RSA" and jwk["kid"] == kid end)
+
+    case jwk do
+      nil -> {:error, :error_generating_signer}
+      _ -> {:ok, Joken.Signer.create(alg, jwk)}
+    end
+  end
+
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg, "kid" => kid}, _jwt_secret, %{
+         "keys" => keys
+       })
+       when is_binary(kid) and alg in @es_algorithms do
+    jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "EC" and jwk["kid"] == kid end)
+
+    case jwk do
+      nil -> {:error, :error_generating_signer}
+      _ -> {:ok, Joken.Signer.create(alg, jwk)}
+    end
+  end
+
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg, "kid" => kid}, _jwt_secret, %{
+         "keys" => keys
+       })
+       when is_binary(kid) and alg in @ed_algorithms do
+    jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "OKP" and jwk["kid"] == kid end)
+
+    case jwk do
+      nil -> {:error, :error_generating_signer}
+      _ -> {:ok, Joken.Signer.create(alg, jwk)}
+    end
+  end
+
+  # Most Supabase Auth JWTs fall in this case, as they're usually signed with
+  # HS256, have a kid header, but there's no JWK as this is sensitive. In this
+  # case, the jwt_secret should be used.
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg, "kid" => kid}, jwt_secret, %{
+         "keys" => keys
+       })
+       when is_binary(kid) and alg in @hs_algorithms do
+    jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "oct" and jwk["kid"] == kid end)
+
+    case jwk do
+      # If there's no JWK, and HS* is being used, instead of erroring, try
+      # the jwt_secret instead.
+      nil -> {:ok, Joken.Signer.create(alg, jwt_secret)}
+      _ -> {:ok, Joken.Signer.create(alg, jwk)}
+    end
+  end
+
+  defp generate_signer(%{"typ" => "JWT", "alg" => alg}, jwt_secret, _jwt_jwks)
+       when alg in @hs_algorithms do
     {:ok, Joken.Signer.create(alg, jwt_secret)}
   end
 
-  defp generate_signer(_header, _secret), do: {:error, :error_generating_signer}
+  defp generate_signer(_header, _jwt_secret, _jwt_jwks), do: {:error, :error_generating_signer}
 end

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -438,10 +438,9 @@ defmodule RealtimeWeb.RealtimeChannel do
     assign(socket, :access_token, tenant_token)
   end
 
-  defp confirm_token(%{
-         assigns:
-           %{jwt_secret: jwt_secret, jwt_jwks: jwt_jwks, access_token: access_token} = assigns
-       }) do
+  defp confirm_token(%{assigns: assigns}) do
+    %{jwt_secret: jwt_secret, access_token: access_token} = assigns
+    jwt_jwks = Map.get(assigns, :jwt_jwks)
     secure_key = Application.fetch_env!(:realtime, :db_enc_key)
 
     with jwt_secret_dec <- Helpers.decrypt!(jwt_secret, secure_key),

--- a/lib/realtime_web/channels/realtime_channel/assign.ex
+++ b/lib/realtime_web/channels/realtime_channel/assign.ex
@@ -14,6 +14,7 @@ defmodule RealtimeWeb.RealtimeChannel.Assigns do
     :postgres_extension,
     :claims,
     :jwt_secret,
+    :jwt_jwks,
     :tenant_token,
     :access_token,
     :postgres_cdc_module,
@@ -38,6 +39,7 @@ defmodule RealtimeWeb.RealtimeChannel.Assigns do
           postgres_extension: map(),
           claims: map(),
           jwt_secret: String.t(),
+          jwt_jwks: map(),
           tenant_token: String.t(),
           access_token: String.t(),
           channel_name: String.t()

--- a/lib/realtime_web/channels/user_socket.ex
+++ b/lib/realtime_web/channels/user_socket.ex
@@ -40,6 +40,7 @@ defmodule RealtimeWeb.UserSocket do
       with %Tenant{
              extensions: extensions,
              jwt_secret: jwt_secret,
+             jwt_jwks: jwt_jwks,
              max_concurrent_users: max_conn_users,
              max_events_per_second: max_events_per_second,
              max_bytes_per_second: max_bytes_per_second,
@@ -49,11 +50,12 @@ defmodule RealtimeWeb.UserSocket do
            } <- Tenants.Cache.get_tenant_by_external_id(external_id),
            token when is_binary(token) <- access_token(params, headers),
            jwt_secret_dec <- decrypt!(jwt_secret, secure_key),
-           {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec),
+           {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec, jwt_jwks),
            {:ok, postgres_cdc_module} <- PostgresCdc.driver(postgres_cdc_default) do
         assigns = %RealtimeChannel.Assigns{
           claims: claims,
           jwt_secret: jwt_secret,
+          jwt_jwks: jwt_jwks,
           limits: %{
             max_concurrent_users: max_conn_users,
             max_events_per_second: max_events_per_second,

--- a/lib/realtime_web/open_api_schemas.ex
+++ b/lib/realtime_web/open_api_schemas.ex
@@ -67,6 +67,20 @@ defmodule RealtimeWeb.OpenApiSchemas do
             external_id: %Schema{type: :string, description: "External ID"},
             name: %Schema{type: :string, description: "Tenant name"},
             jwt_secret: %Schema{type: :string, description: "JWT secret"},
+            jwt_jwks: %Schema{
+              type: :object,
+              description: "JWKS for verifying JWTs",
+              properties: %{
+                keys: %Schema{
+                  type: :array,
+                  description: "Set of JWKs",
+                  items: %Schema{
+                    type: :object,
+                    description: "JWK"
+                  }
+                }
+              }
+            },
             max_concurrent_users: %Schema{
               type: :number,
               description: "Maximum connected concurrent clients"
@@ -177,6 +191,20 @@ defmodule RealtimeWeb.OpenApiSchemas do
         max_joins_per_second: %Schema{
           type: :number,
           description: "Maximum number of channel joins permitted for all connected clients"
+        },
+        jwt_jwks: %Schema{
+          type: :object,
+          description: "JWKS for verifying JWTs",
+          properties: %{
+            keys: %Schema{
+              type: :array,
+              description: "Set of JWKs",
+              items: %Schema{
+                type: :object,
+                description: "JWK"
+              }
+            }
+          }
         },
         inserted_at: %Schema{type: :string, format: "date-time", description: "Insert timestamp"},
         extensions: %Schema{

--- a/lib/realtime_web/plugs/auth_tenant.ex
+++ b/lib/realtime_web/plugs/auth_tenant.ex
@@ -15,10 +15,10 @@ defmodule RealtimeWeb.AuthTenant do
   def call(%{assigns: %{tenant: tenant}} = conn, _opts) do
     secure_key = Application.get_env(:realtime, :db_enc_key)
 
-    with %Tenant{jwt_secret: jwt_secret} <- tenant,
+    with %Tenant{jwt_secret: jwt_secret, jwt_jwks: jwt_jwks} <- tenant,
          token when is_binary(token) <- access_token(conn),
          jwt_secret_dec <- decrypt!(jwt_secret, secure_key),
-         {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec) do
+         {:ok, claims} <- ChannelsAuthorization.authorize_conn(token, jwt_secret_dec, jwt_jwks) do
       Logger.metadata(external_id: tenant.external_id, project: tenant.external_id)
 
       conn

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -3,7 +3,7 @@ defmodule RealtimeWeb.Router do
 
   require Logger
 
-  import RealtimeWeb.ChannelsAuthorization, only: [authorize: 2]
+  import RealtimeWeb.ChannelsAuthorization, only: [authorize: 3]
 
   pipeline :browser do
     plug(:accepts, ["html"])
@@ -146,7 +146,7 @@ defmodule RealtimeWeb.Router do
     secret = Application.fetch_env!(:realtime, secret_key)
 
     with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
-         {:ok, _claims} <- authorize(token, secret) do
+         {:ok, _claims} <- authorize(token, secret, nil) do
       conn
     else
       _ ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.27.7",
+      version: "2.28.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20240306114423_add_tenant_jwt_jwks.exs
+++ b/priv/repo/migrations/20240306114423_add_tenant_jwt_jwks.exs
@@ -1,0 +1,9 @@
+defmodule Realtime.Repo.Migrations.AdddTenantJwtJwksColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenants) do
+      add :jwt_jwks, :map, default: nil
+    end
+  end
+end

--- a/test/api_jwt_secret_test.exs
+++ b/test/api_jwt_secret_test.exs
@@ -10,7 +10,7 @@ defmodule RealtimeWeb.ApiJwtSecretTest do
   end
 
   test "api key is right", %{conn: conn} do
-    with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+    with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
       jwt = "jwt_token"
 
       conn =

--- a/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
+++ b/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
@@ -41,7 +41,7 @@ defmodule Realtime.Extensions.CdcRlsTest do
     with_mocks([
       {ChannelsAuthorization, [],
        [
-         authorize_conn: fn _, _ ->
+         authorize_conn: fn _, _, _ ->
            {:ok, %{"exp" => Joken.current_time() + 1_000, "role" => "postgres"}}
          end
        ]}

--- a/test/realtime_web/channels/auth/channels_authorization_test.exs
+++ b/test/realtime_web/channels/auth/channels_authorization_test.exs
@@ -7,26 +7,26 @@ defmodule RealtimeWeb.ChannelsAuthorizationTest do
 
   @secret ""
 
-  test "authorize/1 when token is authorized" do
+  test "authorize/3 when token is authorized" do
     input_token = "\n token %20 1 %20 2 %20 3   "
     expected_token = "token123"
 
     with_mock JwtVerification,
-      verify: fn token, @secret ->
+      verify: fn token, @secret, _jwks ->
         assert token == expected_token
         {:ok, %{}}
       end do
-      assert {:ok, %{}} = ChannelsAuthorization.authorize(input_token, @secret)
+      assert {:ok, %{}} = ChannelsAuthorization.authorize(input_token, @secret, nil)
     end
   end
 
-  test "authorize/1 when token is unauthorized" do
-    with_mock JwtVerification, verify: fn _token, _secret -> :error end do
-      assert :error = ChannelsAuthorization.authorize("bad_token", @secret)
+  test "authorize/3 when token is unauthorized" do
+    with_mock JwtVerification, verify: fn _token, _secret, _jwks -> :error end do
+      assert :error = ChannelsAuthorization.authorize("bad_token", @secret, nil)
     end
   end
 
-  test "authorize/1 when token is not a string" do
-    assert :error = ChannelsAuthorization.authorize([], @secret)
+  test "authorize/3 when token is not a string" do
+    assert :error = ChannelsAuthorization.authorize([], @secret, nil)
   end
 end

--- a/test/realtime_web/channels/auth/jwt_verification_test.exs
+++ b/test/realtime_web/channels/auth/jwt_verification_test.exs
@@ -212,4 +212,27 @@ defmodule RealtimeWeb.JwtVerificationTest do
 
     assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, jwks)
   end
+
+  test "verify/3 using ES256 JWK" do
+    jwks = %{
+      "keys" => [
+        %{
+          "kty" => "EC",
+          "x" => "iX_niXPSL2nW-9IyCELzyceAtuE3B98pWML5tQGACD4",
+          "y" => "kT02DoLhXx6gtpkbrN8XwQ2wtzE6cDBaqlWgVXIeqV0",
+          "crv" => "P-256",
+          "d" => "FBVYnsYA2C3FTggEwV8kCRMo4FLl220_cWY2RdXyb_8",
+          "kid" => "key-id-1"
+        }
+      ]
+    }
+
+    token =
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6ImtleS1pZC0xIn0.eyJpYXQiOjE3MTIwNDk2NTcsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwic3ViIjoidXNlci1pZCIsImV4cCI6MTcxMjA1MzI1N30.IIQBuEiSnZacGMqiqsrLAeRGOjIaB4F3x1gnLN5zvhFryJ-6tdgu96lFv5HUF13IL2UfHWad0OuvoDt4DEHRxw"
+
+    current_time = 1_712_049_657 + 1
+    Mock.freeze(current_time)
+
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, jwks)
+  end
 end

--- a/test/realtime_web/channels/auth/jwt_verification_test.exs
+++ b/test/realtime_web/channels/auth/jwt_verification_test.exs
@@ -17,77 +17,78 @@ defmodule RealtimeWeb.JwtVerificationTest do
     :ok
   end
 
-  test "verify/1 when token is not a string" do
-    assert {:error, :not_a_string} = JwtVerification.verify([], @jwt_secret)
+  test "verify/3 when token is not a string" do
+    assert {:error, :not_a_string} = JwtVerification.verify([], @jwt_secret, nil)
   end
 
-  test "verify/1 when token has invalid format" do
+  test "verify/3 when token has invalid format" do
     invalid_token = Base.encode64("{}")
 
-    assert {:error, :expected_claims_map} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, :expected_claims_map} =
+             JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token header is not a map" do
+  test "verify/3 when token header is not a map" do
     invalid_token =
       Base.encode64("[]") <> "." <> Base.encode64("{}") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token claims is not a map" do
+  test "verify/3 when token claims is not a map" do
     invalid_token =
       Base.encode64("{}") <> "." <> Base.encode64("[]") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token header does not have typ or alg" do
+  test "verify/3 when token header does not have typ or alg" do
     invalid_token =
       Base.encode64("{\"typ\": \"JWT\"}") <>
         "." <> Base.encode64("{}") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
 
     invalid_token =
       Base.encode64("{\"alg\": \"HS256\"}") <>
         "." <> Base.encode64("{}") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token header alg is not allowed" do
+  test "verify/3 when token header alg is not allowed" do
     invalid_token =
       Base.encode64("{\"typ\": \"JWT\", \"alg\": \"ZZ999\"}") <>
         "." <> Base.encode64("{}") <> "." <> Base.encode64("<<\"sig\">>")
 
-    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret)
+    assert {:error, _reason} = JwtVerification.verify(invalid_token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token is valid and alg is HS256" do
+  test "verify/3 when token is valid and alg is HS256" do
     signer = Joken.Signer.create("HS256", @jwt_secret)
 
     token = Joken.generate_and_sign!(%{}, %{}, signer)
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token is valid and alg is HS384" do
+  test "verify/3 when token is valid and alg is HS384" do
     signer = Joken.Signer.create("HS384", @jwt_secret)
 
     token = Joken.generate_and_sign!(%{}, %{}, signer)
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token is valid and alg is HS512" do
+  test "verify/3 when token is valid and alg is HS512" do
     signer = Joken.Signer.create("HS512", @jwt_secret)
 
     token = Joken.generate_and_sign!(%{}, %{}, signer)
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token has expired" do
+  test "verify/3 when token has expired" do
     signer = Joken.Signer.create(@alg, @jwt_secret)
 
     current_time = 1_610_086_801
@@ -103,7 +104,7 @@ defmodule RealtimeWeb.JwtVerificationTest do
       )
 
     assert {:error, [message: "Invalid token", claim: "exp", claim_val: 1_610_086_801]} =
-             JwtVerification.verify(token, @jwt_secret)
+             JwtVerification.verify(token, @jwt_secret, nil)
 
     token =
       Joken.generate_and_sign!(
@@ -115,10 +116,10 @@ defmodule RealtimeWeb.JwtVerificationTest do
       )
 
     assert {:error, [message: "Invalid token", claim: "exp", claim_val: 1_610_086_800]} =
-             JwtVerification.verify(token, @jwt_secret)
+             JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token has not expired" do
+  test "verify/3 when token has not expired" do
     signer = Joken.Signer.create(@alg, @jwt_secret)
 
     Mock.freeze()
@@ -133,10 +134,10 @@ defmodule RealtimeWeb.JwtVerificationTest do
         signer
       )
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token claims match expected claims from :jwt_claim_validators config" do
+  test "verify/3 when token claims match expected claims from :jwt_claim_validators config" do
     Application.put_env(:realtime, :jwt_claim_validators, %{
       "iss" => "Tester",
       "aud" => "www.test.com"
@@ -159,10 +160,10 @@ defmodule RealtimeWeb.JwtVerificationTest do
         signer
       )
 
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret)
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, nil)
   end
 
-  test "verify/1 when token claims do not match expected claims from :jwt_claim_validators config" do
+  test "verify/3 when token claims do not match expected claims from :jwt_claim_validators config" do
     Application.put_env(:realtime, :jwt_claim_validators, %{
       "iss" => "Issuer",
       "aud" => "www.test.com"
@@ -186,6 +187,6 @@ defmodule RealtimeWeb.JwtVerificationTest do
       )
 
     assert {:error, [message: "Invalid token", claim: "iss", claim_val: "Tester"]} =
-             JwtVerification.verify(token, @jwt_secret)
+             JwtVerification.verify(token, @jwt_secret, nil)
   end
 end

--- a/test/realtime_web/channels/auth/jwt_verification_test.exs
+++ b/test/realtime_web/channels/auth/jwt_verification_test.exs
@@ -206,11 +206,8 @@ defmodule RealtimeWeb.JwtVerificationTest do
     token =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImtleS1pZC0xIn0.eyJpYXQiOjE3MTIwNDc1NjUsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwic3ViIjoidXNlci1pZCIsImV4cCI6MTcxMjA1MTE2NX0.zUeoZrWK1efAc4q9y978_9qkhdXktdjf5H8O9Rw0SHcPaXW8OBcuNR2huRrgORvqFx6_sHn6nCJaWkZGzO-f8wskMD7Z4INq2JUypr6nASie3Qu2lLyeY3WTInaXNAKH-oqlfTLRskbz8zkIxOj2bBJiN9ceQLkJU-c92ndiuiG5D1jyQrGsvRdFem_cemp0yOoEaC0XWdjeV6C_UD-34GIyv3o8H4HZg1GcCiyNnAfDmLAcTOQPmqkwsRDQb-pm5O3HwpQt9WHOB6i1vzf-nmIGyCRA7STPdALK16-aiAyT4SJRxM5WN3iK8yitH7g4JETb9WocBbwIM_zfNnUI5w"
 
-    # extracted from iat claim in token above
-    current_time = 1_712_047_565 + 1
-    Mock.freeze(current_time)
-
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, jwks)
+    # Check that the signature is valid even though time may be off.
+    assert {:error, :signature_error} != JwtVerification.verify(token, @jwt_secret, jwks)
   end
 
   test "verify/3 using ES256 JWK" do
@@ -230,9 +227,7 @@ defmodule RealtimeWeb.JwtVerificationTest do
     token =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6ImtleS1pZC0xIn0.eyJpYXQiOjE3MTIwNDk2NTcsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwic3ViIjoidXNlci1pZCIsImV4cCI6MTcxMjA1MzI1N30.IIQBuEiSnZacGMqiqsrLAeRGOjIaB4F3x1gnLN5zvhFryJ-6tdgu96lFv5HUF13IL2UfHWad0OuvoDt4DEHRxw"
 
-    current_time = 1_712_049_657 + 1
-    Mock.freeze(current_time)
-
-    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, jwks)
+    # Check that the signature is valid even though time may be off.
+    assert {:error, :signature_error} != JwtVerification.verify(token, @jwt_secret, jwks)
   end
 end

--- a/test/realtime_web/channels/auth/jwt_verification_test.exs
+++ b/test/realtime_web/channels/auth/jwt_verification_test.exs
@@ -189,4 +189,27 @@ defmodule RealtimeWeb.JwtVerificationTest do
     assert {:error, [message: "Invalid token", claim: "iss", claim_val: "Tester"]} =
              JwtVerification.verify(token, @jwt_secret, nil)
   end
+
+  test "verify/3 using RS256 JWK" do
+    jwks = %{
+      "keys" => [
+        %{
+          "kty" => "RSA",
+          "n" =>
+            "6r1mKwCalvJ0NyThyQkBr5huFILwwhXcxtsdlw-WybNz4avzODQwLFkA-b2fnnfdFgualV2NdcvoJSo1bzVGCWWqwWKWdTQKFjtcjAIC4FnhOv5ynNF9Ub-11ORDd1aiq_4XKNA4GaS1HqBekVDAAvJYy99Jz0CkLx4NU_VrS0U9sOQzUAhy2MwZCx2kZ3SWKEMjjEIkbvIb22IdRTyuFsAndKGpyzhw-MalnU5P2hOig-QApNBc0WJtTHTAa4PLQ6v_5jNc5PzCwP8jGK9SlrSF-GOnx9BVBX9t-AIDp-BviKbtY7y-pku6-f7HSiS2T3iAJkHXPm9E_NwwhWzMJQ",
+          "e" => "AQAB",
+          "kid" => "key-id-1"
+        }
+      ]
+    }
+
+    token =
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImtleS1pZC0xIn0.eyJpYXQiOjE3MTIwNDc1NjUsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwic3ViIjoidXNlci1pZCIsImV4cCI6MTcxMjA1MTE2NX0.zUeoZrWK1efAc4q9y978_9qkhdXktdjf5H8O9Rw0SHcPaXW8OBcuNR2huRrgORvqFx6_sHn6nCJaWkZGzO-f8wskMD7Z4INq2JUypr6nASie3Qu2lLyeY3WTInaXNAKH-oqlfTLRskbz8zkIxOj2bBJiN9ceQLkJU-c92ndiuiG5D1jyQrGsvRdFem_cemp0yOoEaC0XWdjeV6C_UD-34GIyv3o8H4HZg1GcCiyNnAfDmLAcTOQPmqkwsRDQb-pm5O3HwpQt9WHOB6i1vzf-nmIGyCRA7STPdALK16-aiAyT4SJRxM5WN3iK8yitH7g4JETb9WocBbwIM_zfNnUI5w"
+
+    # extracted from iat claim in token above
+    current_time = 1_712_047_565 + 1
+    Mock.freeze(current_time)
+
+    assert {:ok, _claims} = JwtVerification.verify(token, @jwt_secret, jwks)
+  end
 end

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -34,7 +34,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time() + 1_000, "role" => "postgres"}}
            end
          ]}
@@ -50,7 +50,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time() + 1_000, "role" => "postgres"}}
            end
          ]}
@@ -77,7 +77,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time() + 1, "role" => "postgres"}}
            end
          ]}
@@ -92,7 +92,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time(), "role" => "postgres"}}
            end
          ]}
@@ -106,7 +106,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       with_mocks([
         {ChannelsAuthorization, [],
          [
-           authorize_conn: fn _, _ ->
+           authorize_conn: fn _, _, _ ->
              {:ok, %{"exp" => Joken.current_time() - 1, "role" => "postgres"}}
            end
          ]}
@@ -122,7 +122,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
   describe "checks tenant db connectivity" do
     setup_with_mocks([
       {ChannelsAuthorization, [],
-       authorize_conn: fn _, _ ->
+       authorize_conn: fn _, _, _ ->
          {:ok, %{"exp" => Joken.current_time() + 1_000, "role" => "postgres"}}
        end}
     ]) do

--- a/test/realtime_web/controllers/metrics_controller_test.exs
+++ b/test/realtime_web/controllers/metrics_controller_test.exs
@@ -16,7 +16,7 @@ defmodule RealtimeWeb.MetricsControllerTest do
   end
 
   test "exporting metrics", %{conn: conn} do
-    with_mock JwtVerification, verify: fn _token, _secret -> {:ok, %{}} end do
+    with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
       conn = get(conn, Routes.metrics_path(conn, :index))
       assert conn.status == 200
       lines = String.split(conn.resp_body, "\n") |> length()

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -26,7 +26,8 @@ defmodule Generators do
         }
       ],
       "postgres_cdc_default" => "postgres_cdc_rls",
-      "jwt_secret" => "new secret"
+      "jwt_secret" => "new secret",
+      "jwt_jwks" => nil
     }
 
     override = override |> Enum.map(fn {k, v} -> {"#{k}", v} end) |> Map.new()


### PR DESCRIPTION
Adds support for verifying end-user JWTs using JWKS in addition to the JWT secret. This means that third-party authentication systems that use asymmetric JWTs can be used with Realtime.