### PR TITLE
fix: use updated_at column to check RLS policy instead

### DIFF
--- a/lib/realtime/api/broadcast.ex
+++ b/lib/realtime/api/broadcast.ex
@@ -10,7 +10,6 @@ defmodule Realtime.Api.Broadcast do
 
   @schema_prefix "realtime"
   schema "broadcasts" do
-    field(:check, :boolean, default: false)
     timestamps()
 
     belongs_to(:channel, Realtime.Api.Channel)
@@ -18,7 +17,7 @@ defmodule Realtime.Api.Broadcast do
 
   def changeset(broadcast, attrs) do
     broadcast
-    |> cast(attrs, [:check, :inserted_at, :updated_at, :channel_id])
+    |> cast(attrs, [:inserted_at, :updated_at, :channel_id])
     |> put_timestamp(:updated_at)
     |> maybe_put_timestamp(:inserted_at)
   end
@@ -26,7 +25,7 @@ defmodule Realtime.Api.Broadcast do
   def check_changeset(broadcast, attrs) do
     broadcast
     |> change()
-    |> put_change(:check, attrs[:check])
+    |> put_change(:updated_at, attrs[:updated_at])
   end
 
   defp put_timestamp(changeset, field) do

--- a/lib/realtime/api/channel.ex
+++ b/lib/realtime/api/channel.ex
@@ -11,7 +11,6 @@ defmodule Realtime.Api.Channel do
   @schema_prefix "realtime"
   schema "channels" do
     field(:name, :string)
-    field(:check, :boolean, default: false)
     timestamps()
 
     has_many(:broadcasts, Realtime.Api.Broadcast)
@@ -20,7 +19,7 @@ defmodule Realtime.Api.Channel do
 
   def changeset(channel, attrs) do
     channel
-    |> cast(attrs, [:name, :check, :inserted_at, :updated_at])
+    |> cast(attrs, [:name, :inserted_at, :updated_at])
     |> validate_required([:name])
     |> put_timestamp(:updated_at)
     |> maybe_put_timestamp(:inserted_at)
@@ -29,7 +28,7 @@ defmodule Realtime.Api.Channel do
   def check_changeset(channel, attrs) do
     channel
     |> change()
-    |> put_change(:check, attrs[:check])
+    |> put_change(:updated_at, attrs[:updated_at])
   end
 
   defp put_timestamp(changeset, field) do

--- a/lib/realtime/api/presence.ex
+++ b/lib/realtime/api/presence.ex
@@ -10,7 +10,6 @@ defmodule Realtime.Api.Presence do
 
   @schema_prefix "realtime"
   schema "presences" do
-    field(:check, :boolean, default: false)
     timestamps()
 
     belongs_to(:channel, Realtime.Api.Channel)
@@ -18,7 +17,7 @@ defmodule Realtime.Api.Presence do
 
   def changeset(broadcast, attrs) do
     broadcast
-    |> cast(attrs, [:check, :inserted_at, :updated_at, :channel_id])
+    |> cast(attrs, [:inserted_at, :updated_at, :channel_id])
     |> put_timestamp(:updated_at)
     |> maybe_put_timestamp(:inserted_at)
   end
@@ -26,7 +25,7 @@ defmodule Realtime.Api.Presence do
   def check_changeset(broadcast, attrs) do
     broadcast
     |> change()
-    |> put_change(:check, attrs[:check])
+    |> put_change(:updated_at, attrs[:updated_at])
   end
 
   defp put_timestamp(changeset, field) do

--- a/lib/realtime/tenants/authorization/policies/broadcast_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/broadcast_policies.ex
@@ -65,10 +65,11 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPolicies do
 
       case Repo.one(conn, query, Broadcast, mode: :savepoint) do
         {:ok, %Broadcast{} = broadcast} ->
-          changeset = Broadcast.check_changeset(broadcast, %{check: true})
+          now = DateTime.utc_now()
+          changeset = Broadcast.check_changeset(broadcast, %{updated_at: now})
 
           case Repo.update(conn, changeset, Broadcast, mode: :savepoint) do
-            {:ok, %Broadcast{check: true}} ->
+            {:ok, %Broadcast{updated_at: ^now}} ->
               Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
               Policies.update_policies(policies, :broadcast, :write, true)
 

--- a/lib/realtime/tenants/authorization/policies/broadcast_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/broadcast_policies.ex
@@ -65,11 +65,11 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPolicies do
 
       case Repo.one(conn, query, Broadcast, mode: :savepoint) do
         {:ok, %Broadcast{} = broadcast} ->
-          now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-          changeset = Broadcast.check_changeset(broadcast, %{updated_at: now})
+          zero = NaiveDateTime.new!(~D[1970-01-01], ~T[00:00:00])
+          changeset = Broadcast.check_changeset(broadcast, %{updated_at: zero})
 
           case Repo.update(conn, changeset, Broadcast, mode: :savepoint) do
-            {:ok, %Broadcast{updated_at: ^now}} ->
+            {:ok, %Broadcast{updated_at: ^zero}} ->
               Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
               Policies.update_policies(policies, :broadcast, :write, true)
 

--- a/lib/realtime/tenants/authorization/policies/broadcast_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/broadcast_policies.ex
@@ -65,7 +65,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPolicies do
 
       case Repo.one(conn, query, Broadcast, mode: :savepoint) do
         {:ok, %Broadcast{} = broadcast} ->
-          now = DateTime.utc_now()
+          now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
           changeset = Broadcast.check_changeset(broadcast, %{updated_at: now})
 
           case Repo.update(conn, changeset, Broadcast, mode: :savepoint) do

--- a/lib/realtime/tenants/authorization/policies/channel_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/channel_policies.ex
@@ -77,7 +77,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPolicies do
   def check_write_policies(conn, policies, %Authorization{channel: channel})
       when not is_nil(channel) do
     Postgrex.transaction(conn, fn transaction_conn ->
-      now = DateTime.utc_now()
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
       changeset = Channel.check_changeset(channel, %{updated_at: now})
 
       case Repo.update(transaction_conn, changeset, Channel, mode: :savepoint) do

--- a/lib/realtime/tenants/authorization/policies/channel_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/channel_policies.ex
@@ -77,11 +77,11 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPolicies do
   def check_write_policies(conn, policies, %Authorization{channel: channel})
       when not is_nil(channel) do
     Postgrex.transaction(conn, fn transaction_conn ->
-      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-      changeset = Channel.check_changeset(channel, %{updated_at: now})
+      zero = NaiveDateTime.new!(~D[1970-01-01], ~T[00:00:00])
+      changeset = Channel.check_changeset(channel, %{updated_at: zero})
 
       case Repo.update(transaction_conn, changeset, Channel, mode: :savepoint) do
-        {:ok, %Channel{updated_at: ^now}} ->
+        {:ok, %Channel{updated_at: ^zero}} ->
           Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
           Policies.update_policies(policies, :channel, :write, true)
 

--- a/lib/realtime/tenants/authorization/policies/presence_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/presence_policies.ex
@@ -65,11 +65,11 @@ defmodule Realtime.Tenants.Authorization.Policies.PresencePolicies do
 
       case Repo.one(conn, query, Presence, mode: :savepoint) do
         {:ok, %Presence{} = broadcast} ->
-          now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-          changeset = Presence.check_changeset(broadcast, %{updated_at: now})
+          zero = NaiveDateTime.new!(~D[1970-01-01], ~T[00:00:00])
+          changeset = Presence.check_changeset(broadcast, %{updated_at: zero})
 
           case Repo.update(conn, changeset, Presence, mode: :savepoint) do
-            {:ok, %Presence{updated_at: ^now}} ->
+            {:ok, %Presence{updated_at: ^zero}} ->
               Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
               Policies.update_policies(policies, :presence, :write, true)
 

--- a/lib/realtime/tenants/authorization/policies/presence_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/presence_policies.ex
@@ -65,7 +65,7 @@ defmodule Realtime.Tenants.Authorization.Policies.PresencePolicies do
 
       case Repo.one(conn, query, Presence, mode: :savepoint) do
         {:ok, %Presence{} = broadcast} ->
-          now = DateTime.utc_now()
+          now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
           changeset = Presence.check_changeset(broadcast, %{updated_at: now})
 
           case Repo.update(conn, changeset, Presence, mode: :savepoint) do

--- a/lib/realtime/tenants/authorization/policies/presence_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/presence_policies.ex
@@ -65,10 +65,11 @@ defmodule Realtime.Tenants.Authorization.Policies.PresencePolicies do
 
       case Repo.one(conn, query, Presence, mode: :savepoint) do
         {:ok, %Presence{} = broadcast} ->
-          changeset = Presence.check_changeset(broadcast, %{check: true})
+          now = DateTime.utc_now()
+          changeset = Presence.check_changeset(broadcast, %{updated_at: now})
 
           case Repo.update(conn, changeset, Presence, mode: :savepoint) do
-            {:ok, %Presence{check: true}} ->
+            {:ok, %Presence{updated_at: ^now}} ->
               Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
               Policies.update_policies(policies, :presence, :write, true)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.25",
+      version: "2.28.26",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
@@ -85,7 +85,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
 
     @tag role: "authenticated",
          policies: [:authenticated_read_broadcast, :authenticated_write_broadcast]
-    test "authenticated user has write policies and reverts check", context do
+    test "authenticated user has write policies and reverts updated_at", context do
       query = from(b in Broadcast, where: b.channel_id == ^context.channel.id)
       {:ok, %Broadcast{updated_at: updated_at}} = Repo.one(context.db_conn, query, Broadcast)
 
@@ -102,7 +102,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
         assert result == %Policies{broadcast: %BroadcastPolicies{write: true}}
       end)
 
-      # Ensure check stays with the initial value
+      # Ensure updated_at with the initial value
       assert {:ok, %{updated_at: ^updated_at}} = Repo.one(context.db_conn, query, Broadcast)
     end
 

--- a/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
@@ -87,7 +87,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
          policies: [:authenticated_read_broadcast, :authenticated_write_broadcast]
     test "authenticated user has write policies and reverts check", context do
       query = from(b in Broadcast, where: b.channel_id == ^context.channel.id)
-      {:ok, %Broadcast{check: check}} = Repo.one(context.db_conn, query, Broadcast)
+      {:ok, %Broadcast{updated_at: updated_at}} = Repo.one(context.db_conn, query, Broadcast)
 
       Postgrex.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, context.authorization_context)
@@ -103,7 +103,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
       end)
 
       # Ensure check stays with the initial value
-      assert {:ok, %{check: ^check}} = Repo.one(context.db_conn, query, Broadcast)
+      assert {:ok, %{updated_at: ^updated_at}} = Repo.one(context.db_conn, query, Broadcast)
     end
 
     @tag role: "anon", policies: [:authenticated_read_broadcast, :authenticated_write_broadcast]

--- a/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
@@ -108,7 +108,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
 
     @tag role: "authenticated",
          policies: [:authenticated_read_channel, :authenticated_write_channel]
-    test "authenticated user has write policies and reverts check", context do
+    test "authenticated user has write policies and reverts updated_at", context do
       query = from(c in Channel, where: c.id == ^context.channel.id)
       {:ok, %Channel{updated_at: updated_at}} = Repo.one(context.db_conn, query, Channel)
 
@@ -124,7 +124,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
                end)
 
       assert {:ok, %Policies{channel: %ChannelPolicies{write: true}}} = result
-      # Ensure check stays with the initial value
+      # Ensure updated_at stays with the initial value
       assert {:ok, %{updated_at: ^updated_at}} = Repo.one(context.db_conn, query, Channel)
     end
 

--- a/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/channel_policies_test.exs
@@ -110,7 +110,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
          policies: [:authenticated_read_channel, :authenticated_write_channel]
     test "authenticated user has write policies and reverts check", context do
       query = from(c in Channel, where: c.id == ^context.channel.id)
-      {:ok, %Channel{check: check}} = Repo.one(context.db_conn, query, Channel)
+      {:ok, %Channel{updated_at: updated_at}} = Repo.one(context.db_conn, query, Channel)
 
       assert {:ok, result} =
                Postgrex.transaction(context.db_conn, fn transaction_conn ->
@@ -125,7 +125,7 @@ defmodule Realtime.Tenants.Authorization.Policies.ChannelPoliciesTest do
 
       assert {:ok, %Policies{channel: %ChannelPolicies{write: true}}} = result
       # Ensure check stays with the initial value
-      assert {:ok, %{check: ^check}} = Repo.one(context.db_conn, query, Channel)
+      assert {:ok, %{updated_at: ^updated_at}} = Repo.one(context.db_conn, query, Channel)
     end
 
     @tag role: "anon", policies: [:authenticated_read_channel, :authenticated_write_channel]

--- a/test/realtime/tenants/authorization/permissions/presence_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/presence_policies_test.exs
@@ -87,7 +87,7 @@ defmodule Realtime.Tenants.Authorization.Policies.PresencePoliciesTest do
          policies: [:authenticated_read_presence, :authenticated_write_presence]
     test "authenticated user has write policies and reverts check", context do
       query = from(b in Presence, where: b.channel_id == ^context.channel.id)
-      {:ok, %Presence{check: check}} = Repo.one(context.db_conn, query, Presence)
+      {:ok, %Presence{updated_at: updated_at}} = Repo.one(context.db_conn, query, Presence)
 
       Postgrex.transaction(context.db_conn, fn transaction_conn ->
         Authorization.set_conn_config(transaction_conn, context.authorization_context)
@@ -103,7 +103,7 @@ defmodule Realtime.Tenants.Authorization.Policies.PresencePoliciesTest do
       end)
 
       # Ensure check stays with the initial value
-      assert {:ok, %{check: ^check}} = Repo.one(context.db_conn, query, Presence)
+      assert {:ok, %{updated_at: ^updated_at}} = Repo.one(context.db_conn, query, Presence)
     end
 
     @tag role: "anon", policies: [:authenticated_read_presence, :authenticated_write_presence]

--- a/test/realtime/tenants/authorization/permissions/presence_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/presence_policies_test.exs
@@ -85,7 +85,7 @@ defmodule Realtime.Tenants.Authorization.Policies.PresencePoliciesTest do
 
     @tag role: "authenticated",
          policies: [:authenticated_read_presence, :authenticated_write_presence]
-    test "authenticated user has write policies and reverts check", context do
+    test "authenticated user has write policies and reverts updated_at", context do
       query = from(b in Presence, where: b.channel_id == ^context.channel.id)
       {:ok, %Presence{updated_at: updated_at}} = Repo.one(context.db_conn, query, Presence)
 
@@ -102,7 +102,7 @@ defmodule Realtime.Tenants.Authorization.Policies.PresencePoliciesTest do
         assert result == %Policies{presence: %PresencePolicies{write: true}}
       end)
 
-      # Ensure check stays with the initial value
+      # Ensure updated_at stays with the initial value
       assert {:ok, %{updated_at: ^updated_at}} = Repo.one(context.db_conn, query, Presence)
     end
 


### PR DESCRIPTION
Uses the `updated_at` column to generate Channel policies instead of `check` column.

We want to drop the `check` column as it'll likely be confusing for folks.