### PR TITLE
feat: Support LISTEN broadcast in Realtime

### DIFF
--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -25,6 +25,7 @@ defmodule Realtime.Api.Tenant do
     field(:suspend, :boolean, default: false)
     field(:events_per_second_rolling, :float, virtual: true)
     field(:events_per_second_now, :integer, virtual: true)
+    field(:notify_private_alpha, :boolean, default: false)
 
     has_many(:extensions, Realtime.Api.Extensions,
       foreign_key: :tenant_external_id,
@@ -71,7 +72,8 @@ defmodule Realtime.Api.Tenant do
       :max_bytes_per_second,
       :max_channels_per_client,
       :max_joins_per_second,
-      :suspend
+      :suspend,
+      :notify_private_alpha
     ])
     |> validate_required([
       :external_id,

--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -70,7 +70,11 @@ defmodule Realtime.Application do
         {PartitionSupervisor,
          child_spec: DynamicSupervisor,
          strategy: :one_for_one,
-         name: Realtime.Tenants.Connect.DynamicSupervisor}
+         name: Realtime.Tenants.Connect.DynamicSupervisor},
+        {PartitionSupervisor,
+         child_spec: DynamicSupervisor,
+         strategy: :one_for_one,
+         name: Realtime.Tenants.Listen.DynamicSupervisor}
       ] ++ extensions_supervisors()
 
     children =

--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -5,12 +5,81 @@ defmodule Realtime.Tenants.BatchBroadcast do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Realtime.Api.Tenant
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
+  alias Realtime.Tenants
+  alias Realtime.Tenants.Authorization
+  alias Realtime.Tenants.Authorization.Policies
+  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Connect
+
+  alias RealtimeWeb.Endpoint
+
   embedded_schema do
     embeds_many :messages, Message do
       field :event, :string
       field :topic, :string
       field :payload, :map
       field :private, :boolean, default: false
+    end
+  end
+
+  def broadcast(auth_params, tenant, messages, super_user \\ false)
+
+  def broadcast(%Plug.Conn{} = conn, %Tenant{} = tenant, messages, super_user) do
+    auth_params = %{
+      headers: conn.req_headers,
+      jwt: conn.assigns.jwt,
+      claims: conn.assigns.claims,
+      role: conn.assigns.role
+    }
+
+    broadcast(auth_params, %Tenant{} = tenant, messages, super_user)
+  end
+
+  def broadcast(auth_params, tenant, messages, super_user) do
+    with %Ecto.Changeset{valid?: true} = changeset <- changeset(%__MODULE__{}, messages),
+         %Ecto.Changeset{changes: %{messages: messages}} = changeset,
+         events_per_second_key = Tenants.events_per_second_key(tenant),
+         :ok <- check_rate_limit(events_per_second_key, tenant, length(messages)) do
+      tenant_db_conn = Connect.lookup_or_start_connection(tenant.external_id)
+
+      events =
+        messages
+        |> Enum.map(fn %{changes: event} -> event end)
+        |> Enum.group_by(fn event -> Map.get(event, :private, false) end)
+
+      # Handle events for public channel
+      events
+      |> Map.get(false, [])
+      |> Enum.each(fn %{topic: sub_topic, payload: payload, event: event} ->
+        send_message_and_count(tenant, sub_topic, event, payload, true)
+      end)
+
+      # Handle events for private channel
+      events
+      |> Map.get(true, [])
+      |> Enum.group_by(fn event -> Map.get(event, :topic) end)
+      |> Enum.each(fn {topic, events} ->
+        if super_user do
+          Enum.each(events, fn %{topic: sub_topic, payload: payload, event: event} ->
+            send_message_and_count(tenant, sub_topic, event, payload, false)
+          end)
+        else
+          case permissions_for_message(auth_params, tenant_db_conn, topic) do
+            %Policies{broadcast: %BroadcastPolicies{write: true}} ->
+              Enum.each(events, fn %{topic: sub_topic, payload: payload, event: event} ->
+                send_message_and_count(tenant, sub_topic, event, payload, false)
+              end)
+
+            _ ->
+              nil
+          end
+        end
+      end)
+
+      :ok
     end
   end
 
@@ -31,6 +100,46 @@ defmodule Realtime.Tenants.BatchBroadcast do
     case get_change(changeset, :private) do
       nil -> put_change(changeset, :private, false)
       _ -> changeset
+    end
+  end
+
+  defp send_message_and_count(tenant, topic, event, payload, public?) do
+    events_per_second_key = Tenants.events_per_second_key(tenant)
+    tenant_topic = Tenants.tenant_topic(tenant, topic, public?)
+    payload = %{"payload" => payload, "event" => event, "type" => "broadcast"}
+
+    GenCounter.add(events_per_second_key)
+    Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
+  end
+
+  defp permissions_for_message(_, {:error, _}, _), do: nil
+  defp permissions_for_message(nil, _, _), do: nil
+
+  defp permissions_for_message(auth_params, {:ok, db_conn}, topic) do
+    with auth_params = Map.put(auth_params, :topic, topic),
+         auth_params = Authorization.build_authorization_params(auth_params),
+         %Policies{} = policies <- Authorization.get_authorizations(db_conn, auth_params) do
+      policies
+    else
+      {:error, :not_found} -> nil
+      error -> error
+    end
+  end
+
+  defp check_rate_limit(events_per_second_key, %Tenant{} = tenant, total_messages_to_broadcast) do
+    %{max_events_per_second: max_events_per_second} = tenant
+    {:ok, %{avg: events_per_second}} = RateCounter.get(events_per_second_key)
+
+    cond do
+      events_per_second > max_events_per_second ->
+        {:error, :too_many_requests, "You have exceeded your rate limit"}
+
+      total_messages_to_broadcast + events_per_second > max_events_per_second ->
+        {:error, :too_many_requests,
+         "Too many messages to broadcast, please reduce the batch size"}
+
+      true ->
+        :ok
     end
   end
 end

--- a/lib/realtime/tenants/listen.ex
+++ b/lib/realtime/tenants/listen.ex
@@ -1,0 +1,100 @@
+defmodule Realtime.Tenants.Listen do
+  @moduledoc """
+  Creates a listener for tenant NOTIFY postgres commands.
+  """
+  use GenServer, restart: :transient
+  require Logger
+
+  alias Realtime.Api.Tenant
+  alias Realtime.Database
+  alias Realtime.PostgresCdc
+  alias Realtime.Registry.Unique
+  alias Realtime.Tenants
+  alias Realtime.Tenants.BatchBroadcast
+
+  defstruct tenant_id: nil, listen_conn: nil
+
+  @cdc "postgres_cdc_rls"
+  @topic "realtime:broadcast"
+  def start_link(%Tenant{} = tenant) do
+    name = {:via, Registry, {Unique, {__MODULE__, :tenant_id, tenant.external_id}}}
+    GenServer.start_link(__MODULE__, tenant, name: name)
+  end
+
+  def init(%Tenant{} = tenant) do
+    settings =
+      tenant
+      |> then(&PostgresCdc.filter_settings(@cdc, &1.extensions))
+      |> then(fn settings ->
+        Database.from_settings(settings, "realtime_listen", :rand_exp, true)
+      end)
+      |> Map.from_struct()
+
+    name =
+      {:via, Registry,
+       {Realtime.Registry.Unique, {Postgrex.Notifications, :tenant_id, tenant.external_id}}}
+
+    settings =
+      settings
+      |> Map.put(:hostname, settings[:host])
+      |> Map.put(:database, settings[:name])
+      |> Map.put(:password, settings[:pass])
+      |> Map.put(:username, "postgres")
+      |> Map.put(:port, String.to_integer(settings[:port]))
+      |> Map.put(:ssl, settings[:ssl_enforced])
+      |> Map.put(:auto_reconnect, true)
+      |> Map.put(:name, name)
+      |> Enum.to_list()
+
+    Logger.info("Listening for notifications on #{@topic}")
+
+    case Postgrex.Notifications.start_link(settings) do
+      {:ok, conn} ->
+        Postgrex.Notifications.listen!(conn, @topic)
+        {:ok, %{tenant_id: tenant.external_id, listen_conn: conn}}
+
+      {:error, {:already_started, conn}} ->
+        Postgrex.Notifications.listen!(conn, @topic)
+        {:ok, %{tenant_id: tenant.external_id, listen_conn: conn}}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  catch
+    e -> {:stop, e}
+  end
+
+  @spec start(Realtime.Api.Tenant.t()) :: {:ok, pid()} | {:error, any()}
+  def start(%Tenant{} = tenant) do
+    supervisor = {:via, PartitionSupervisor, {Realtime.Tenants.Listen.DynamicSupervisor, self()}}
+    spec = {__MODULE__, tenant}
+
+    case DynamicSupervisor.start_child(supervisor, spec) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      error -> {:error, error}
+    end
+  catch
+    e -> {:error, e}
+  end
+
+  def handle_info(
+        {:notification, _, _, "realtime:broadcast", payload},
+        %{tenant_id: tenant_id} = state
+      ) do
+    tenant = Tenants.Cache.get_tenant_by_external_id(tenant_id)
+
+    case Jason.decode(payload) do
+      {:ok, content} when is_list(content) ->
+        BatchBroadcast.broadcast(%{}, tenant, %{messages: content}, true)
+
+      {:ok, content} ->
+        BatchBroadcast.broadcast(%{}, tenant, %{messages: [content]}, true)
+
+      {:error, _} ->
+        Logger.error("Error decoding payload")
+    end
+
+    {:noreply, state}
+  end
+end

--- a/lib/realtime_web/controllers/broadcast_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_controller.ex
@@ -3,17 +3,6 @@ defmodule RealtimeWeb.BroadcastController do
   use OpenApiSpex.ControllerSpecs
   require Logger
 
-  alias Realtime.Api.Tenant
-  alias Realtime.GenCounter
-  alias Realtime.RateCounter
-  alias Realtime.Tenants
-  alias Realtime.Tenants.Authorization
-  alias Realtime.Tenants.Authorization.Policies
-  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
-  alias Realtime.Tenants.BatchBroadcast
-  alias Realtime.Tenants.Connect
-
-  alias RealtimeWeb.Endpoint
   alias RealtimeWeb.OpenApiSchemas.EmptyResponse
   alias RealtimeWeb.OpenApiSchemas.TenantBatchParams
   alias RealtimeWeb.OpenApiSchemas.TooManyRequestsResponse
@@ -43,89 +32,8 @@ defmodule RealtimeWeb.BroadcastController do
   )
 
   def broadcast(%{assigns: %{tenant: tenant}} = conn, attrs) do
-    with %Ecto.Changeset{valid?: true} = changeset <-
-           BatchBroadcast.changeset(%BatchBroadcast{}, attrs),
-         %Ecto.Changeset{changes: %{messages: messages}} = changeset,
-         events_per_second_key = Tenants.events_per_second_key(tenant),
-         :ok <- check_rate_limit(events_per_second_key, tenant, length(messages)) do
-      tenant_db_conn = Connect.lookup_or_start_connection(tenant.external_id)
-
-      events =
-        messages
-        |> Enum.map(fn %{changes: event} -> event end)
-        |> Enum.group_by(fn event -> Map.get(event, :private, false) end)
-
-      # Handle events without authorization check
-      events
-      |> Map.get(false, [])
-      |> Enum.each(fn %{topic: sub_topic, payload: payload, event: event} ->
-        send_message_and_count(tenant, sub_topic, event, payload, true)
-      end)
-
-      # Handle events with authorization check
-
-      events
-      |> Map.get(true, [])
-      |> Enum.group_by(fn event -> Map.get(event, :topic) end)
-      |> Enum.each(fn {topic, events} ->
-        case permissions_for_message(conn, tenant_db_conn, topic) do
-          %Policies{broadcast: %BroadcastPolicies{write: true}} ->
-            Enum.each(events, fn %{topic: sub_topic, payload: payload, event: event} ->
-              send_message_and_count(tenant, sub_topic, event, payload, false)
-            end)
-
-          _ ->
-            nil
-        end
-      end)
-
+    with :ok <- Realtime.Tenants.BatchBroadcast.broadcast(conn, tenant, attrs) do
       send_resp(conn, :accepted, "")
-    end
-  end
-
-  defp send_message_and_count(tenant, topic, event, payload, public?) do
-    events_per_second_key = Tenants.events_per_second_key(tenant)
-    tenant_topic = Tenants.tenant_topic(tenant, topic, public?)
-    payload = %{"payload" => payload, "event" => event, "type" => "broadcast"}
-
-    GenCounter.add(events_per_second_key)
-    Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
-  end
-
-  defp permissions_for_message(_, {:error, _}, _), do: nil
-
-  defp permissions_for_message(conn, {:ok, db_conn}, topic) do
-    params = %{
-      headers: conn.req_headers,
-      jwt: conn.assigns.jwt,
-      claims: conn.assigns.claims,
-      role: conn.assigns.role
-    }
-
-    with params = Map.put(params, :topic, topic),
-         params = Authorization.build_authorization_params(params),
-         %Policies{} = policies <- Authorization.get_authorizations(db_conn, params) do
-      policies
-    else
-      {:error, :not_found} -> nil
-      error -> error
-    end
-  end
-
-  defp check_rate_limit(events_per_second_key, %Tenant{} = tenant, total_messages_to_broadcast) do
-    %{max_events_per_second: max_events_per_second} = tenant
-    {:ok, %{avg: events_per_second}} = RateCounter.get(events_per_second_key)
-
-    cond do
-      events_per_second > max_events_per_second ->
-        {:error, :too_many_requests, "You have exceeded your rate limit"}
-
-      total_messages_to_broadcast + events_per_second > max_events_per_second ->
-        {:error, :too_many_requests,
-         "Too many messages to broadcast, please reduce the batch size"}
-
-      true ->
-        :ok
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.29.18",
+      version: "2.30.0",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20240704172020_add-notify-private-alpha.exs
+++ b/priv/repo/migrations/20240704172020_add-notify-private-alpha.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.Realtime.Repo.Migrations.Add-notify-private-alpha" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenants) do
+      add :notify_private_alpha, :boolean, default: false
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -26,14 +26,15 @@ Repo.transaction(fn ->
           "db_host" => System.get_env("DB_HOST", default_db_host),
           "db_user" => System.get_env("DB_USER", "supabase_admin"),
           "db_password" => System.get_env("DB_PASSWORD", "postgres"),
-          "db_port" => System.get_env("DB_PORT", "5432"),
+          "db_port" => System.get_env("DB_PORT", "5433"),
           "region" => "us-east-1",
           "poll_interval_ms" => 100,
           "poll_max_record_bytes" => 1_048_576,
           "ssl_enforced" => false
         }
       }
-    ]
+    ],
+    "notify_private_alpha" => true
   })
   |> Repo.insert!()
 end)

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -17,7 +17,6 @@ defmodule Realtime.Integration.RtChannelTest do
   alias Realtime.Api.Tenant
   alias Realtime.Integration.WebsocketClient
   alias Realtime.Repo
-  alias Realtime.Tenants.Connect
 
   @moduletag :capture_log
   @port 4002
@@ -611,9 +610,9 @@ defmodule Realtime.Integration.RtChannelTest do
   end
 
   def rls_context(context) do
-    [tenant] = Repo.all(Tenant)
+    [tenant] = Tenant |> Repo.all() |> Repo.preload(:extensions)
 
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    {:ok, db_conn} = Realtime.Tenants.Connect.lookup_or_start_connection(tenant.external_id)
 
     clean_table(db_conn, "realtime", "messages")
     topic = Map.get(context, :topic, random_string())

--- a/test/realtime/messages_test.exs
+++ b/test/realtime/messages_test.exs
@@ -4,17 +4,11 @@ defmodule Realtime.MessagesTest do
 
   alias Realtime.Api.Message
   alias Realtime.Messages
-  alias Realtime.Tenants.Connect
 
   setup do
     tenant = tenant_fixture()
-
-    {:ok, pid} = Connect.connect(tenant.external_id)
-    Process.link(pid)
-    {:ok, conn} = Connect.get_status(tenant.external_id)
-
+    {:ok, conn} = connect(tenant)
     clean_table(conn, "realtime", "messages")
-
     on_exit(fn -> Process.exit(conn, :normal) end)
     %{conn: conn, tenant: tenant}
   end

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -8,16 +8,11 @@ defmodule Realtime.RepoTest do
   alias Realtime.Crypto
   alias Realtime.Repo
   alias Realtime.Database
-  alias Realtime.Tenants.Connect
 
   setup do
     tenant = tenant_fixture()
-
-    {:ok, _} = start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
-    {:ok, db_conn} = Connect.get_status(tenant.external_id)
-
+    {:ok, db_conn} = connect(tenant)
     clean_table(db_conn, "realtime", "messages")
-
     %{db_conn: db_conn, tenant: tenant}
   end
 

--- a/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
+++ b/test/realtime/tenants/authorization/permissions/broadcast_policies_test.exs
@@ -6,7 +6,6 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
-  alias Realtime.Tenants.Connect
 
   alias RealtimeWeb.Joken.CurrentTime
 
@@ -146,8 +145,7 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPoliciesTest do
     start_supervised!(CurrentTime.Mock)
     tenant = tenant_fixture()
 
-    {:ok, _} = start_supervised({Connect, tenant_id: tenant.external_id}, restart: :transient)
-    {:ok, db_conn} = Connect.get_status(tenant.external_id)
+    {:ok, db_conn} = connect(tenant)
 
     clean_table(db_conn, "realtime", "messages")
     message = message_fixture(tenant, %{extension: :broadcast})

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -9,7 +9,6 @@ defmodule Realtime.Tenants.AuthorizationTest do
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
   alias Realtime.Tenants.Authorization.Policies.TopicPolicies
   alias Realtime.Tenants.Authorization.Policies.PresencePolicies
-  alias Realtime.Tenants.Connect
 
   alias RealtimeWeb.Joken.CurrentTime
 
@@ -108,7 +107,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
     start_supervised!(CurrentTime.Mock)
     tenant = tenant_fixture()
 
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    {:ok, db_conn} = connect(tenant)
 
     clean_table(db_conn, "realtime", "messages")
     topic = random_string()

--- a/test/realtime/tenants/listen_test.exs
+++ b/test/realtime/tenants/listen_test.exs
@@ -1,0 +1,87 @@
+defmodule Realtime.Tenants.ListenTest do
+  # async: false due to the fact that it's doing Postgres NOTIFY and could interfere with other tests
+  use Realtime.DataCase, async: false
+  import Mock
+
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
+  alias Realtime.Tenants.Listen
+
+  alias RealtimeWeb.Endpoint
+
+  describe("start/1") do
+    setup do
+      start_supervised(RealtimeWeb.Joken.CurrentTime.Mock)
+      start_supervised(Realtime.RateCounter.DynamicSupervisor)
+      start_supervised(Realtime.GenCounter.DynamicSupervisor)
+
+      tenant = tenant_fixture()
+      RateCounter.new({:channel, :events, tenant.external_id})
+
+      {:ok, listen_conn} = Listen.start(tenant)
+      {:ok, db_conn} = connect(tenant)
+
+      on_exit(fn ->
+        Process.exit(listen_conn, :normal)
+        Process.exit(db_conn, :normal)
+      end)
+
+      {:ok, tenant: tenant, db_conn: db_conn}
+    end
+
+    test "on public notify, broadcasts to topic", %{tenant: tenant, db_conn: db_conn} do
+      with_mocks [
+        {Endpoint, [:passthrough], broadcast_from: fn _, _, _, _ -> :ok end},
+        {GenCounter, [:passthrough], add: fn _ -> :ok end},
+        {RateCounter, [:passthrough], get: fn _ -> {:ok, %{avg: 0}} end}
+      ] do
+        topic = random_string()
+
+        messages =
+          Stream.repeatedly(fn ->
+            %{
+              private: Enum.random([true, false]),
+              topic: topic,
+              payload: random_string(),
+              event: random_string()
+            }
+          end)
+          |> Enum.take(10)
+
+        Enum.each(messages, fn %{private: private, topic: topic, payload: payload, event: event} ->
+          broadcast_test_message(db_conn, private, topic, event, payload)
+        end)
+
+        :timer.sleep(100)
+
+        messages =
+          Enum.map(messages, fn %{private: private, topic: topic, payload: payload, event: event} ->
+            payload = %{
+              "type" => "broadcast",
+              "event" => event,
+              "payload" => %{"payload" => payload}
+            }
+
+            private_prefix = if private, do: "-private:", else: ":"
+
+            args = [
+              "#{String.upcase(tenant.external_id)}#{private_prefix}#{topic}",
+              "broadcast",
+              payload
+            ]
+
+            %{mod: Endpoint, fun: :broadcast_from, args: args}
+          end)
+
+        calls = Endpoint |> call_history() |> Enum.map(&elem(&1, 1))
+
+        Enum.each(messages, fn expected ->
+          assert Enum.find(calls, fn {mod, function, args} ->
+                   mod == expected.mod and function == expected.fun and
+                     Enum.drop(args, 1) == expected.args
+                 end)
+        end)
+      end
+    end
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -23,7 +23,7 @@ defmodule RealtimeWeb.ChannelCase do
       # Import conveniences for testing with channels
       import Phoenix.ChannelTest
       import Generators
-
+      import TenantConnection
       # The default endpoint for testing
       @endpoint RealtimeWeb.Endpoint
     end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -22,6 +22,7 @@ defmodule RealtimeWeb.ConnCase do
     quote do
       # Import conveniences for testing with connections
       import Generators
+      import TenantConnection
       import Phoenix.ConnTest
       import Plug.Conn
       import Realtime.DataCase

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -24,6 +24,7 @@ defmodule Realtime.DataCase do
       import Ecto.Query
       import Realtime.DataCase
       import Generators
+      import TenantConnection
     end
   end
 

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -2,7 +2,7 @@ defmodule Generators do
   @moduledoc """
   Data genarators for tests.
   """
-  alias Realtime.Tenants.Connect
+
   @spec tenant_fixture(map()) :: Realtime.Api.Tenant.t()
   def tenant_fixture(override \\ %{}) do
     create_attrs = %{
@@ -27,7 +27,8 @@ defmodule Generators do
       ],
       "postgres_cdc_default" => "postgres_cdc_rls",
       "jwt_secret" => "new secret",
-      "jwt_jwks" => nil
+      "jwt_jwks" => nil,
+      "notify_private_alpha" => true
     }
 
     override = override |> Enum.map(fn {k, v} -> {"#{k}", v} end) |> Map.new()
@@ -41,7 +42,7 @@ defmodule Generators do
   end
 
   def message_fixture(tenant, override \\ %{}) do
-    {:ok, db_conn} = Connect.get_status(tenant.external_id)
+    {:ok, db_conn} = TenantConnection.connect(tenant)
 
     create_attrs = %{
       "topic" => random_string(),

--- a/test/support/tenant_connection.ex
+++ b/test/support/tenant_connection.ex
@@ -4,11 +4,27 @@ defmodule TenantConnection do
   """
   alias Realtime.Api.Tenant
 
-  def connect_child_spec(%Tenant{external_id: external_id}, connect_child_spec \\ []) do
-    {Realtime.Tenants.Connect, Keyword.merge(connect_child_spec, tenant_id: external_id)}
+  def connect(%Tenant{} = tenant) do
+    tenant
+    |> then(&Realtime.PostgresCdc.filter_settings("postgres_cdc_rls", &1.extensions))
+    |> then(fn settings -> Realtime.Database.from_settings(settings, "realtime_listen", :stop) end)
+    |> Realtime.Database.connect_db()
   end
 
-  def tenant_connection(tenant) do
-    Realtime.Tenants.Connect.get_status(tenant.external_id)
+  def broadcast_test_message(conn, private, topic, event, payload) do
+    query =
+      """
+      select pg_notify(
+          'realtime:broadcast',
+          json_build_object(
+              'private', $1::boolean,
+              'topic', $2::text,
+              'event', $3::text,
+              'payload', $4::jsonb
+          )::text
+      );
+      """
+
+    Postgrex.query!(conn, query, [private, topic, event, %{payload: payload}])
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Support LISTEN/NOTIFY on `realtime:broadcast` which allows users to trigger broadcast messages by sending a payload to this topic.

```sql
select pg_notify(
          'realtime:broadcast',
          json_build_object(
              'private', $1::boolean,
              'topic', $2::text,
              'event', $3::text,
              'payload', $4::jsonb
          )::text
      );
```

We want to keep it as close to the Broadcast endpoint as possible and it already includes the feature flag `notify_private_alpha` to enabled it (defaults to false)