### PR TITLE
fix: Receiving Broadcast required write instead of read

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -165,16 +165,10 @@ defmodule RealtimeWeb.RealtimeChannel do
       cond do
         type == "presence_diff" and
             match?(%Policies{broadcast: %PresencePolicies{read: false}}, policies) ->
-          Logger.error("Presence tracking message ignored")
-
-        type != "presence_diff" and
-            match?(%Policies{broadcast: %BroadcastPolicies{read: false}}, policies) ->
-          Logger.error("Broadcast message ignored")
           socket
 
         type != "presence_diff" and
-            match?(%Policies{broadcast: %BroadcastPolicies{write: false}}, policies) ->
-          Logger.error("Broadcast message ignored")
+            match?(%Policies{broadcast: %BroadcastPolicies{read: false}}, policies) ->
           socket
 
         true ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.33",
+      version: "2.28.34",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION

## What kind of change does this PR introduce?

Receiving Broadcasts was wrongly requiring write permissions.

