### PR TITLE
fix: Change param from id to name in Channel CRUD actions

### DIFF
--- a/lib/realtime/channels.ex
+++ b/lib/realtime/channels.ex
@@ -69,12 +69,12 @@ defmodule Realtime.Channels do
   end
 
   @doc """
-  Deletes a channel by id from the tenant database using a given DBConnection
+  Deletes a channel by name from the tenant database using a given DBConnection
   """
-  @spec delete_channel_by_id(binary(), DBConnection.conn()) ::
+  @spec delete_channel_by_name(binary(), DBConnection.conn()) ::
           :ok | {:error, any()}
-  def delete_channel_by_id(id, conn) do
-    query = from c in Channel, where: c.id == ^id
+  def delete_channel_by_name(name, conn) do
+    query = from c in Channel, where: c.name == ^name
 
     case Repo.del(conn, query) do
       {:ok, 1} -> :ok
@@ -84,12 +84,12 @@ defmodule Realtime.Channels do
   end
 
   @doc """
-  Updates a channel by id from the tenant database using a given DBConnection
+  Updates a channel by name from the tenant database using a given DBConnection
   """
-  @spec update_channel_by_id(binary(), map(), DBConnection.conn()) ::
+  @spec update_channel_by_name(binary(), map(), DBConnection.conn()) ::
           {:ok, Channel.t()} | {:error, any()}
-  def update_channel_by_id(id, attrs, conn) do
-    with {:ok, channel} when not is_nil(channel) <- get_channel_by_id(id, conn) do
+  def update_channel_by_name(name, attrs, conn) do
+    with {:ok, channel} when not is_nil(channel) <- get_channel_by_name(name, conn) do
       channel = Channel.changeset(channel, attrs)
       Repo.update(conn, channel, Channel)
     end

--- a/lib/realtime_web/controllers/channels_controller.ex
+++ b/lib/realtime_web/controllers/channels_controller.ex
@@ -56,10 +56,10 @@ defmodule RealtimeWeb.ChannelsController do
     parameters: [
       id: [
         in: :path,
-        name: "id",
+        name: "name",
         schema: %OpenApiSpex.Schema{type: :string},
         required: true,
-        example: "1"
+        example: "channel_name"
       ],
       token: [
         in: :header,
@@ -85,11 +85,11 @@ defmodule RealtimeWeb.ChannelsController do
           }
         } = conn,
         %{
-          "id" => id
+          "name" => name
         }
       ) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id),
-         {:ok, channel} when not is_nil(channel) <- Channels.get_channel_by_id(id, db_conn) do
+         {:ok, channel} when not is_nil(channel) <- Channels.get_channel_by_name(name, db_conn) do
       json(conn, channel)
     else
       {:ok, nil} -> {:error, :not_found}
@@ -142,10 +142,10 @@ defmodule RealtimeWeb.ChannelsController do
     parameters: [
       id: [
         in: :path,
-        name: "id",
+        name: "name",
         schema: %OpenApiSpex.Schema{type: :string},
         required: true,
-        example: "1"
+        example: "channel_name"
       ],
       token: [
         in: :header,
@@ -169,10 +169,10 @@ defmodule RealtimeWeb.ChannelsController do
             policies: %Policies{channel: %ChannelPolicies{write: true}}
           }
         } = conn,
-        %{"id" => id}
+        %{"name" => name}
       ) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id),
-         :ok <- Channels.delete_channel_by_id(id, db_conn) do
+         :ok <- Channels.delete_channel_by_name(name, db_conn) do
       send_resp(conn, :accepted, "")
     end
   end
@@ -184,10 +184,10 @@ defmodule RealtimeWeb.ChannelsController do
     parameters: [
       id: [
         in: :path,
-        name: "id",
+        name: "name",
         schema: %OpenApiSpex.Schema{type: :string},
         required: true,
-        example: "1"
+        example: "channel_name"
       ],
       token: [
         in: :header,
@@ -210,12 +210,13 @@ defmodule RealtimeWeb.ChannelsController do
           assigns: %{
             tenant: tenant,
             policies: %Policies{channel: %ChannelPolicies{write: true}}
-          }
+          },
+          body_params: body_params
         } = conn,
-        %{"id" => id} = params
+        %{"name" => name}
       ) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id),
-         {:ok, channel} <- Channels.update_channel_by_id(id, params, db_conn) do
+         {:ok, channel} <- Channels.update_channel_by_name(name, body_params, db_conn) do
       conn
       |> put_status(:accepted)
       |> json(channel)

--- a/lib/realtime_web/plugs/rls_authorization.ex
+++ b/lib/realtime_web/plugs/rls_authorization.ex
@@ -47,8 +47,8 @@ defmodule RealtimeWeb.RlsAuthorization do
           params
       end
 
-    with {:ok, id} <- Map.fetch(path_params, "id"),
-         {:ok, channel} <- Channels.get_channel_by_id(id, db_conn) do
+    with {:ok, name} <- Map.fetch(path_params, "name"),
+         {:ok, channel} <- Channels.get_channel_by_name(name, db_conn) do
       params
       |> Map.put(:channel, channel)
       |> Map.put(:channel_name, channel.name)

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -109,7 +109,10 @@ defmodule RealtimeWeb.Router do
   scope "/api", RealtimeWeb do
     pipe_through([:open_cors, :tenant_api, :secure_tenant_api, :channel_rls_authorization])
 
-    resources("/channels", ChannelsController, only: [:index, :show, :create, :update, :delete])
+    resources("/channels", ChannelsController,
+      only: [:index, :show, :create, :update, :delete],
+      param: "name"
+    )
   end
 
   # Enables LiveDashboard only for development

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.27.1",
+      version: "2.27.2",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/channels_test.exs
+++ b/test/realtime/channels_test.exs
@@ -84,29 +84,29 @@ defmodule Realtime.ChannelsTest do
     end
   end
 
-  describe "delete_channel_by_id/2" do
+  describe "delete_channel_by_name/2" do
     test "deletes correct channel", %{conn: conn, tenant: tenant} do
       [channel | _] = Stream.repeatedly(fn -> channel_fixture(tenant) end) |> Enum.take(10)
-      assert :ok = Channels.delete_channel_by_id(channel.id, conn)
-      assert {:error, :not_found} = Channels.get_channel_by_id(channel.id, conn)
+      assert :ok = Channels.delete_channel_by_name(channel.name, conn)
+      assert {:error, :not_found} = Channels.get_channel_by_name(channel.name, conn)
     end
 
     test "not found error if does not exist", %{conn: conn} do
-      assert {:error, :not_found} = Channels.delete_channel_by_id(0, conn)
+      assert {:error, :not_found} = Channels.delete_channel_by_name("none", conn)
     end
   end
 
-  describe "update_channel_by_id/2" do
+  describe "update_channel_by_name/2" do
     test "update correct channel", %{conn: conn, tenant: tenant} do
       name = random_string()
       [channel | _] = Stream.repeatedly(fn -> channel_fixture(tenant) end) |> Enum.take(10)
-      assert {:ok, channel} = Channels.update_channel_by_id(channel.id, %{name: name}, conn)
-      {:ok, channel} = Channels.get_channel_by_id(channel.id, conn)
+      assert {:ok, channel} = Channels.update_channel_by_name(channel.name, %{name: name}, conn)
+      {:ok, channel} = Channels.get_channel_by_name(channel.name, conn)
       assert name == channel.name
     end
 
     test "not found error if does not exist", %{conn: conn} do
-      assert {:error, :not_found} = Channels.update_channel_by_id(0, %{name: ""}, conn)
+      assert {:error, :not_found} = Channels.update_channel_by_name("none", %{name: ""}, conn)
     end
   end
 end

--- a/test/realtime_web/controllers/channels_controller_test.exs
+++ b/test/realtime_web/controllers/channels_controller_test.exs
@@ -77,7 +77,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
 
       expected = channel |> Jason.encode!() |> Jason.decode!()
 
-      conn = get(conn, ~p"/api/channels/#{channel.id}")
+      conn = get(conn, ~p"/api/channels/#{channel.name}")
       res = json_response(conn, 200)
       assert res == expected
     end
@@ -126,7 +126,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     @tag role: "authenticated"
     test "deletes a channel", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
-      conn = delete(conn, ~p"/api/channels/#{channel.id}")
+      conn = delete(conn, ~p"/api/channels/#{channel.name}")
       assert conn.status == 202
     end
 
@@ -139,7 +139,7 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     @tag role: "anon"
     test "returns 401 if unauthorized", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
-      conn = delete(conn, ~p"/api/channels/#{channel.id}")
+      conn = delete(conn, ~p"/api/channels/#{channel.name}")
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end
@@ -149,12 +149,13 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     test "updates a channel", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
       name = random_string()
-      conn = put(conn, ~p"/api/channels/#{channel.id}", %{name: name})
+      conn = put(conn, ~p"/api/channels/#{channel.name}", %{name: name})
       res = json_response(conn, 202)
       assert name == res["name"]
 
+      channel = channel_fixture(tenant)
       name = random_string()
-      conn = patch(conn, ~p"/api/channels/#{channel.id}", %{name: name})
+      conn = patch(conn, ~p"/api/channels/#{channel.name}", %{name: name})
       res = json_response(conn, 202)
       assert name == res["name"]
     end
@@ -162,16 +163,16 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     @tag role: "authenticated"
     test "422 if params are invalid", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
-      conn = put(conn, ~p"/api/channels/#{channel.id}", %{"name" => 1})
+      conn = put(conn, ~p"/api/channels/#{channel.name}", %{"name" => 1})
       assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
-      conn = patch(conn, ~p"/api/channels/#{channel.id}", %{"name" => 1})
+      conn = patch(conn, ~p"/api/channels/#{channel.name}", %{"name" => 1})
       assert json_response(conn, 422) == %{"errors" => %{"name" => ["is invalid"]}}
     end
 
     @tag role: "anon"
     test "returns 401 if unauthorized", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
-      conn = put(conn, ~p"/api/channels/#{channel.id}", %{"name" => 1})
+      conn = put(conn, ~p"/api/channels/#{channel.name}", %{"name" => "new_name"})
       assert json_response(conn, 401) == %{"message" => "Unauthorized"}
     end
   end

--- a/test/realtime_web/plugs/rls_authorization_test.exs
+++ b/test/realtime_web/plugs/rls_authorization_test.exs
@@ -41,7 +41,7 @@ defmodule RealtimeWeb.RlsAuthorizationTest do
     conn =
       conn
       |> setup_conn(tenant, claims, jwt, role)
-      |> Map.put(:path_params, %{"id" => channel.id})
+      |> Map.put(:path_params, %{"name" => channel.name})
 
     conn = RlsAuthorization.call(conn, %{})
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

To make the API easier to interact with, we're using name instead of using id to run CRUD operations on channels
