### PR TITLE
fix: Remove v3 prefix from API for Channels endpoints

### DIFF
--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -106,7 +106,7 @@ defmodule RealtimeWeb.Router do
     post("/broadcast", BroadcastController, :broadcast)
   end
 
-  scope "/v3/api", RealtimeWeb do
+  scope "/api", RealtimeWeb do
     pipe_through([:open_cors, :tenant_api, :secure_tenant_api, :channel_rls_authorization])
 
     resources("/channels", ChannelsController, only: [:index, :show, :create, :update, :delete])

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.27.0",
+      version: "2.27.1",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/channels_controller_test.exs
+++ b/test/realtime_web/controllers/channels_controller_test.exs
@@ -53,7 +53,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
         |> Jason.encode!()
         |> Jason.decode!()
 
-      conn = get(conn, ~p"/v3/api/channels")
+      conn = get(conn, ~p"/api/channels")
       res = json_response(conn, 200)
 
       res = Enum.sort_by(res, fn %{"id" => id} -> id end)
@@ -63,7 +63,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
 
     @tag role: "authenticated"
     test "returns 401 if unauthorized", %{conn: conn} do
-      conn = get(conn, ~p"/v3/api/channels")
+      conn = get(conn, ~p"/api/channels")
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end
@@ -77,7 +77,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
 
       expected = channel |> Jason.encode!() |> Jason.decode!()
 
-      conn = get(conn, ~p"/v3/api/channels/#{channel.id}")
+      conn = get(conn, ~p"/api/channels/#{channel.id}")
       res = json_response(conn, 200)
       assert res == expected
     end
@@ -87,13 +87,13 @@ defmodule RealtimeWeb.ChannelsControllerTest do
       Stream.repeatedly(fn -> channel_fixture(tenant) end)
       |> Enum.take(10)
 
-      conn = get(conn, ~p"/v3/api/channels/0")
+      conn = get(conn, ~p"/api/channels/0")
       assert json_response(conn, 404) == %{"message" => "Not found"}
     end
 
     @tag role: "anon"
     test "returns 401 if unauthorized", %{conn: conn} do
-      conn = get(conn, ~p"/v3/api/channels/0")
+      conn = get(conn, ~p"/api/channels/0")
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end
@@ -102,7 +102,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     @tag role: "authenticated"
     test "creates a channel", %{conn: conn} do
       name = random_string()
-      conn = post(conn, ~p"/v3/api/channels", %{"name" => name})
+      conn = post(conn, ~p"/api/channels", %{"name" => name})
       res = json_response(conn, 201)
       assert name == res["name"]
     end
@@ -111,13 +111,13 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     test "422 if params are invalid", %{conn: conn, tenant: tenant} do
       name = random_string()
       channel_fixture(tenant, %{name: name})
-      conn = post(conn, ~p"/v3/api/channels", %{"name" => name})
+      conn = post(conn, ~p"/api/channels", %{"name" => name})
       assert json_response(conn, 422) == %{"errors" => %{"name" => ["has already been taken"]}}
     end
 
     @tag role: "anon"
     test "returns 401 if unauthorized", %{conn: conn} do
-      conn = post(conn, ~p"/v3/api/channels", %{name: random_string()})
+      conn = post(conn, ~p"/api/channels", %{name: random_string()})
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end
@@ -126,20 +126,20 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     @tag role: "authenticated"
     test "deletes a channel", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
-      conn = delete(conn, ~p"/v3/api/channels/#{channel.id}")
+      conn = delete(conn, ~p"/api/channels/#{channel.id}")
       assert conn.status == 202
     end
 
     @tag role: "authenticated"
     test "returns unauthorized if id doesn't exist", %{conn: conn} do
-      conn = delete(conn, ~p"/v3/api/channels/0")
+      conn = delete(conn, ~p"/api/channels/0")
       assert conn.status == 401
     end
 
     @tag role: "anon"
     test "returns 401 if unauthorized", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
-      conn = delete(conn, ~p"/v3/api/channels/#{channel.id}")
+      conn = delete(conn, ~p"/api/channels/#{channel.id}")
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end
@@ -149,12 +149,12 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     test "updates a channel", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
       name = random_string()
-      conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{name: name})
+      conn = put(conn, ~p"/api/channels/#{channel.id}", %{name: name})
       res = json_response(conn, 202)
       assert name == res["name"]
 
       name = random_string()
-      conn = patch(conn, ~p"/v3/api/channels/#{channel.id}", %{name: name})
+      conn = patch(conn, ~p"/api/channels/#{channel.id}", %{name: name})
       res = json_response(conn, 202)
       assert name == res["name"]
     end
@@ -162,16 +162,16 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     @tag role: "authenticated"
     test "422 if params are invalid", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
-      conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{"name" => 1})
+      conn = put(conn, ~p"/api/channels/#{channel.id}", %{"name" => 1})
       assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
-      conn = patch(conn, ~p"/v3/api/channels/#{channel.id}", %{"name" => 1})
+      conn = patch(conn, ~p"/api/channels/#{channel.id}", %{"name" => 1})
       assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
     end
 
     @tag role: "anon"
     test "returns 401 if unauthorized", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
-      conn = put(conn, ~p"/v3/api/channels/#{channel.id}", %{"name" => 1})
+      conn = put(conn, ~p"/api/channels/#{channel.id}", %{"name" => 1})
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove v3 prefix from API for Channels endpoints
