### PR TITLE
fix: Add static asset to be used by Web Workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ node_modules
 config/prod.secret.exs
 
 demo/.env
+
+.lexical

--- a/lib/realtime_web.ex
+++ b/lib/realtime_web.ex
@@ -17,7 +17,7 @@ defmodule RealtimeWeb do
   and import those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images favicon.svg robots.txt)
+  def static_paths, do: ~w(assets fonts images favicon.svg robots.txt worker.js)
 
   def controller do
     quote do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.26",
+      version: "2.30.27",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/static/worker.js
+++ b/priv/static/worker.js
@@ -1,0 +1,5 @@
+addEventListener("message", (e) => {
+  if (e.data === "start") {
+    setInterval(() => postMessage("keepAlive"), 100);
+  }
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

To support a future change in the realtime-js library we're adding a static asset to realtime so users can use it as their default worker.
