### PR TITLE
fix: Use logged tables for realtime.messages

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -57,7 +57,8 @@ defmodule Realtime.Tenants.Migrations do
     RemoveCheckColumns,
     RedefineAuthorizationTables,
     FixWalrusRoleHandling,
-    UnloggedMessagesTable
+    UnloggedMessagesTable,
+    LoggedMessagesTable
   }
 
   @migrations [
@@ -105,7 +106,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_240_418_121_054, RemoveCheckColumns},
     {20_240_523_004_032, RedefineAuthorizationTables},
     {20_240_618_124_746, FixWalrusRoleHandling},
-    {20_240_801_235_015, UnloggedMessagesTable}
+    {20_240_801_235_015, UnloggedMessagesTable},
+    {20_240_805_133_720, LoggedMessagesTable}
   ]
 
   @spec run_migrations(map()) :: :ok | {:error, any()}

--- a/lib/realtime/tenants/repo/migrations/20240805133720_logged_messages_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20240805133720_logged_messages_table.ex
@@ -1,0 +1,10 @@
+defmodule Realtime.Tenants.Migrations.LoggedMessagesTable do
+  @moduledoc false
+  use Ecto.Migration
+
+  def change do
+    execute """
+    ALTER TABLE realtime.messages SET LOGGED;
+    """
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.19",
+      version: "2.30.20",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use logged tables for realtime.messages
