### PR TITLE
fix: Posgtres role with Realtime Admin grants

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -46,7 +46,8 @@ defmodule Realtime.Tenants.Migrations do
     AddUpdateGrantToChannels,
     AddBroadcastsPoliciesTable,
     AddInsertAndDeleteGrantToChannels,
-    AddPresencesPoliciesTable
+    AddPresencesPoliciesTable,
+    CreateRealtimeAdminAndMoveOwnership
   }
 
   alias Realtime.Helpers
@@ -91,7 +92,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_240_109_165_339, AddUpdateGrantToChannels},
     {20_240_227_174_441, AddBroadcastsPoliciesTable},
     {20_240_311_171_622, AddInsertAndDeleteGrantToChannels},
-    {20_240_321_100_241, AddPresencesPoliciesTable}
+    {20_240_321_100_241, AddPresencesPoliciesTable},
+    {20_240_401_105_812, CreateRealtimeAdminAndMoveOwnership}
   ]
 
   @spec run_migrations(map()) :: {:ok, [integer()]} | {:error, any()}

--- a/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
+++ b/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
@@ -9,6 +9,7 @@ defmodule Realtime.Tenants.Migrations.CreateRealtimeAdminAndMoveOwnership do
     execute("GRANT ALL PRIVILEGES ON SCHEMA realtime TO supabase_realtime_admin")
     execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA realtime TO supabase_realtime_admin")
     execute("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA realtime TO supabase_realtime_admin")
+    execute("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA realtime TO supabase_realtime_admin")
 
     execute("ALTER table realtime.channels OWNER to supabase_realtime_admin")
     execute("ALTER table realtime.broadcasts OWNER to supabase_realtime_admin")

--- a/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
+++ b/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
@@ -16,20 +16,20 @@ defmodule Realtime.Tenants.Migrations.CreateRealtimeAdminAndMoveOwnership do
     execute("ALTER function realtime.channel_name() owner to supabase_realtime_admin")
 
     execute("""
-      DO
-      $do$
-      BEGIN
-         IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles
-            WHERE  rolname = 'authenticator') THEN
-            CREATE ROLE authenticator NOINHERIT ;
-            GRANT anon TO authenticator;
-            GRANT authenticated TO authenticator;
-            GRANT service_role TO authenticator;
-            GRANT postgres TO authenticator;
-         END IF;
-      END
-      $do$;
-      """)
+    DO
+    $do$
+    BEGIN
+       IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles
+          WHERE  rolname = 'authenticator') THEN
+          CREATE ROLE authenticator NOINHERIT ;
+          GRANT anon TO authenticator;
+          GRANT authenticated TO authenticator;
+          GRANT service_role TO authenticator;
+          GRANT postgres TO authenticator;
+       END IF;
+    END
+    $do$;
+    """)
 
     execute("GRANT supabase_realtime_admin TO authenticator")
   end

--- a/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
+++ b/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
@@ -15,6 +15,22 @@ defmodule Realtime.Tenants.Migrations.CreateRealtimeAdminAndMoveOwnership do
     execute("ALTER table realtime.presences OWNER TO supabase_realtime_admin")
     execute("ALTER function realtime.channel_name() owner to supabase_realtime_admin")
 
-    execute("GRANT supabase_realtime_admin TO postgres")
+    execute("""
+      DO
+      $do$
+      BEGIN
+         IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles
+            WHERE  rolname = 'authenticator') THEN
+            CREATE ROLE authenticator NOINHERIT ;
+            GRANT anon TO authenticator;
+            GRANT authenticated TO authenticator;
+            GRANT service_role TO authenticator;
+            GRANT postgres TO authenticator;
+         END IF;
+      END
+      $do$;
+      """)
+
+    execute("GRANT supabase_realtime_admin TO authenticator")
   end
 end

--- a/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
+++ b/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
@@ -15,22 +15,6 @@ defmodule Realtime.Tenants.Migrations.CreateRealtimeAdminAndMoveOwnership do
     execute("ALTER table realtime.presences OWNER TO supabase_realtime_admin")
     execute("ALTER function realtime.channel_name() owner to supabase_realtime_admin")
 
-    execute("""
-    DO
-    $do$
-    BEGIN
-       IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles
-          WHERE  rolname = 'authenticator') THEN
-          CREATE ROLE authenticator NOINHERIT ;
-          GRANT anon TO authenticator;
-          GRANT authenticated TO authenticator;
-          GRANT service_role TO authenticator;
-          GRANT postgres TO authenticator;
-       END IF;
-    END
-    $do$;
-    """)
-
-    execute("GRANT supabase_realtime_admin TO authenticator")
+    execute("GRANT supabase_realtime_admin TO postgres")
   end
 end

--- a/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
+++ b/lib/realtime/tenants/repo/migrations/20240401105812_create_realtime_admin_and_move_ownership.ex
@@ -1,0 +1,20 @@
+defmodule Realtime.Tenants.Migrations.CreateRealtimeAdminAndMoveOwnership do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    execute("CREATE ROLE supabase_realtime_admin WITH NOINHERIT NOLOGIN NOREPLICATION")
+
+    execute("GRANT ALL PRIVILEGES ON SCHEMA realtime TO supabase_realtime_admin")
+    execute("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA realtime TO supabase_realtime_admin")
+    execute("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA realtime TO supabase_realtime_admin")
+
+    execute("ALTER table realtime.channels OWNER to supabase_realtime_admin")
+    execute("ALTER table realtime.broadcasts OWNER to supabase_realtime_admin")
+    execute("ALTER table realtime.presences OWNER TO supabase_realtime_admin")
+    execute("ALTER function realtime.channel_name() owner to supabase_realtime_admin")
+
+    execute("GRANT supabase_realtime_admin TO postgres")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.27.6",
+      version: "2.27.7",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Creates a new role called `supabase_realtime_admin`, moves ownership to this role and then we grant all the attributes roles to postgres user so users can add RLS rules to realtime tables