### PR TITLE
fix: Reduce Metrics Payload

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
@@ -17,15 +17,12 @@ defmodule Realtime.PromEx.Plugins.Tenants do
   defp rpc_metrics(_opts) do
     Event.build(:realtime, [
       distribution(
-        [:realtime, :tenants, :rpc],
-        event_name: [:realtime, :tenants, :rpc],
+        [:realtime, :rpc],
+        event_name: [:realtime, :rpc],
         description: "Latency of rpc calls triggered by a tenant action",
         measurement: :latency,
         unit: {:microsecond, :millisecond},
-        tags: [:tenant],
-        reporter_options: [
-          buckets: [10, 50, 250, 1500, 6000, 30_000]
-        ]
+        reporter_options: [buckets: [10, 50, 250, 1500, 15_000]]
       )
     ])
   end

--- a/lib/realtime/rpc.ex
+++ b/lib/realtime/rpc.ex
@@ -38,10 +38,9 @@ defmodule Realtime.Rpc do
     tenant = Keyword.get(opts, :tenant, nil)
 
     Telemetry.execute(
-      [:realtime, :tenants, :rpc],
+      [:realtime, :rpc],
       %{latency: latency},
       %{
-        tenant: tenant,
         mod: mod,
         func: func,
         target_node: node,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.28.34",
+      version: "2.28.35",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION

## What kind of change does this PR introduce?

RPC metrics are very consuming per tenant. We're moving towards a more global RPC check approach which will reduce the metrics endpoint reply as a consequence.

