### PR TITLE
fix: Improve returns of Channel endpoint

### DIFF
--- a/lib/realtime_web/controllers/channels_controller.ex
+++ b/lib/realtime_web/controllers/channels_controller.ex
@@ -49,7 +49,7 @@ defmodule RealtimeWeb.ChannelsController do
     end
   end
 
-  def index(_conn, _params), do: {:error, :unauthorized}
+  def index(conn, _params), do: json(conn, [])
 
   operation(:show,
     summary: "Show user channel",
@@ -97,7 +97,7 @@ defmodule RealtimeWeb.ChannelsController do
     end
   end
 
-  def show(_conn, _params), do: {:error, :unauthorized}
+  def show(_conn, _params), do: {:error, :not_found}
 
   operation(:create,
     summary: "Create user channel",
@@ -114,6 +114,7 @@ defmodule RealtimeWeb.ChannelsController do
     request_body: ChannelParams.params(),
     responses: %{
       201 => ChannelResponse.response(),
+      401 => UnauthorizedResponse.response(),
       404 => NotFoundResponse.response()
     }
   )
@@ -158,6 +159,7 @@ defmodule RealtimeWeb.ChannelsController do
     ],
     responses: %{
       202 => EmptyResponse.response(),
+      401 => UnauthorizedResponse.response(),
       404 => NotFoundResponse.response()
     }
   )
@@ -177,7 +179,7 @@ defmodule RealtimeWeb.ChannelsController do
     end
   end
 
-  def delete(_conn, _params), do: {:error, :unauthorized}
+  def delete(_conn, _params), do: {:error, :not_found}
 
   operation(:update,
     summary: "Update user channel",
@@ -201,6 +203,7 @@ defmodule RealtimeWeb.ChannelsController do
     request_body: ChannelParams.params(),
     responses: %{
       201 => ChannelResponse.response(),
+      401 => UnauthorizedResponse.response(),
       404 => NotFoundResponse.response()
     }
   )
@@ -223,5 +226,5 @@ defmodule RealtimeWeb.ChannelsController do
     end
   end
 
-  def update(_conn, _params), do: {:error, :unauthorized}
+  def update(_conn, _params), do: {:error, :not_found}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.13",
+      version: "2.28.14",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/channels_controller_test.exs
+++ b/test/realtime_web/controllers/channels_controller_test.exs
@@ -62,9 +62,9 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     end
 
     @tag role: "authenticated"
-    test "returns 401 if unauthorized", %{conn: conn} do
+    test "returns empty list if unauthorized", %{conn: conn} do
       conn = get(conn, ~p"/api/channels")
-      assert json_response(conn, 401) == %{"message" => "Unauthorized"}
+      assert json_response(conn, 200) == []
     end
   end
 
@@ -92,9 +92,9 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     end
 
     @tag role: "anon"
-    test "returns 401 if unauthorized", %{conn: conn} do
+    test "returns 404 if unauthorized", %{conn: conn} do
       conn = get(conn, ~p"/api/channels/0")
-      assert json_response(conn, 401) == %{"message" => "Unauthorized"}
+      assert json_response(conn, 404) == %{"message" => "Not found"}
     end
   end
 
@@ -131,16 +131,16 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     end
 
     @tag role: "authenticated"
-    test "returns unauthorized if id doesn't exist", %{conn: conn} do
+    test "returns 404 if id doesn't exist", %{conn: conn} do
       conn = delete(conn, ~p"/api/channels/0")
-      assert conn.status == 401
+      assert conn.status == 404
     end
 
     @tag role: "anon"
-    test "returns 401 if unauthorized", %{conn: conn, tenant: tenant} do
+    test "returns 404 if unauthorized", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
       conn = delete(conn, ~p"/api/channels/#{channel.name}")
-      assert json_response(conn, 401) == %{"message" => "Unauthorized"}
+      assert json_response(conn, 404) == %{"message" => "Not found"}
     end
   end
 
@@ -170,10 +170,10 @@ defmodule RealtimeWeb.ChannelsControllerTest do
     end
 
     @tag role: "anon"
-    test "returns 401 if unauthorized", %{conn: conn, tenant: tenant} do
+    test "returns 404 if unauthorized", %{conn: conn, tenant: tenant} do
       channel = channel_fixture(tenant)
       conn = put(conn, ~p"/api/channels/#{channel.name}", %{"name" => "new_name"})
-      assert json_response(conn, 401) == %{"message" => "Unauthorized"}
+      assert json_response(conn, 404) == %{"message" => "Not found"}
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Listing without required authentication will return an empty list
* All other commands will return 404 on lack of authentication