### PR TITLE
fix: Start rate limits if not created on Listen

### DIFF
--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -38,7 +38,7 @@ defmodule Realtime.Tenants.BatchBroadcast do
     broadcast(auth_params, %Tenant{} = tenant, messages, super_user)
   end
 
-  def broadcast(auth_params, tenant, messages, super_user) do
+  def broadcast(auth_params, %Tenant{} = tenant, messages, super_user) do
     with %Ecto.Changeset{valid?: true} = changeset <- changeset(%__MODULE__{}, messages),
          %Ecto.Changeset{changes: %{messages: messages}} = changeset,
          events_per_second_key = Tenants.events_per_second_key(tenant),

--- a/lib/realtime/tenants/listen.ex
+++ b/lib/realtime/tenants/listen.ex
@@ -37,6 +37,10 @@ defmodule Realtime.Tenants.Listen do
   @cdc "postgres_cdc_rls"
   @topic "realtime:broadcast"
   def init(%Tenant{} = tenant) do
+    Logger.metadata(external_id: tenant.external_id, project: tenant.external_id)
+    events_per_second_key = Tenants.events_per_second_key(tenant)
+    Realtime.RateCounter.new(events_per_second_key)
+
     settings =
       tenant
       |> then(&PostgresCdc.filter_settings(@cdc, &1.extensions))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.7",
+      version: "2.30.8",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Starts the rate limit for a given tenant on Listen. Also improved logging as it was missing context.

