### PR TITLE
fix: return :ok on successful Presence.track/4 call

### DIFF
--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -65,7 +65,8 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
         payload = Map.get(payload, "payload", %{})
 
         case Presence.track(self(), tenant_topic, presence_key, payload) do
-          {:ok, _} -> :ok
+          {:ok, _} ->
+            :ok
 
           {:error, {:already_tracked, _, _, _}} ->
             case Presence.update(self(), tenant_topic, presence_key, payload) do

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -65,11 +65,15 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
         payload = Map.get(payload, "payload", %{})
 
         case Presence.track(self(), tenant_topic, presence_key, payload) do
-          {:error, {:already_tracked, _, _, _}} ->
-            Presence.update(self(), tenant_topic, presence_key, payload)
-            :ok
+          {:ok, _} -> :ok
 
-          _ ->
+          {:error, {:already_tracked, _, _, _}} ->
+            case Presence.update(self(), tenant_topic, presence_key, payload) do
+              {:ok, _} -> :ok
+              {:error, _} -> :error
+            end
+
+          {:error, _} ->
             :error
         end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.16",
+      version: "2.28.17",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`Presence.track/4` returns `:error` on successful tracking.

## What is the new behavior?

`Presence.track/4` returns `:ok` on successful tracking.

## Additional Context

Related: https://github.com/supabase/realtime-js/pull/290
