### PR TITLE
fix: Move to UUIDs on realtime schema support tables

### DIFF
--- a/lib/realtime/api/broadcast.ex
+++ b/lib/realtime/api/broadcast.ex
@@ -8,7 +8,10 @@ defmodule Realtime.Api.Broadcast do
 
   @type t :: %__MODULE__{}
 
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
   @schema_prefix "realtime"
+
   schema "broadcasts" do
     field(:check, :boolean, default: false)
     timestamps()

--- a/lib/realtime/api/channel.ex
+++ b/lib/realtime/api/channel.ex
@@ -8,7 +8,10 @@ defmodule Realtime.Api.Channel do
 
   @type t :: %__MODULE__{}
 
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
   @schema_prefix "realtime"
+
   schema "channels" do
     field(:name, :string)
     field(:check, :boolean, default: false)

--- a/lib/realtime/api/presence.ex
+++ b/lib/realtime/api/presence.ex
@@ -8,7 +8,10 @@ defmodule Realtime.Api.Presence do
 
   @type t :: %__MODULE__{}
 
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
   @schema_prefix "realtime"
+
   schema "presences" do
     field(:check, :boolean, default: false)
     timestamps()

--- a/lib/realtime/repo.ex
+++ b/lib/realtime/repo.ex
@@ -126,6 +126,12 @@ defmodule Realtime.Repo do
 
     %{header: header, rows: rows} =
       Enum.reduce(changeset.changes, acc, fn {field, row}, %{header: header, rows: rows} ->
+        row =
+          case schema.__schema__(:type, field) do
+            :binary_id -> Ecto.UUID.dump!(row)
+            _ -> row
+          end
+
         %{
           header: [Atom.to_string(field) | header],
           rows: [row | rows]

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -47,7 +47,8 @@ defmodule Realtime.Tenants.Migrations do
     AddBroadcastsPoliciesTable,
     AddInsertAndDeleteGrantToChannels,
     AddPresencesPoliciesTable,
-    CreateRealtimeAdminAndMoveOwnership
+    CreateRealtimeAdminAndMoveOwnership,
+    ChangeIdsToBeUuid
   }
 
   alias Realtime.Helpers
@@ -93,7 +94,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_240_227_174_441, AddBroadcastsPoliciesTable},
     {20_240_311_171_622, AddInsertAndDeleteGrantToChannels},
     {20_240_321_100_241, AddPresencesPoliciesTable},
-    {20_240_401_105_812, CreateRealtimeAdminAndMoveOwnership}
+    {20_240_401_105_812, CreateRealtimeAdminAndMoveOwnership},
+    {20240410221036, ChangeIdsToBeUuid},
   ]
 
   @spec run_migrations(map()) :: {:ok, [integer()]} | {:error, any()}

--- a/lib/realtime/tenants/repo/migrations/20240410221036_change_ids_to_be_uuid.ex
+++ b/lib/realtime/tenants/repo/migrations/20240410221036_change_ids_to_be_uuid.ex
@@ -1,0 +1,51 @@
+defmodule Realtime.Tenants.Migrations.ChangeIdsToBeUuid do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:channels) do
+      add :uuid, :uuid, default: fragment("gen_random_uuid()")
+    end
+
+    alter table(:broadcasts) do
+      add :uuid, :uuid, default: fragment("gen_random_uuid()")
+    end
+
+    alter table(:presences) do
+      add :uuid, :uuid, default: fragment("gen_random_uuid()")
+    end
+
+    alter table(:broadcasts) do
+      remove :id
+      remove :channel_id
+    end
+
+    alter table(:presences) do
+      remove :id
+      remove :channel_id
+    end
+
+    alter table(:channels) do
+      remove :id
+    end
+
+    rename table(:channels), :uuid, to: :id
+    rename table(:broadcasts), :uuid, to: :id
+    rename table(:presences), :uuid, to: :id
+
+    alter table(:channels) do
+      modify :id, :uuid, primary_key: true
+    end
+
+    alter table(:broadcasts) do
+      modify :id, :uuid, primary_key: true
+      add :channel_id, references(:channels, on_delete: :delete_all, type: :uuid), null: false
+    end
+
+    alter table(:presences) do
+      modify :id, :uuid, primary_key: true
+      add :channel_id, references(:channels, on_delete: :delete_all, type: :uuid), null: false
+    end
+  end
+end

--- a/test/realtime/channels_test.exs
+++ b/test/realtime/channels_test.exs
@@ -38,7 +38,7 @@ defmodule Realtime.ChannelsTest do
     end
 
     test "not found error if does not exist", %{conn: conn} do
-      assert {:error, :not_found} = Channels.get_channel_by_id(0, conn)
+      assert {:error, :not_found} = Channels.get_channel_by_id(Ecto.UUID.generate(), conn)
     end
   end
 

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -78,7 +78,6 @@ defmodule Generators do
     end)
 
     Postgrex.query!(db_conn, "TRUNCATE TABLE #{schema}.#{table} CASCADE", [])
-    Postgrex.query!(db_conn, "ALTER SEQUENCE #{schema}.#{table}_id_seq RESTART WITH 1", [])
   end
 
   @doc """


### PR DESCRIPTION
## What kind of change does this PR introduce?

Move to UUIDs on realtime schema support tables
