### PR TITLE
fix: Revert default poolsize for checker to 1

### DIFF
--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -135,7 +135,7 @@ defmodule Realtime.Helpers do
       name = settings["db_name"]
       user = settings["db_user"]
       password = settings["db_password"]
-      pool = settings["db_pool"] || 5
+      pool = settings["db_pool"] || 1
       queue_target = settings["db_queue_target"] || 2000
 
       opts = %{

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.18",
+      version: "2.28.19",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Revert default poolsize for checker to 1
