### PR TITLE
fix: Use INSERT instead of UPDATE

### DIFF
--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -169,9 +169,8 @@ defmodule Generators do
   def policy_query(:authenticated_write_broadcast, %{name: name}) do
     """
     CREATE POLICY authenticated_write_broadcast_#{name}
-    ON realtime.broadcasts FOR UPDATE
+    ON realtime.broadcasts FOR INSERT
     TO authenticated
-    USING ( realtime.channel_name() = '#{name}' )
     WITH CHECK ( realtime.channel_name() = '#{name}' );
     """
   end
@@ -188,9 +187,8 @@ defmodule Generators do
   def policy_query(:authenticated_write_presence, %{name: name}) do
     """
     CREATE POLICY authenticated_write_presence_#{name}
-    ON realtime.presences FOR UPDATE
+    ON realtime.presences FOR INSERT
     TO authenticated
-    USING ( realtime.channel_name() = '#{name}' )
     WITH CHECK ( realtime.channel_name() = '#{name}' );
     """
   end


### PR DESCRIPTION

## What kind of change does this PR introduce?

Uses an INSERT RLS policy instead of a UPDATE to check if user can connect.

This is done by checking if the user was able to insert and it failed due to unique violation so they had permissions to try and insert.
