### PR TITLE
fix: Configurable pool size and queue target per tenant on Connect

### DIFF
--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -135,6 +135,8 @@ defmodule Realtime.Helpers do
       name = settings["db_name"]
       user = settings["db_user"]
       password = settings["db_password"]
+      pool = settings["db_pool"] || 5
+      queue_target = settings["db_queue_target"] || 2000
 
       opts = %{
         host: host,
@@ -142,8 +144,8 @@ defmodule Realtime.Helpers do
         name: name,
         user: user,
         pass: password,
-        pool: 1,
-        queue_target: 1000,
+        pool: pool,
+        queue_target: queue_target,
         ssl_enforced: ssl_enforced,
         application_name: application_name,
         backoff: :stop

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.11",
+      version: "2.28.12",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Configurable pool size and queue target per tenant on Connect
