### PR TITLE
fix: Infer private channel based on Channel entry

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -57,9 +57,10 @@ defmodule RealtimeWeb.RealtimeChannel do
          channel = ChannelsCache.get_channel_by_name(sub_topic, db_conn),
          {:ok, socket} <- assign_policies(channel, db_conn, access_token, claims, socket) do
       is_new_api = is_new_api(params)
-      Realtime.UsersCounter.add(transport_pid, tenant)
-
+      public? = match?({:ok, _}, channel)
       tenant_topic = tenant <> ":" <> sub_topic
+
+      Realtime.UsersCounter.add(transport_pid, tenant)
       RealtimeWeb.Endpoint.subscribe(tenant_topic)
 
       pg_change_params = pg_change_params(is_new_api, params, channel_pid, claims, sub_topic)
@@ -73,12 +74,6 @@ defmodule RealtimeWeb.RealtimeChannel do
         tenant: tenant,
         module: module
       }
-
-      public? =
-        case channel do
-          {:ok, _} -> false
-          _ -> true
-        end
 
       postgres_cdc_subscribe(opts)
 

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -5,9 +5,6 @@ defmodule RealtimeWeb.RealtimeChannel do
   use RealtimeWeb, :channel
   require Logger
 
-  alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
-  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
-  alias Realtime.Tenants.Authorization.Policies
   alias DBConnection.Backoff
 
   alias Phoenix.Tracker.Shard
@@ -20,6 +17,9 @@ defmodule RealtimeWeb.RealtimeChannel do
   alias Realtime.SignalHandler
   alias Realtime.Tenants
   alias Realtime.Tenants.Authorization
+  alias Realtime.Tenants.Authorization.Policies
+  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
   alias Realtime.Tenants.Connect
 
   alias RealtimeWeb.ChannelsAuthorization
@@ -54,10 +54,9 @@ defmodule RealtimeWeb.RealtimeChannel do
          :ok <- limit_max_users(socket.assigns),
          {:ok, claims, confirm_token_ref, access_token} <- confirm_token(socket),
          {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant),
-         is_new_api = is_new_api(params),
-         public = is_public(params),
-         {:ok, socket} <-
-           assign_policies(public, db_conn, sub_topic, access_token, claims, socket) do
+         channel = ChannelsCache.get_channel_by_name(sub_topic, db_conn),
+         {:ok, socket} <- assign_policies(channel, db_conn, access_token, claims, socket) do
+      is_new_api = is_new_api(params)
       Realtime.UsersCounter.add(transport_pid, tenant)
 
       tenant_topic = tenant <> ":" <> sub_topic
@@ -75,6 +74,12 @@ defmodule RealtimeWeb.RealtimeChannel do
         module: module
       }
 
+      public? =
+        case channel do
+          {:ok, _} -> false
+          _ -> true
+        end
+
       postgres_cdc_subscribe(opts)
 
       Logger.debug("Start channel: " <> inspect(pg_change_params))
@@ -91,7 +96,7 @@ defmodule RealtimeWeb.RealtimeChannel do
         self_broadcast: !!params["config"]["broadcast"]["self"],
         tenant_topic: tenant_topic,
         channel_name: sub_topic,
-        public: !!public
+        public: public?
       }
 
       {:ok, state, assign(socket, assigns)}
@@ -517,13 +522,6 @@ defmodule RealtimeWeb.RealtimeChannel do
   defp is_new_api(%{"config" => _}), do: true
   defp is_new_api(_), do: false
 
-  defp is_public(params) do
-    case params["config"]["broadcast"]["public"] do
-      nil -> true
-      public -> !!public
-    end
-  end
-
   defp pg_change_params(true, params, channel_pid, claims, _) do
     send(self(), :sync_presence)
 
@@ -610,37 +608,31 @@ defmodule RealtimeWeb.RealtimeChannel do
     {:error, %{reason: error_msg}}
   end
 
-  defp assign_policies(false, db_conn, sub_topic, access_token, claims, socket) do
-    case ChannelsCache.get_channel_by_name(sub_topic, db_conn) do
-      {:error, :not_found} ->
-        {:error, "Channel #{sub_topic} does not exist, please create it first"}
+  defp assign_policies({:ok, channel}, db_conn, access_token, claims, socket) do
+    authorization_context =
+      Authorization.build_authorization_params(%{
+        channel: channel,
+        headers: socket.assigns.headers,
+        jwt: access_token,
+        claims: claims,
+        role: claims["role"]
+      })
 
-      {:ok, channel} ->
-        authorization_context =
-          Authorization.build_authorization_params(%{
-            channel: channel,
-            headers: socket.assigns.headers,
-            jwt: access_token,
-            claims: claims,
-            role: claims["role"]
-          })
+    {:ok, socket} = Authorization.get_authorizations(socket, db_conn, authorization_context)
 
-        {:ok, socket} = Authorization.get_authorizations(socket, db_conn, authorization_context)
+    case socket.assigns.policies do
+      %Policies{broadcast: %BroadcastPolicies{read: false}} ->
+        {:error, "You do not have permissions to read Broadcast messages from this channel"}
 
-        case socket.assigns.policies do
-          %Policies{broadcast: %BroadcastPolicies{read: false}} ->
-            {:error, "You do not have permissions to read Broadcast messages from this channel"}
+      %Policies{channel: %ChannelPolicies{read: false}} ->
+        {:error, "You do not have permissions to read from this Channel"}
 
-          %Policies{channel: %ChannelPolicies{read: false}} ->
-            {:error, "You do not have permissions to read from this Channel"}
-
-          _ ->
-            {:ok, socket}
-        end
+      _ ->
+        {:ok, socket}
     end
   end
 
-  defp assign_policies(true, _, _, _, _, socket) do
+  defp assign_policies(_, _, _, _, socket) do
     {:ok, assign(socket, policies: nil)}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.26.7",
+      version: "2.26.8",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -244,7 +244,7 @@ defmodule Realtime.Integration.RtChannelTest do
     )
 
     socket = get_connection("authenticated")
-    config = %{broadcast: %{self: true, public: false}}
+    config = %{broadcast: %{self: true}}
     topic = "realtime:#{channel.name}"
 
     WebsocketClient.join(socket, topic, %{config: config})
@@ -290,7 +290,7 @@ defmodule Realtime.Integration.RtChannelTest do
     )
 
     socket = get_connection("authenticated")
-    config = %{broadcast: %{self: true, public: false}}
+    config = %{broadcast: %{self: true}}
     topic = "realtime:#{channel.name}"
 
     WebsocketClient.join(socket, topic, %{config: config})
@@ -331,7 +331,7 @@ defmodule Realtime.Integration.RtChannelTest do
     channel = channel_fixture(tenant)
     create_rls_policies(db_conn, [:authenticated_read_channel], channel)
     socket = get_connection("authenticated")
-    config = %{broadcast: %{self: true, public: false}}
+    config = %{broadcast: %{self: true}}
     topic = "realtime:#{channel.name}"
 
     WebsocketClient.join(socket, topic, %{config: config})
@@ -364,7 +364,7 @@ defmodule Realtime.Integration.RtChannelTest do
     channel = channel_fixture(tenant)
     create_rls_policies(db_conn, [:authenticated_read_broadcast], channel)
     socket = get_connection("authenticated")
-    config = %{broadcast: %{self: true, public: false}}
+    config = %{broadcast: %{self: true}}
     topic = "realtime:#{channel.name}"
 
     WebsocketClient.join(socket, topic, %{config: config})
@@ -376,36 +376,6 @@ defmodule Realtime.Integration.RtChannelTest do
                        "response" => %{
                          "reason" => "\"You do not have permissions to read from this Channel\""
                        },
-                       "status" => "error"
-                     },
-                     ref: "1",
-                     join_ref: nil
-                   },
-                   500
-  end
-
-  test "private broadcast with non existing channel fails to join" do
-    [tenant] = Repo.all(Tenant)
-
-    start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
-    {:ok, db_conn} = Connect.get_status(tenant.external_id)
-
-    clean_table(db_conn, "realtime", "broadcasts")
-    clean_table(db_conn, "realtime", "channels")
-
-    socket = get_connection("authenticated")
-    config = %{broadcast: %{self: true, public: false}}
-    channel_name = random_string()
-    topic = "realtime:#{channel_name}"
-
-    WebsocketClient.join(socket, topic, %{config: config})
-    reason = "\"Channel #{channel_name} does not exist, please create it first\""
-
-    assert_receive %Phoenix.Socket.Message{
-                     topic: ^topic,
-                     event: "phx_reply",
-                     payload: %{
-                       "response" => %{"reason" => ^reason},
                        "status" => "error"
                      },
                      ref: "1",


### PR DESCRIPTION
## What kind of change does this PR introduce?

To facilitate the usage of Authz in Realtime during this first iteration we will have the assumption that if we have a Channel present in the tenant database we will have the assumption that the user intented to have a private channel which will end calculating the policies based on RLS rules.

Also small fix for counter which was counting failed sent messages
