### PR TITLE
fix: allow custom command to be executed by run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/realtime ./
 COPY run.sh run.sh
 RUN ls -la /app
 ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--", "sh", "run.sh"]
+CMD ["/app/bin/server"]
 
 # Appended by flyctl
 ENV ECTO_IPV6 true

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN chown nobody /app
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/realtime ./
 COPY run.sh run.sh
 RUN ls -la /app
-ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--", "run.sh"]
+ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--", "/app/run.sh"]
 CMD ["/app/bin/server"]
 
 # Appended by flyctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN chown nobody /app
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/realtime ./
 COPY run.sh run.sh
 RUN ls -la /app
-ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--", "sh", "run.sh"]
+ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--", "run.sh"]
 CMD ["/app/bin/server"]
 
 # Appended by flyctl

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.29.12",
+      version: "2.29.13",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/run.sh
+++ b/run.sh
@@ -71,4 +71,4 @@ fi
 
 echo "Starting Realtime"
 ulimit -n
-exec /app/bin/server
+exec "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu pipefail
+set -euo pipefail
 set -x
 ulimit -n
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

relates to https://github.com/supabase/cli/pull/2444

## What is the current behavior?

Unable to override docker cmd.

## What is the new behavior?

Allows overriding docker cmd so that migrations can be seeded.

## Additional context

Add any other context or screenshots.
