### PR TITLE
fix: Avoid catch to return nested tuple error

### DIFF
--- a/lib/realtime/rpc.ex
+++ b/lib/realtime/rpc.ex
@@ -39,7 +39,9 @@ defmodule Realtime.Rpc do
     try do
       :timer.tc(fn -> :erpc.call(node, mod, func, args, timeout) end)
     catch
-      kind, reason -> {:error, {:badrpc, {kind, reason}}}
+      kind, reason ->
+        log_error("ErrorOnRpcCall", {kind, reason})
+        {:error, "RPC call error"}
     else
       {_, {:EXIT, _}} = badrpc ->
         log_error("ErrorOnRpcCall", badrpc)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.24",
+      version: "2.30.25",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Avoid catch to return nested tuple error
