### PR TITLE
fix: Revalidate policies on token refresh message

### DIFF
--- a/lib/realtime_web/controllers/broadcast_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_controller.ex
@@ -85,7 +85,7 @@ defmodule RealtimeWeb.BroadcastController do
         events
         |> Enum.filter(fn {sub_topic, _} -> sub_topic == channel_name end)
         |> Enum.each(fn {_, %{topic: sub_topic, payload: payload, event: event}} ->
-          send_message_and_count(tenant, sub_topic, event, payload)
+          send_message_and_count(tenant, sub_topic, event, payload, true)
         end)
       end)
 
@@ -105,7 +105,7 @@ defmodule RealtimeWeb.BroadcastController do
               channel: %ChannelPolicies{read: true},
               broadcast: %BroadcastPolicies{write: true}
             } ->
-              send_message_and_count(tenant, channel_name, event, payload)
+              send_message_and_count(tenant, channel_name, event, payload, false)
 
             _ ->
               nil
@@ -117,9 +117,9 @@ defmodule RealtimeWeb.BroadcastController do
     end
   end
 
-  defp send_message_and_count(tenant, channel_name, event, payload) do
+  defp send_message_and_count(tenant, channel_name, event, payload, public?) do
     events_per_second_key = Tenants.events_per_second_key(tenant)
-    tenant_topic = Tenants.tenant_topic(tenant, channel_name)
+    tenant_topic = Tenants.tenant_topic(tenant, channel_name, public?)
     payload = %{"payload" => payload, "event" => event, "type" => "broadcast"}
 
     GenCounter.add(events_per_second_key)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.15",
+      version: "2.28.16",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -278,7 +278,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
         conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
         Enum.each(channels, fn %{name: name} ->
-          topic = Tenants.tenant_topic(tenant, name)
+          topic = Tenants.tenant_topic(tenant, name, false)
           assert_called(Endpoint.broadcast_from(:_, topic, "broadcast", :_))
         end)
 
@@ -327,7 +327,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
         conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
         Enum.each(channels, fn %{name: name} ->
-          topic = Tenants.tenant_topic(tenant, name)
+          topic = Tenants.tenant_topic(tenant, name, name == "open_channel")
           assert_called(Endpoint.broadcast_from(:_, topic, "broadcast", :_))
         end)
 
@@ -378,14 +378,14 @@ defmodule RealtimeWeb.BroadcastControllerTest do
         conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
         Enum.each(channels, fn %{name: name} ->
-          topic = Tenants.tenant_topic(tenant, name)
+          topic = Tenants.tenant_topic(tenant, name, false)
           assert_called(Endpoint.broadcast_from(:_, topic, "broadcast", :_))
         end)
 
         assert_not_called(
           Endpoint.broadcast_from(
             :_,
-            Tenants.tenant_topic(tenant, no_auth_channel.name),
+            Tenants.tenant_topic(tenant, no_auth_channel.name, false),
             "broadcast",
             :_
           )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Whenever the user resets their token we will recheck their policies against the new token to ensure the user is still valid

