### PR TITLE
fix: Set realtime.messages to unlogged

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -56,7 +56,8 @@ defmodule Realtime.Tenants.Migrations do
     CreateRealtimeAdminAndMoveOwnership,
     RemoveCheckColumns,
     RedefineAuthorizationTables,
-    FixWalrusRoleHandling
+    FixWalrusRoleHandling,
+    UnloggedMessagesTable
   }
 
   @migrations [
@@ -103,7 +104,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_240_401_105_812, CreateRealtimeAdminAndMoveOwnership},
     {20_240_418_121_054, RemoveCheckColumns},
     {20_240_523_004_032, RedefineAuthorizationTables},
-    {20_240_618_124_746, FixWalrusRoleHandling}
+    {20_240_618_124_746, FixWalrusRoleHandling},
+    {20_240_801_235_015, UnloggedMessagesTable}
   ]
 
   @spec run_migrations(map()) :: :ok | {:error, any()}

--- a/lib/realtime/tenants/repo/migrations/20240801235015_unlogged_messages_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20240801235015_unlogged_messages_table.ex
@@ -1,0 +1,10 @@
+defmodule Realtime.Tenants.Migrations.UnloggedMessagesTable do
+  @moduledoc false
+  use Ecto.Migration
+
+  def change do
+    execute """
+    ALTER TABLE realtime.messages SET UNLOGGED;
+    """
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.16",
+      version: "2.30.17",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Due to the way we're doing the checks, to increase performance, we're moving thist able to unlogged.

At a later stage we might revert this and do other approaches but at the moment this is a sane approach

