### PR TITLE
fix: Matching error due to not returning socket on ignored message

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -161,10 +161,12 @@ defmodule RealtimeWeb.RealtimeChannel do
         type == "presence_diff" and
             match?(%Policies{broadcast: %PresencePolicies{read: false}}, policies) ->
           Logger.error("Presence tracking message ignored")
+          socket
 
         type != "presence_diff" and
             match?(%Policies{broadcast: %BroadcastPolicies{write: false}}, policies) ->
           Logger.error("Broadcast message ignored")
+          socket
 
         true ->
           socket

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.3",
+      version: "2.28.4",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Matching error due to not returning socket on ignored message