### PR TITLE
fix: Run Query within transaction of DB Conn owner

### DIFF
--- a/lib/realtime/channels.ex
+++ b/lib/realtime/channels.ex
@@ -6,8 +6,8 @@ defmodule Realtime.Channels do
   alias Realtime.Api.Broadcast
   alias Realtime.Api.Channel
   alias Realtime.Api.Presence
+  alias Realtime.Helpers
   alias Realtime.Repo
-  alias Realtime.Tenants.Connect
 
   import Ecto.Query
 
@@ -16,7 +16,7 @@ defmodule Realtime.Channels do
   """
   @spec list_channels(DBConnection.conn()) :: {:error, any()} | {:ok, [struct()]}
   def list_channels(conn) do
-    Connect.transaction(conn, fn db_conn -> Repo.all(db_conn, Channel, Channel) end)
+    Helpers.transaction(conn, fn db_conn -> Repo.all(db_conn, Channel, Channel) end)
   end
 
   @doc """
@@ -26,7 +26,7 @@ defmodule Realtime.Channels do
   def get_channel_by_id(id, conn) do
     query = from c in Channel, where: c.id == ^id
 
-    Connect.transaction(conn, fn transaction_conn ->
+    Helpers.transaction(conn, fn transaction_conn ->
       Repo.one(transaction_conn, query, Channel)
     end)
   end
@@ -45,7 +45,7 @@ defmodule Realtime.Channels do
     channel = Channel.changeset(%Channel{}, attrs)
 
     result =
-      Connect.transaction(conn, fn transaction_conn ->
+      Helpers.transaction(conn, fn transaction_conn ->
         with {:ok, %Channel{} = channel} <-
                Repo.insert(transaction_conn, channel, Channel, opts),
              broadcast_changeset = Broadcast.changeset(%Broadcast{}, %{channel_id: channel.id}),
@@ -71,7 +71,7 @@ defmodule Realtime.Channels do
   def get_channel_by_name(name, conn) do
     query = from c in Channel, where: c.name == ^name
 
-    Connect.transaction(conn, fn transaction_conn ->
+    Helpers.transaction(conn, fn transaction_conn ->
       Repo.one(transaction_conn, query, Channel)
     end)
   end
@@ -84,7 +84,7 @@ defmodule Realtime.Channels do
   def delete_channel_by_name(name, conn) do
     query = from c in Channel, where: c.name == ^name
 
-    Connect.transaction(conn, fn transaction_conn ->
+    Helpers.transaction(conn, fn transaction_conn ->
       case Repo.del(transaction_conn, query) do
         {:ok, 1} -> :ok
         {:ok, 0} -> {:error, :not_found}
@@ -102,7 +102,7 @@ defmodule Realtime.Channels do
     with {:ok, channel} when not is_nil(channel) <- get_channel_by_name(name, conn) do
       channel = Channel.changeset(channel, attrs)
 
-      Connect.transaction(conn, fn transaction_conn ->
+      Helpers.transaction(conn, fn transaction_conn ->
         Repo.update(transaction_conn, channel, Channel)
       end)
     end

--- a/lib/realtime/channels.ex
+++ b/lib/realtime/channels.ex
@@ -7,6 +7,7 @@ defmodule Realtime.Channels do
   alias Realtime.Api.Channel
   alias Realtime.Api.Presence
   alias Realtime.Repo
+  alias Realtime.Tenants.Connect
 
   import Ecto.Query
 
@@ -15,7 +16,7 @@ defmodule Realtime.Channels do
   """
   @spec list_channels(DBConnection.conn()) :: {:error, any()} | {:ok, [struct()]}
   def list_channels(conn) do
-    Repo.all(conn, Channel, Channel)
+    Connect.transaction(conn, fn db_conn -> Repo.all(db_conn, Channel, Channel) end)
   end
 
   @doc """
@@ -24,14 +25,17 @@ defmodule Realtime.Channels do
   @spec get_channel_by_id(binary(), DBConnection.conn()) :: {:ok, Channel.t()} | {:error, any()}
   def get_channel_by_id(id, conn) do
     query = from c in Channel, where: c.id == ^id
-    Repo.one(conn, query, Channel)
+
+    Connect.transaction(conn, fn transaction_conn ->
+      Repo.one(transaction_conn, query, Channel)
+    end)
   end
 
   @spec create_channel(
           map(),
           DBConnection.t(),
           Postgrex.option() | Keyword.t()
-        ) :: {:error, any()} | {:ok, any()}
+        ) :: {:error, any()} | {:ok, Channel.t()}
   @doc """
   Creates a channel and supporting tables for a given channel in the tenant database using a given DBConnection.
 
@@ -41,8 +45,9 @@ defmodule Realtime.Channels do
     channel = Channel.changeset(%Channel{}, attrs)
 
     result =
-      Postgrex.transaction(conn, fn transaction_conn ->
-        with {:ok, %Channel{} = channel} <- Repo.insert(transaction_conn, channel, Channel, opts),
+      Connect.transaction(conn, fn transaction_conn ->
+        with {:ok, %Channel{} = channel} <-
+               Repo.insert(transaction_conn, channel, Channel, opts),
              broadcast_changeset = Broadcast.changeset(%Broadcast{}, %{channel_id: channel.id}),
              presence_changeset = Broadcast.changeset(%Presence{}, %{channel_id: channel.id}),
              {:ok, _} <- Repo.insert(transaction_conn, broadcast_changeset, Broadcast, opts),
@@ -52,9 +57,9 @@ defmodule Realtime.Channels do
       end)
 
     case result do
-      {:ok, %Ecto.Changeset{valid?: false} = error} -> {:error, error}
-      {:ok, {:error, error}} -> {:error, error}
-      result -> result
+      %Ecto.Changeset{valid?: false} = error -> {:error, error}
+      {:error, error} -> {:error, error}
+      result -> {:ok, result}
     end
   end
 
@@ -65,7 +70,10 @@ defmodule Realtime.Channels do
           {:ok, Channel.t()} | {:error, any()}
   def get_channel_by_name(name, conn) do
     query = from c in Channel, where: c.name == ^name
-    Repo.one(conn, query, Channel)
+
+    Connect.transaction(conn, fn transaction_conn ->
+      Repo.one(transaction_conn, query, Channel)
+    end)
   end
 
   @doc """
@@ -76,11 +84,13 @@ defmodule Realtime.Channels do
   def delete_channel_by_name(name, conn) do
     query = from c in Channel, where: c.name == ^name
 
-    case Repo.del(conn, query) do
-      {:ok, 1} -> :ok
-      {:ok, 0} -> {:error, :not_found}
-      error -> error
-    end
+    Connect.transaction(conn, fn transaction_conn ->
+      case Repo.del(transaction_conn, query) do
+        {:ok, 1} -> :ok
+        {:ok, 0} -> {:error, :not_found}
+        error -> error
+      end
+    end)
   end
 
   @doc """
@@ -91,7 +101,10 @@ defmodule Realtime.Channels do
   def update_channel_by_name(name, attrs, conn) do
     with {:ok, channel} when not is_nil(channel) <- get_channel_by_name(name, conn) do
       channel = Channel.changeset(channel, attrs)
-      Repo.update(conn, channel, Channel)
+
+      Connect.transaction(conn, fn transaction_conn ->
+        Repo.update(transaction_conn, channel, Channel)
+      end)
     end
   end
 end

--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -424,6 +424,30 @@ defmodule Realtime.Helpers do
     end
   end
 
+  @doc """
+  Runs database transaction in local node or against a target node withing a Postgrex transaction
+  """
+  @spec transaction(pid | DBConnection.t(), fun) :: any()
+  def transaction(%DBConnection{} = db_conn, func) do
+    with {:ok, result} <- Postgrex.transaction(db_conn, func) do
+      result
+    else
+      {:error, error} -> error
+    end
+  end
+
+  def transaction(db_conn, func) when node() == node(db_conn) do
+    with {:ok, result} <- Postgrex.transaction(db_conn, func) do
+      result
+    else
+      {:error, error} -> error
+    end
+  end
+
+  def transaction(db_conn, func) do
+    Rpc.enhanced_call(node(db_conn), __MODULE__, :run_db_request, [db_conn, func], timeout: 15_000)
+  end
+
   defp stop_user_tenant_process(tenant, platform_region, acc) do
     Extensions.PostgresCdcRls.handle_stop(tenant, 5_000)
     # credo:disable-for-next-line

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -11,11 +11,11 @@ defmodule Realtime.Tenants.Authorization do
   require Logger
 
   alias Realtime.Api.Channel
+  alias Realtime.Helpers
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
   alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
   alias Realtime.Tenants.Authorization.Policies.PresencePolicies
-  alias Realtime.Tenants.Connect
 
   defstruct [:channel_name, :channel, :headers, :jwt, :claims, :role]
 
@@ -121,7 +121,7 @@ defmodule Realtime.Tenants.Authorization do
 
   @policies_mods [ChannelPolicies, BroadcastPolicies, PresencePolicies]
   defp get_policies_for_connection(conn, authorization_context) do
-    Connect.transaction(conn, fn transaction_conn ->
+    Helpers.transaction(conn, fn transaction_conn ->
       set_conn_config(transaction_conn, authorization_context)
 
       Enum.reduce_while(@policies_mods, %Policies{}, fn policies_mod, policies ->

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -15,6 +15,7 @@ defmodule Realtime.Tenants.Authorization do
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
   alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
   alias Realtime.Tenants.Authorization.Policies.PresencePolicies
+  alias Realtime.Tenants.Connect
 
   defstruct [:channel_name, :channel, :headers, :jwt, :claims, :role]
 
@@ -57,15 +58,15 @@ defmodule Realtime.Tenants.Authorization do
           {:ok, Phoenix.Socket.t() | Plug.Conn.t()} | {:error, :unauthorized}
   def get_authorizations(%Phoenix.Socket{} = socket, db_conn, authorization_context) do
     case get_policies_for_connection(db_conn, authorization_context) do
-      {:ok, policies} -> {:ok, Phoenix.Socket.assign(socket, :policies, policies)}
-      error -> error
+      %Policies{} = policies -> {:ok, Phoenix.Socket.assign(socket, :policies, policies)}
+      error -> {:error, error}
     end
   end
 
   def get_authorizations(%Plug.Conn{} = conn, db_conn, authorization_context) do
     case get_policies_for_connection(db_conn, authorization_context) do
-      {:ok, policies} -> {:ok, Plug.Conn.assign(conn, :policies, policies)}
-      error -> error
+      %Policies{} = policies -> {:ok, Plug.Conn.assign(conn, :policies, policies)}
+      error -> {:error, error}
     end
   end
 
@@ -120,7 +121,7 @@ defmodule Realtime.Tenants.Authorization do
 
   @policies_mods [ChannelPolicies, BroadcastPolicies, PresencePolicies]
   defp get_policies_for_connection(conn, authorization_context) do
-    Postgrex.transaction(conn, fn transaction_conn ->
+    Connect.transaction(conn, fn transaction_conn ->
       set_conn_config(transaction_conn, authorization_context)
 
       Enum.reduce_while(@policies_mods, %Policies{}, fn policies_mod, policies ->

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -68,30 +68,6 @@ defmodule Realtime.Tenants.Connect do
     end
   end
 
-  @doc """
-  Runs database transaction in local node or against a target node withing a Postgrex transaction
-  """
-  @spec transaction(pid | DBConnection.t(), fun) :: any()
-  def transaction(%DBConnection{} = db_conn, func) do
-    with {:ok, result} <- Postgrex.transaction(db_conn, func) do
-      result
-    else
-      {:error, error} -> error
-    end
-  end
-
-  def transaction(db_conn, func) when node() == node(db_conn) do
-    with {:ok, result} <- Postgrex.transaction(db_conn, func) do
-      result
-    else
-      {:error, error} -> error
-    end
-  end
-
-  def transaction(db_conn, func) do
-    Rpc.enhanced_call(node(db_conn), __MODULE__, :run_db_request, [db_conn, func], timeout: 15_000)
-  end
-
   def start_link(opts) do
     tenant_id = Keyword.get(opts, :tenant_id)
 

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -68,6 +68,30 @@ defmodule Realtime.Tenants.Connect do
     end
   end
 
+  @doc """
+  Runs database transaction in local node or against a target node withing a Postgrex transaction
+  """
+  @spec transaction(pid | DBConnection.t(), fun) :: any()
+  def transaction(%DBConnection{} = db_conn, func) do
+    with {:ok, result} <- Postgrex.transaction(db_conn, func) do
+      result
+    else
+      {:error, error} -> error
+    end
+  end
+
+  def transaction(db_conn, func) when node() == node(db_conn) do
+    with {:ok, result} <- Postgrex.transaction(db_conn, func) do
+      result
+    else
+      {:error, error} -> error
+    end
+  end
+
+  def transaction(db_conn, func) do
+    Rpc.enhanced_call(node(db_conn), __MODULE__, :run_db_request, [db_conn, func], timeout: 15_000)
+  end
+
   def start_link(opts) do
     tenant_id = Keyword.get(opts, :tenant_id)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.27.3",
+      version: "2.27.4",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
@@ -181,7 +181,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
           channel_name: channel_name
       }
 
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
+      Connect.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, authorization_context)
 
         assert {:ok, result} =
@@ -213,7 +213,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
           channel_name: channel_name
       }
 
-      Postgrex.transaction(context.db_conn, fn transaction_conn ->
+      Connect.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, authorization_context)
 
         assert {:ok, result} =

--- a/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
@@ -6,6 +6,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
 
   alias Realtime.Api.Channel
   alias Realtime.Channels
+  alias Realtime.Helpers
   alias Realtime.Repo
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
@@ -181,7 +182,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
           channel_name: channel_name
       }
 
-      Connect.transaction(context.db_conn, fn transaction_conn ->
+      Helpers.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, authorization_context)
 
         assert {:ok, result} =
@@ -213,7 +214,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
           channel_name: channel_name
       }
 
-      Connect.transaction(context.db_conn, fn transaction_conn ->
+      Helpers.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, authorization_context)
 
         assert {:ok, result} =


### PR DESCRIPTION
## What kind of change does this PR introduce?

Postgrex is unable to checkout connections from external nodes (as expected...) so we need to run an rpc call against the db connection owner instead.

This abstracts that work by giving that work to the Connect module which already is the one attributing said connections.

