### PR TITLE
fix: Broadcast HTTP endpoint respects policies per channel

### DIFF
--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -55,17 +55,29 @@ defmodule Realtime.Tenants.Authorization do
   Runs validations based on RLS policies to set policies for a given connection (either Phoenix.Socket or Plug.Conn).
   """
   @spec get_authorizations(Phoenix.Socket.t() | Plug.Conn.t(), DBConnection.t(), __MODULE__.t()) ::
-          {:ok, Phoenix.Socket.t() | Plug.Conn.t()} | {:error, :unauthorized}
+          {:ok, Phoenix.Socket.t() | Plug.Conn.t()} | {:error, any()}
   def get_authorizations(%Phoenix.Socket{} = socket, db_conn, authorization_context) do
-    case get_policies_for_connection(db_conn, authorization_context) do
+    case get_authorizations(db_conn, authorization_context) do
       %Policies{} = policies -> {:ok, Phoenix.Socket.assign(socket, :policies, policies)}
       error -> {:error, error}
     end
   end
 
   def get_authorizations(%Plug.Conn{} = conn, db_conn, authorization_context) do
-    case get_policies_for_connection(db_conn, authorization_context) do
+    case get_authorizations(db_conn, authorization_context) do
       %Policies{} = policies -> {:ok, Plug.Conn.assign(conn, :policies, policies)}
+      error -> error
+    end
+  end
+
+  @doc """
+  Runs validations based on RLS policies and returns the policies
+  """
+  @spec get_authorizations(DBConnection.t(), __MODULE__.t()) ::
+          %Policies{} | {:error, any()}
+  def get_authorizations(db_conn, authorization_context) do
+    case get_policies_for_connection(db_conn, authorization_context) do
+      %Policies{} = policies -> policies
       error -> {:error, error}
     end
   end

--- a/lib/realtime_web/controllers/broadcast_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_controller.ex
@@ -1,4 +1,7 @@
 defmodule RealtimeWeb.BroadcastController do
+  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
+  alias Realtime.Channels
   use RealtimeWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
@@ -6,13 +9,16 @@ defmodule RealtimeWeb.BroadcastController do
   alias Realtime.GenCounter
   alias Realtime.RateCounter
   alias Realtime.Tenants
+  alias Realtime.Tenants.Authorization
+  alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.BatchBroadcast
-  alias RealtimeWeb.Endpoint
+  alias Realtime.Tenants.Connect
 
+  alias RealtimeWeb.Endpoint
   alias RealtimeWeb.OpenApiSchemas.EmptyResponse
   alias RealtimeWeb.OpenApiSchemas.TenantBatchParams
-  alias RealtimeWeb.OpenApiSchemas.UnprocessableEntityResponse
   alias RealtimeWeb.OpenApiSchemas.TooManyRequestsResponse
+  alias RealtimeWeb.OpenApiSchemas.UnprocessableEntityResponse
 
   action_fallback(RealtimeWeb.FallbackController)
 
@@ -40,19 +46,56 @@ defmodule RealtimeWeb.BroadcastController do
   def broadcast(%{assigns: %{tenant: tenant}} = conn, attrs) do
     with %Ecto.Changeset{valid?: true} = changeset <-
            BatchBroadcast.changeset(%BatchBroadcast{}, attrs),
-         %Ecto.Changeset{changes: %{messages: messages}} <- changeset,
-         events_per_second_key <- Tenants.events_per_second_key(tenant),
-         :ok <- check_rate_limit(events_per_second_key, tenant, length(messages)) do
+         %Ecto.Changeset{changes: %{messages: messages}} = changeset,
+         events_per_second_key = Tenants.events_per_second_key(tenant),
+         :ok <- check_rate_limit(events_per_second_key, tenant, length(messages)),
+         {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id) do
       for %{changes: %{topic: sub_topic, payload: payload, event: event}} <- messages do
-        tenant_topic = Tenants.tenant_topic(tenant, sub_topic)
-        payload = %{"payload" => payload, "event" => event, "type" => "broadcast"}
+        case permissions_for_channel(db_conn, conn, sub_topic) do
+          nil ->
+            send_message_and_count(tenant, sub_topic, event, payload)
 
-        Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
+          %Policies{
+            channel: %ChannelPolicies{read: true},
+            broadcast: %BroadcastPolicies{write: true}
+          } ->
+            send_message_and_count(tenant, sub_topic, event, payload)
 
-        GenCounter.add(events_per_second_key)
+          _ ->
+            nil
+        end
       end
 
       send_resp(conn, :accepted, "")
+    end
+  end
+
+  defp send_message_and_count(tenant, sub_topic, event, payload) do
+    events_per_second_key = Tenants.events_per_second_key(tenant)
+    tenant_topic = Tenants.tenant_topic(tenant, sub_topic)
+    payload = %{"payload" => payload, "event" => event, "type" => "broadcast"}
+
+    GenCounter.add(events_per_second_key)
+    Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
+  end
+
+  defp permissions_for_channel(db_conn, conn, sub_topic) do
+    params = %{
+      headers: conn.req_headers,
+      jwt: conn.assigns.jwt,
+      claims: conn.assigns.claims,
+      role: conn.assigns.role
+    }
+
+    with {:ok, channel} <- Channels.get_channel_by_name(sub_topic, db_conn),
+         params = Map.put(params, :channel, channel),
+         params = Map.put(params, :channel_name, channel.name),
+         params = Authorization.build_authorization_params(params),
+         %Policies{} = policies <- Authorization.get_authorizations(db_conn, params) do
+      policies
+    else
+      {:error, :not_found} -> nil
+      error -> error
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.8",
+      version: "2.28.9",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -1,4 +1,5 @@
 defmodule RealtimeWeb.BroadcastControllerTest do
+  alias Realtime.Tenants.Connect
   use RealtimeWeb.ConnCase, async: false
 
   import Mock
@@ -217,5 +218,236 @@ defmodule RealtimeWeb.BroadcastControllerTest do
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{})
       assert conn.status == 401
     end
+  end
+
+  describe "authorization for broadcast" do
+    setup %{conn: conn} = context do
+      start_supervised(Realtime.RateCounter.DynamicSupervisor)
+      start_supervised(Realtime.GenCounter.DynamicSupervisor)
+      start_supervised(RealtimeWeb.Joken.CurrentTime.Mock)
+      tenant = tenant_fixture()
+
+      secret =
+        Realtime.Helpers.decrypt!(tenant.jwt_secret, Application.get_env(:realtime, :db_enc_key))
+
+      {:ok, _} = start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
+      {:ok, db_conn} = Connect.get_status(tenant.external_id)
+
+      clean_table(db_conn, "realtime", "broadcasts")
+      clean_table(db_conn, "realtime", "channels")
+
+      claims = %{sub: random_string(), role: context.role, exp: Joken.current_time() + 1_000}
+      signer = Joken.Signer.create("HS256", secret)
+
+      jwt = Joken.generate_and_sign!(%{}, claims, signer)
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/json")
+        |> put_req_header("authorization", "Bearer #{jwt}")
+        |> then(&%{&1 | host: "#{tenant.external_id}.supabase.com"})
+
+      {:ok, conn: conn, db_conn: db_conn, tenant: tenant}
+    end
+
+    @tag role: "authenticated"
+    test "user with permission to read all channels and write to them is able to broadcast", %{
+      conn: conn,
+      db_conn: db_conn,
+      tenant: tenant
+    } do
+      with_mocks [
+        {Endpoint, [:passthrough], broadcast_from: fn _, _, _, _ -> :ok end},
+        {GenCounter, [:passthrough], add: fn _ -> :ok end}
+      ] do
+        channels =
+          Stream.repeatedly(fn -> generate_channel_with_policies(db_conn, tenant) end)
+          |> Enum.take(5)
+
+        messages =
+          Enum.map(channels, fn %{name: name} ->
+            %{
+              "topic" => name,
+              "payload" => %{"content" => random_string()},
+              "event" => random_string()
+            }
+          end)
+
+        conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
+
+        Enum.each(channels, fn %{name: name} ->
+          topic = Tenants.tenant_topic(tenant, name)
+          assert_called(Endpoint.broadcast_from(:_, topic, "broadcast", :_))
+        end)
+
+        assert_called_exactly(
+          GenCounter.add(Tenants.events_per_second_key(tenant)),
+          length(channels)
+        )
+
+        assert conn.status == 202
+      end
+    end
+
+    @tag role: "authenticated"
+    test "user with permission is also able to broadcast to open channel", %{
+      conn: conn,
+      db_conn: db_conn,
+      tenant: tenant
+    } do
+      with_mocks [
+        {Endpoint, [:passthrough], broadcast_from: fn _, _, _, _ -> :ok end},
+        {GenCounter, [:passthrough], add: fn _ -> :ok end}
+      ] do
+        channels =
+          Stream.repeatedly(fn -> generate_channel_with_policies(db_conn, tenant) end)
+          |> Enum.take(5)
+
+        messages =
+          Enum.map(channels, fn %{name: name} ->
+            %{
+              "topic" => name,
+              "payload" => %{"content" => random_string()},
+              "event" => random_string()
+            }
+          end)
+
+        messages =
+          messages ++
+            [
+              %{
+                "topic" => "open_channel",
+                "payload" => %{"content" => random_string()},
+                "event" => random_string()
+              }
+            ]
+
+        conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
+
+        Enum.each(channels, fn %{name: name} ->
+          topic = Tenants.tenant_topic(tenant, name)
+          assert_called(Endpoint.broadcast_from(:_, topic, "broadcast", :_))
+        end)
+
+        # Check open channel
+        assert_called(
+          Endpoint.broadcast_from(
+            :_,
+            Tenants.tenant_topic(tenant, "open_channel"),
+            "broadcast",
+            :_
+          )
+        )
+
+        assert_called_exactly(
+          GenCounter.add(Tenants.events_per_second_key(tenant)),
+          length(channels) + 1
+        )
+
+        assert conn.status == 202
+      end
+    end
+
+    @tag role: "authenticated"
+    test "user with permission to read a limited set is only able to broadcast to said set", %{
+      conn: conn,
+      db_conn: db_conn,
+      tenant: tenant
+    } do
+      with_mocks [
+        {Endpoint, [:passthrough], broadcast_from: fn _, _, _, _ -> :ok end},
+        {GenCounter, [:passthrough], add: fn _ -> :ok end}
+      ] do
+        channels =
+          Stream.repeatedly(fn -> generate_channel_with_policies(db_conn, tenant) end)
+          |> Enum.take(5)
+
+        no_auth_channel = channel_fixture(tenant)
+
+        messages =
+          Enum.map(channels ++ [no_auth_channel], fn %{name: name} ->
+            %{
+              "topic" => name,
+              "payload" => %{"content" => random_string()},
+              "event" => random_string()
+            }
+          end)
+
+        conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
+
+        Enum.each(channels, fn %{name: name} ->
+          topic = Tenants.tenant_topic(tenant, name)
+          assert_called(Endpoint.broadcast_from(:_, topic, "broadcast", :_))
+        end)
+
+        assert_not_called(
+          Endpoint.broadcast_from(
+            :_,
+            Tenants.tenant_topic(tenant, no_auth_channel.name),
+            "broadcast",
+            :_
+          )
+        )
+
+        assert_called_exactly(
+          GenCounter.add(Tenants.events_per_second_key(tenant)),
+          length(channels)
+        )
+
+        assert conn.status == 202
+      end
+    end
+
+    @tag role: "anon"
+    test "user without permission won't broadcast", %{
+      conn: conn,
+      db_conn: db_conn,
+      tenant: tenant
+    } do
+      with_mocks [
+        {Endpoint, [:passthrough], broadcast_from: fn _, _, _, _ -> :ok end},
+        {GenCounter, [:passthrough], add: fn _ -> :ok end}
+      ] do
+        channels =
+          Stream.repeatedly(fn -> generate_channel_with_policies(db_conn, tenant) end)
+          |> Enum.take(5)
+
+        messages =
+          Enum.map(channels, fn %{name: name} ->
+            %{
+              "topic" => name,
+              "payload" => %{"content" => random_string()},
+              "event" => random_string()
+            }
+          end)
+
+        conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
+
+        Enum.each(channels, fn %{name: name} ->
+          topic = Tenants.tenant_topic(tenant, name)
+          assert_not_called(Endpoint.broadcast_from(:_, topic, "broadcast", :_))
+        end)
+
+        assert_not_called(GenCounter.add(Tenants.events_per_second_key(tenant)))
+
+        assert conn.status == 202
+      end
+    end
+  end
+
+  defp generate_channel_with_policies(db_conn, tenant) do
+    channel = channel_fixture(tenant)
+
+    create_rls_policies(
+      db_conn,
+      [
+        :authenticated_read_channel,
+        :authenticated_read_broadcast,
+        :authenticated_write_broadcast
+      ],
+      channel
+    )
+
+    channel
   end
 end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -139,7 +139,7 @@ defmodule Generators do
 
   def policy_query(:authenticated_read_channel, %{name: name}) do
     """
-    CREATE POLICY authenticated_read_channel
+    CREATE POLICY authenticated_read_channel_#{name}
     ON realtime.channels FOR SELECT
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' );
@@ -148,7 +148,7 @@ defmodule Generators do
 
   def policy_query(:authenticated_write_channel, %{name: name}) do
     """
-    CREATE POLICY authenticated_write_channel
+    CREATE POLICY authenticated_write_channel_#{name}
     ON realtime.channels FOR UPDATE
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' )
@@ -158,7 +158,7 @@ defmodule Generators do
 
   def policy_query(:authenticated_read_broadcast, %{name: name}) do
     """
-    CREATE POLICY authenticated_read_broadcast
+    CREATE POLICY authenticated_read_broadcast_#{name}
     ON realtime.broadcasts FOR SELECT
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' );
@@ -167,7 +167,7 @@ defmodule Generators do
 
   def policy_query(:authenticated_write_broadcast, %{name: name}) do
     """
-    CREATE POLICY authenticated_write_broadcast
+    CREATE POLICY authenticated_write_broadcast_#{name}
     ON realtime.broadcasts FOR UPDATE
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' )
@@ -177,7 +177,7 @@ defmodule Generators do
 
   def policy_query(:authenticated_read_presence, %{name: name}) do
     """
-    CREATE POLICY authenticated_read_presence
+    CREATE POLICY authenticated_read_presence_#{name}
     ON realtime.presences FOR SELECT
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' );
@@ -186,7 +186,7 @@ defmodule Generators do
 
   def policy_query(:authenticated_write_presence, %{name: name}) do
     """
-    CREATE POLICY authenticated_write_presence
+    CREATE POLICY authenticated_write_presence_#{name}
     ON realtime.presences FOR UPDATE
     TO authenticated
     USING ( realtime.channel_name() = '#{name}' )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix to handle policies on the Broadcast endpoint. We need to check policies one by one in this scenario since the user can broadcast a batch of messages to different channels
