### PR TITLE
fix: Delete endpoint returns accept response

### DIFF
--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -176,7 +176,6 @@ defmodule RealtimeWeb.TenantController do
     responses: %{
       204 => EmptyResponse.response(),
       403 => UnauthorizedResponse.response(),
-      404 => NotFoundResponse.response(),
       500 => ErrorResponse.response()
     }
   )
@@ -198,7 +197,7 @@ defmodule RealtimeWeb.TenantController do
       nil ->
         Logger.error("Tenant #{tenant_id} does not exist")
 
-        send_resp(conn, 404, "")
+        send_resp(conn, 204, "")
 
       err ->
         msg = "Error deleting tenant: #{inspect(err)}"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.26.5",
+      version: "2.26.6",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

As deletion is an idempotent operation, we do not require the endpoint to return "not found" status code and we will move to a "accept" status code.