### PR TITLE
fix: Performance improvements

### DIFF
--- a/lib/realtime/tenants/authorization/policies/channel_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/channel_policies.ex
@@ -80,9 +80,8 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPolicies do
       changeset = Channel.check_changeset(channel, %{check: true})
 
       case Repo.update(transaction_conn, changeset, Channel, mode: :savepoint) do
-        {:ok, %Channel{check: true} = channel} ->
-          revert_changeset = Channel.check_changeset(channel, %{check: false})
-          {:ok, _} = Repo.update(transaction_conn, revert_changeset, Channel)
+        {:ok, %Channel{check: true}} ->
+          Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
           Policies.update_policies(policies, :channel, :write, true)
 
         {:ok, _} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.17",
+      version: "2.28.18",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Remove the revert update on write checks in Channel, Broadcast and Presence
* Separates the checks into a transaction PER feature to avoid extra locking and enable conn pool to be more heavily used

