### PR TITLE
fix: Avoid migration conflicts if table exists

### DIFF
--- a/lib/realtime/tenants/repo/migrations/20211116024918_create_realtime_subscription_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20211116024918_create_realtime_subscription_table.ex
@@ -28,7 +28,7 @@ defmodule Realtime.Tenants.Migrations.CreateRealtimeSubscriptionTable do
     END$$;
     """)
 
-    execute("create table realtime.subscription (
+    execute("create table if not exists realtime.subscription (
       -- Tracks which users are subscribed to each table
       id bigint not null generated always as identity,
       user_id uuid not null,

--- a/lib/realtime/tenants/repo/migrations/20231018144023_create_channels.ex
+++ b/lib/realtime/tenants/repo/migrations/20231018144023_create_channels.ex
@@ -4,11 +4,11 @@ defmodule Realtime.Tenants.Migrations.CreateChannels do
   use Ecto.Migration
 
   def change do
-    create table(:channels, prefix: "realtime") do
+    create_if_not_exists table(:channels, prefix: "realtime") do
       add(:name, :string, null: false)
       timestamps()
     end
 
-    create unique_index(:channels, [:name], prefix: "realtime")
+    create_if_not_exists unique_index(:channels, [:name], prefix: "realtime")
   end
 end

--- a/lib/realtime/tenants/repo/migrations/20240227174441_add_broadcast_permissions_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20240227174441_add_broadcast_permissions_table.ex
@@ -4,13 +4,13 @@ defmodule Realtime.Tenants.Migrations.AddBroadcastsPoliciesTable do
   use Ecto.Migration
 
   def change do
-    create table(:broadcasts) do
+    create_if_not_exists table(:broadcasts) do
       add :channel_id, references(:channels, on_delete: :delete_all), null: false
       add :check, :boolean, default: false, null: false
       timestamps()
     end
 
-    create unique_index(:broadcasts, :channel_id)
+    create_if_not_exists unique_index(:broadcasts, :channel_id)
 
     execute("ALTER TABLE realtime.broadcasts ENABLE row level security")
     execute("GRANT SELECT ON realtime.broadcasts TO postgres, anon, authenticated, service_role")

--- a/lib/realtime/tenants/repo/migrations/20240321100241_add_presences_permissions_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20240321100241_add_presences_permissions_table.ex
@@ -4,13 +4,13 @@ defmodule Realtime.Tenants.Migrations.AddPresencesPoliciesTable do
   use Ecto.Migration
 
   def change do
-    create table(:presences) do
+    create_if_not_exists table(:presences) do
       add :channel_id, references(:channels, on_delete: :delete_all), null: false
       add :check, :boolean, default: false, null: false
       timestamps()
     end
 
-    create unique_index(:presences, :channel_id)
+    create_if_not_exists unique_index(:presences, :channel_id)
 
     execute("ALTER TABLE realtime.presences ENABLE row level security")
     execute("GRANT SELECT ON realtime.presences TO postgres, anon, authenticated, service_role")

--- a/lib/realtime/tenants/repo/migrations/20240523004032_redefine_authorization_tables.ex
+++ b/lib/realtime/tenants/repo/migrations/20240523004032_redefine_authorization_tables.ex
@@ -8,13 +8,13 @@ defmodule Realtime.Tenants.Migrations.RedefineAuthorizationTables do
     drop table(:presences, mode: :cascade)
     drop table(:channels, mode: :cascade)
 
-    create table(:messages) do
+    create_if_not_exists table(:messages) do
       add :topic, :text, null: false
       add :extension, :text, null: false
       timestamps()
     end
 
-    create index(:messages, [:topic])
+    create_if_not_exists index(:messages, [:topic])
 
     execute("ALTER TABLE realtime.messages ENABLE row level security")
     execute("GRANT SELECT ON realtime.messages TO postgres, anon, authenticated, service_role")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.12",
+      version: "2.30.13",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20210706140551_create_tenant.exs
+++ b/priv/repo/migrations/20210706140551_create_tenant.exs
@@ -2,7 +2,7 @@ defmodule Realtime.Repo.Migrations.CreateTenants do
   use Ecto.Migration
 
   def change do
-    create table(:tenants, primary_key: false) do
+    create_if_not_exists table(:tenants, primary_key: false) do
       add(:id, :binary_id, primary_key: true)
       add(:name, :string)
       add(:external_id, :string)

--- a/priv/repo/migrations/20220329161857_add_extensions_table.exs
+++ b/priv/repo/migrations/20220329161857_add_extensions_table.exs
@@ -2,7 +2,7 @@ defmodule Realtime.Repo.Migrations.AddExtensionsTable do
   use Ecto.Migration
 
   def change do
-    create table(:extensions, primary_key: false) do
+    create_if_not_exists table(:extensions, primary_key: false) do
       add(:id, :binary_id, primary_key: true)
       add(:type, :string)
       add(:settings, :map)
@@ -15,6 +15,6 @@ defmodule Realtime.Repo.Migrations.AddExtensionsTable do
       timestamps()
     end
 
-    create(index(:extensions, [:tenant_external_id, :type], unique: true))
+    create_if_not_exists(index(:extensions, [:tenant_external_id, :type], unique: true))
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Avoid migration conflicts if table exists