### PR TITLE
fix: Migrate on Healthcheck

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.5",
+      version: "2.28.6",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

To ensure users have all required elements to work with Realtime we will start running migrations on the healthcheck.

We chose this approach to be sure that the database is already available when Realtime is checked.
