### PR TITLE
fix: Ensure that only one migration is ran by host

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -54,19 +54,17 @@ defmodule Realtime.Application do
       [
         Realtime.ErlSysMon,
         Realtime.PromEx,
-        {Cluster.Supervisor, [topologies, [name: Realtime.ClusterSupervisor]]},
+        Realtime.Telemetry.Logger,
         Realtime.Repo,
         RealtimeWeb.Telemetry,
+        {Cluster.Supervisor, [topologies, [name: Realtime.ClusterSupervisor]]},
         {Phoenix.PubSub, name: Realtime.PubSub, pool_size: 10},
-        Realtime.GenCounter.DynamicSupervisor,
         {Cachex, name: Realtime.RateCounter},
         Realtime.Tenants.CacheSupervisor,
+        Realtime.GenCounter.DynamicSupervisor,
         Realtime.RateCounter.DynamicSupervisor,
-        RealtimeWeb.Endpoint,
-        RealtimeWeb.Presence,
-        {Task.Supervisor, name: Realtime.TaskSupervisor},
         Realtime.Latency,
-        Realtime.Telemetry.Logger,
+        {Task.Supervisor, name: Realtime.TaskSupervisor},
         {PartitionSupervisor,
          child_spec: DynamicSupervisor,
          strategy: :one_for_one,
@@ -75,7 +73,11 @@ defmodule Realtime.Application do
          child_spec: DynamicSupervisor,
          strategy: :one_for_one,
          name: Realtime.Tenants.Listen.DynamicSupervisor,
-         max_restarts: 5}
+         max_restarts: 5},
+        {DynamicSupervisor,
+         name: Realtime.Tenants.Migrations.DynamicSupervisor, strategy: :one_for_one},
+        RealtimeWeb.Endpoint,
+        RealtimeWeb.Presence
       ] ++ extensions_supervisors()
 
     children =

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -99,7 +99,7 @@ defmodule Realtime.Tenants.Connect do
     with %Tenant{} = tenant <- Tenants.get_tenant_by_external_id(tenant_id),
          res <- Database.check_tenant_connection(tenant, @application_name),
          [%{settings: settings} | _] <- tenant.extensions,
-         {:ok, _} <- Migrations.run_migrations(settings) do
+         :ok <- Migrations.run_migrations(settings) do
       case res do
         {:ok, conn} ->
           :syn.update_registry(__MODULE__, tenant_id, fn _pid, meta -> %{meta | conn: conn} end)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.15",
+      version: "2.30.16",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/migrations_test.exs
+++ b/test/realtime/tenants/migrations_test.exs
@@ -1,0 +1,29 @@
+defmodule Realtime.Tenants.MigrationsTest do
+  # async: false due to the fact that we're dropping database migrations
+  use Realtime.DataCase, async: false
+  alias Realtime.Tenants.Migrations
+
+  describe "run_migrations/1" do
+    setup do
+      tenant = tenant_fixture()
+      %{tenant: tenant}
+    end
+
+    test "migrations for a given tenant only run once", %{tenant: tenant} do
+      %{extensions: [%{settings: settings}]} = tenant
+      {:ok, conn} = connect(tenant)
+
+      Postgrex.query!(conn, "DROP SCHEMA realtime CASCADE", [])
+      Postgrex.query!(conn, "CREATE SCHEMA realtime", [])
+
+      res =
+        for _ <- 0..10 do
+          Task.async(fn -> Migrations.run_migrations(settings) end)
+        end
+        |> Task.await_many()
+        |> Enum.uniq()
+
+      assert [:ok] = res
+    end
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

By creating a unique process per host we ensure that we don't have multiple migrations running against the tenant database. We use the encrypted host as the uniqueness key.

