### PR TITLE
fix: tune connections a bit more

### DIFF
--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -96,7 +96,7 @@ defmodule Extensions.PostgresCdcRls do
 
   @spec start(map()) :: :ok | {:error, :already_started | :reserved}
   def start(%{"id" => tenant} = args) when is_binary(tenant) do
-    args = Map.merge(args, %{"subs_pool_size" => Map.get(args, "subcriber_pool_size", 5)})
+    args = Map.merge(args, %{"subs_pool_size" => Map.get(args, "subcriber_pool_size", 3)})
 
     Logger.debug("Starting #{__MODULE__} extension with args: #{inspect(args, pretty: true)}")
 

--- a/lib/realtime/helpers.ex
+++ b/lib/realtime/helpers.ex
@@ -135,7 +135,7 @@ defmodule Realtime.Helpers do
       name = settings["db_name"]
       user = settings["db_user"]
       password = settings["db_password"]
-      pool = settings["db_pool"] || 1
+      pool = settings["db_pool"] || 3
       queue_target = settings["db_queue_target"] || 2000
 
       opts = %{

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.23",
+      version: "2.28.24",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- we had db_pool size of 5 but small dbs were running out of connections
- db_pool size of 1 is a bit too small and causes 5xx's on Broadcast POST
- change db_pool size to 3
- change subscribers_pool_size from 5 to 3 so total Realtime conns remains the same
  - 3 should be fine
  - if this is too small we will see query timeouts on `Extensions.PostgresCdcRls.Subscriptions.create` calls
- will keep us at 9 total connections

Previously connections looked like:

| usename        | application_name                  |
| -------------- | --------------------------------- |
| supabase_admin | realtime_subscription_manager_pub |
| supabase_admin | realtime_subscription_manager_pub |
| supabase_admin | realtime_subscription_manager_pub |
| supabase_admin | realtime_subscription_manager_pub |
| supabase_admin | realtime_subscription_manager_pub |
| supabase_admin | realtime_subscription_manager     |
| supabase_admin | realtime_subscription_checker     |
| supabase_admin | realtime_rls                      |
| supabase_admin | realtime_connect                  |

Now they will look like:

| usename        | application_name                  |
| -------------- | --------------------------------- |
| supabase_admin | realtime_subscription_manager_pub |
| supabase_admin | realtime_subscription_manager_pub |
| supabase_admin | realtime_subscription_manager_pub |
| supabase_admin | realtime_subscription_manager     |
| supabase_admin | realtime_subscription_checker     |
| supabase_admin | realtime_rls                      |
| supabase_admin | realtime_connect                  |
| supabase_admin | realtime_connect |
| supabase_admin | realtime_connect |

Confirm Realtime connection counts with the query:

```sql
select usename, application_name from pg_stat_activity where application_name ilike 'realtime_%';
```
