### PR TITLE
fix: Run migration query in the correct region

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -11,6 +11,7 @@ defmodule Realtime.Tenants do
   alias Realtime.Repo.Replica
   alias Realtime.Tenants.Cache
   alias Realtime.UsersCounter
+  alias Realtime.Helpers
 
   @doc """
   Gets a list of connected tenant `external_id` strings in the cluster or a node.
@@ -40,7 +41,8 @@ defmodule Realtime.Tenants do
     case Connect.get_status(external_id) do
       {:ok, conn} ->
         [%{settings: settings} | _] = tenant.extensions
-        {:ok, _} = Migrations.run_migrations(settings)
+        Helpers.transaction(conn, fn _ -> Migrations.run_migrations(settings) end)
+
         {:ok, conn}
 
       {:error, reason} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.6",
+      version: "2.28.7",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -244,6 +244,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       tenant: %Tenant{external_id: ext_id}
     } do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
+        {:ok, db_conn} = Connect.lookup_or_start_connection(ext_id)
         # Fake adding a connected client here
         UsersCounter.add(self(), ext_id)
 
@@ -251,7 +252,7 @@ defmodule RealtimeWeb.TenantControllerTest do
         :syn.register(Realtime.Tenants.Connect, ext_id, self(), %{conn: nil})
 
         :syn.update_registry(Realtime.Tenants.Connect, ext_id, fn _pid, meta ->
-          %{meta | conn: conn}
+          %{meta | conn: db_conn}
         end)
 
         conn = get(conn, Routes.tenant_path(conn, :health, ext_id))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Run migration query in the correct region
