### PR TITLE
fix: Presence policies properly applied

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -648,9 +648,6 @@ defmodule RealtimeWeb.RealtimeChannel do
           match?(%Policies{broadcast: %BroadcastPolicies{read: false}}, socket.assigns.policies) ->
         {:error, "You do not have permissions to read Broadcast messages from this channel"}
 
-      match?(%Policies{presence: %PresencePolicies{read: false}}, socket.assigns.policies) ->
-        {:error, "You do not have permissions to read Presence messages from this channel"}
-
       true ->
         {:ok, socket}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.28",
+      version: "2.28.29",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Lack of permissions on Presence will no longer lock the user out of the Channel.

