### PR TITLE
fix: Broadcast Endpoint performance improvement

### DIFF
--- a/lib/realtime_web/controllers/broadcast_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_controller.ex
@@ -1,16 +1,20 @@
 defmodule RealtimeWeb.BroadcastController do
-  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
-  alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
-  alias Realtime.Channels
   use RealtimeWeb, :controller
   use OpenApiSpex.ControllerSpecs
+  require Logger
+  import Ecto.Query
 
+  alias Realtime.Api.Channel
   alias Realtime.Api.Tenant
   alias Realtime.GenCounter
+  alias Realtime.Helpers
   alias Realtime.RateCounter
+  alias Realtime.Repo
   alias Realtime.Tenants
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
+  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Authorization.Policies.ChannelPolicies
   alias Realtime.Tenants.BatchBroadcast
   alias Realtime.Tenants.Connect
 
@@ -50,36 +54,76 @@ defmodule RealtimeWeb.BroadcastController do
          events_per_second_key = Tenants.events_per_second_key(tenant),
          :ok <- check_rate_limit(events_per_second_key, tenant, length(messages)),
          {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id) do
-      for %{changes: %{topic: sub_topic, payload: payload, event: event}} <- messages do
-        case permissions_for_channel(db_conn, conn, sub_topic) do
-          nil ->
-            send_message_and_count(tenant, sub_topic, event, payload)
+      events =
+        Enum.map(messages, fn %{changes: %{topic: sub_topic} = event} -> {sub_topic, event} end)
 
-          %Policies{
-            channel: %ChannelPolicies{read: true},
-            broadcast: %BroadcastPolicies{write: true}
-          } ->
-            send_message_and_count(tenant, sub_topic, event, payload)
+      channel_names = events |> Enum.map(fn {sub_topic, _} -> sub_topic end) |> MapSet.new()
 
-          _ ->
-            nil
-        end
+      if MapSet.size(channel_names) > 1 do
+        Logger.warning(
+          "This Broadcast is sending to multiple channels. Avoid this as it impact your performance."
+        )
       end
+
+      query_to_check = from(c in Channel, where: c.name in ^MapSet.to_list(channel_names))
+
+      channels =
+        Repo.all(db_conn, query_to_check, Channel)
+        |> then(fn {:ok, channels} -> channels end)
+
+      channels_names_to_check =
+        channels
+        |> Enum.map(& &1.name)
+        |> MapSet.new()
+
+      # Handle events without authorization
+      MapSet.difference(channel_names, channels_names_to_check)
+      |> Enum.each(fn channel_name ->
+        events
+        |> Enum.filter(fn {sub_topic, _} -> sub_topic == channel_name end)
+        |> Enum.each(fn {_, %{topic: sub_topic, payload: payload, event: event}} ->
+          send_message_and_count(tenant, sub_topic, event, payload)
+        end)
+      end)
+
+      # Handle events with authorization
+      channels_names_to_check
+      |> Enum.reduce([], fn sub_topic, acc ->
+        Enum.filter(events, fn
+          {^sub_topic, _} -> true
+          _ -> false
+        end) ++ acc
+      end)
+      |> Enum.map(fn {_, event} -> event end)
+      |> Enum.each(fn %{topic: channel_name, payload: payload, event: event} ->
+        Helpers.transaction(db_conn, fn transaction_conn ->
+          case permissions_for_channel(conn, transaction_conn, channels, channel_name) do
+            %Policies{
+              channel: %ChannelPolicies{read: true},
+              broadcast: %BroadcastPolicies{write: true}
+            } ->
+              send_message_and_count(tenant, channel_name, event, payload)
+
+            _ ->
+              nil
+          end
+        end)
+      end)
 
       send_resp(conn, :accepted, "")
     end
   end
 
-  defp send_message_and_count(tenant, sub_topic, event, payload) do
+  defp send_message_and_count(tenant, channel_name, event, payload) do
     events_per_second_key = Tenants.events_per_second_key(tenant)
-    tenant_topic = Tenants.tenant_topic(tenant, sub_topic)
+    tenant_topic = Tenants.tenant_topic(tenant, channel_name)
     payload = %{"payload" => payload, "event" => event, "type" => "broadcast"}
 
     GenCounter.add(events_per_second_key)
     Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
   end
 
-  defp permissions_for_channel(db_conn, conn, sub_topic) do
+  defp permissions_for_channel(conn, db_conn, channels, channel_name) do
     params = %{
       headers: conn.req_headers,
       jwt: conn.assigns.jwt,
@@ -87,7 +131,7 @@ defmodule RealtimeWeb.BroadcastController do
       role: conn.assigns.role
     }
 
-    with {:ok, channel} <- Channels.get_channel_by_name(sub_topic, db_conn),
+    with channel <- Enum.find(channels, &(&1.name == channel_name)),
          params = Map.put(params, :channel, channel),
          params = Map.put(params, :channel_name, channel.name),
          params = Authorization.build_authorization_params(params),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.9",
+      version: "2.28.10",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

On non authorization required channels we avoid policies. 
On authorization required channels we will run policies within a single transaction to reduce the amount of connections taken for the operation

