### PR TITLE
fix: Handle double message on Presence connect

### DIFF
--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -62,14 +62,14 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
       String.downcase(event) == "track" ->
         payload = Map.get(payload, "payload", %{})
 
-        result =
-          case Presence.track(self(), tenant_topic, presence_key, payload) do
-            {:ok, _} -> :ok
-            {:error, {:already_tracked, _, _, _}} -> :ok
-            _ -> :error
-          end
+        case Presence.track(self(), tenant_topic, presence_key, payload) do
+          {:error, {:already_tracked, _, _, _}} ->
+            Presence.update(self(), tenant_topic, presence_key, payload)
+            :ok
 
-        if result == :ok, do: Presence.update(self(), tenant_topic, presence_key, payload)
+          _ ->
+            :error
+        end
 
       String.downcase(event) == "untrack" ->
         Presence.untrack(self(), tenant_topic, presence_key)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.27.5",
+      version: "2.27.6",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Presence was throwing two messages for the same user because we were updating presence two times leading to a duplicate message.

Before: 
<img width="1263" alt="Screenshot 2024-04-01 at 18 36 29" src="https://github.com/supabase/realtime/assets/1697301/1aff6d83-56b5-4f46-abc5-068a9c7d33f7">

After:
<img width="1281" alt="Screenshot 2024-04-01 at 18 35 08" src="https://github.com/supabase/realtime/assets/1697301/90679243-aa5b-45ef-badd-bf84018f3a25">
