### PR TITLE
fix: Add prefix on secure channels

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -32,7 +32,7 @@ defmodule Realtime.Tenants do
 
   ## Examples
 
-      iex> get_health_conn(%Tenant{external_id: "not_found_tenant"})
+      iex> Realtime.Tenants.get_health_conn(%Realtime.Api.Tenant{external_id: "not_found_tenant"})
       {:error, :tenant_database_unavailable}
   """
 
@@ -44,14 +44,9 @@ defmodule Realtime.Tenants do
   @doc """
   Checks if a tenant is healthy. A tenant is healthy if:
   - Tenant has no db connection and zero client connetions
-  - Teantn has a db connection and >0 client connections
+  - Tenant has a db connection and >0 client connections
 
   A tenant is not healthy if a tenant has client connections and no database connection.
-
-  ## Examples
-
-      iex> health_check("not_healthy_external_id")
-      {:error, %{healthy: false, db_connected: false, connected_cluster: 10}}
   """
 
   @spec health_check(binary) ::
@@ -194,9 +189,19 @@ defmodule Realtime.Tenants do
 
   @doc """
   Builds a PubSub topic from a tenant and a sub-topic.
+  ## Examples
+
+      iex> Realtime.Tenants.tenant_topic(%Realtime.Api.Tenant{external_id: "tenant_id"}, "sub_topic")
+      "tenant_id:sub_topic"
+      iex> Realtime.Tenants.tenant_topic("tenant_id", "sub_topic")
+      "tenant_id:sub_topic"
+      iex> Realtime.Tenants.tenant_topic(%Realtime.Api.Tenant{external_id: "tenant_id"}, "sub_topic", false)
+      "tenant_id:private:sub_topic"
+      iex> Realtime.Tenants.tenant_topic("tenant_id", "sub_topic", false)
+      "tenant_id:private:sub_topic"
   """
   @spec tenant_topic(Tenant.t() | binary(), String.t(), boolean()) :: String.t()
-  def tenant_topic(external_id, sub_topic, public? \\ false)
+  def tenant_topic(external_id, sub_topic, public? \\ true)
 
   def tenant_topic(%Tenant{external_id: external_id}, sub_topic, public?) do
     tenant_topic(external_id, sub_topic, public?)

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -195,9 +195,16 @@ defmodule Realtime.Tenants do
   @doc """
   Builds a PubSub topic from a tenant and a sub-topic.
   """
-  @spec tenant_topic(Tenant.t(), String.t()) :: String.t()
-  def tenant_topic(%Tenant{external_id: external_id}, sub_topic) do
-    "#{external_id}:#{sub_topic}"
+  @spec tenant_topic(Tenant.t() | binary(), String.t(), boolean()) :: String.t()
+  def tenant_topic(external_id, sub_topic, public? \\ false)
+
+  def tenant_topic(%Tenant{external_id: external_id}, sub_topic, public?) do
+    tenant_topic(external_id, sub_topic, public?)
+  end
+
+  def tenant_topic(external_id, sub_topic, public?) do
+    private_prefix = if public?, do: "", else: ":private"
+    "#{external_id}#{private_prefix}:#{sub_topic}"
   end
 
   @doc """

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -57,7 +57,7 @@ defmodule RealtimeWeb.RealtimeChannel do
          {:ok, socket} <- assign_policies(channel, db_conn, params, access_token, claims, socket) do
       is_new_api = is_new_api(params)
       public? = match?({:ok, _}, channel)
-      tenant_topic = tenant <> ":" <> sub_topic
+      tenant_topic = Tenants.tenant_topic(tenant, sub_topic, public?)
 
       Realtime.UsersCounter.add(transport_pid, tenant)
       RealtimeWeb.Endpoint.subscribe(tenant_topic)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.14",
+      version: "2.28.15",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -5,6 +5,7 @@ defmodule Realtime.TenantsTest do
 
   alias Realtime.GenCounter
   alias Realtime.Tenants
+  doctest Realtime.Tenants
 
   describe "tenants" do
     test "get_tenant_limits/1" do


### PR DESCRIPTION
## What kind of change does this PR introduce?

To avoid cross communication between public and private channels we will add a prefix on private channels which is determined by checking if a channel exists in realtime.channel with a given name.
