### PR TITLE
fix: Case insensitive Bearer prefix

### DIFF
--- a/lib/realtime_web/plugs/auth_tenant.ex
+++ b/lib/realtime_web/plugs/auth_tenant.ex
@@ -39,16 +39,27 @@ defmodule RealtimeWeb.AuthTenant do
     authorization = get_req_header(conn, "authorization")
     apikey = get_req_header(conn, "apikey")
 
+    authorization =
+      case authorization do
+        [] ->
+          nil
+
+        [value | _] ->
+          [bearer, token] = value |> String.split(" ")
+          bearer = String.downcase(bearer)
+          if bearer == "bearer", do: token
+      end
+
+    apikey =
+      case apikey do
+        [] -> nil
+        [value | _] -> value
+      end
+
     cond do
-      authorization != [] && match?(["Bearer " <> _], authorization) ->
-        ["Bearer " <> token] = authorization
-        token
-
-      apikey != [] ->
-        hd(apikey)
-
-      true ->
-        nil
+      authorization -> authorization
+      apikey -> apikey
+      true -> nil
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.32",
+      version: "2.28.33",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/plugs/auth_tenant_test.exs
+++ b/test/realtime_web/plugs/auth_tenant_test.exs
@@ -48,6 +48,25 @@ defmodule RealtimeWeb.AuthTenantTest do
       refute conn.halted
     end
 
+    @tag api_key: "bearer #{@token}", header: "authorization"
+    test "returns non halted and null status if token in authorization header is valid and case insensitive",
+         %{
+           conn: conn
+         } do
+      conn = AuthTenant.call(conn, %{})
+      refute conn.status
+      refute conn.halted
+    end
+
+    @tag api_key: "earer #{@token}", header: "authorization"
+    test "returns halted and unauthorized if token is badly formatted", %{
+      conn: conn
+    } do
+      conn = AuthTenant.call(conn, %{})
+      assert conn.status == 401
+      assert conn.halted
+    end
+
     @tag api_key: "invalid", header: "apikey"
     test "returns 401 if token in apikey header isn't valid", %{conn: conn} do
       conn = AuthTenant.call(conn, %{})


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bearer prefix at the moment was case sensitive which could be a problem with some clients.
