### PR TITLE
fix: Improve invalid JWT logs

### DIFF
--- a/lib/realtime_web/channels/auth/channels_authorization.ex
+++ b/lib/realtime_web/channels/auth/channels_authorization.ex
@@ -26,7 +26,7 @@ defmodule RealtimeWeb.ChannelsAuthorization do
         if MapSet.subset?(required, claims_keys) do
           {:ok, claims}
         else
-          {:error, "Fields `role` and `exp` are required in JWT"}
+          {:error, :missing_claims}
         end
 
       {:error, reason} ->

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -94,8 +94,12 @@ defmodule RealtimeWeb.RealtimeChannel do
 
       {:ok, state, assign(socket, assigns)}
     else
-      {:error, [message: "Invalid token", claim: _claim, claim_val: _value]} ->
-        msg = "Invalid JWT Token"
+      {:error, [message: "Invalid token", missing_claims: missing_claims]} ->
+        msg = "Missing JWT claims #{inspect(missing_claims)}"
+        Logging.log_error_message(:error, "InvalidJWTToken", msg)
+
+      {:error, [message: "Invalid token", claim: claim, claim_val: _value]} ->
+        msg = "Invalid value for JWT claim #{claim}"
         Logging.log_error_message(:error, "InvalidJWTToken", msg)
 
       {:error, :too_many_channels} ->

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -94,10 +94,6 @@ defmodule RealtimeWeb.RealtimeChannel do
 
       {:ok, state, assign(socket, assigns)}
     else
-      {:error, [message: "Invalid token", missing_claims: missing_claims]} ->
-        msg = "Missing JWT claims #{inspect(missing_claims)}"
-        Logging.log_error_message(:error, "InvalidJWTToken", msg)
-
       {:error, [message: "Invalid token", claim: claim, claim_val: _value]} ->
         msg = "Invalid value for JWT claim #{claim}"
         Logging.log_error_message(:error, "InvalidJWTToken", msg)

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -95,7 +95,7 @@ defmodule RealtimeWeb.RealtimeChannel do
       {:ok, state, assign(socket, assigns)}
     else
       {:error, [message: "Invalid token", claim: claim, claim_val: _value]} ->
-        msg = "Invalid value for JWT claim #{claim}"
+        msg = "Invalid value for JWT claim #{inspect(claim)}"
         Logging.log_error_message(:error, "InvalidJWTToken", msg)
 
       {:error, :too_many_channels} ->

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -248,8 +248,8 @@ defmodule RealtimeWeb.RealtimeChannel do
            pg_change_params: pg_change_params
          })}
 
-      {:error, error} when is_binary(error) ->
-        shutdown_response(socket, error)
+      {:error, :missing_claims} ->
+        shutdown_response(socket, "Fields `role` and `exp` are required in JWT")
 
       {:error, error} ->
         message = "Access token has expired: " <> Helpers.to_log(error)

--- a/lib/realtime_web/channels/user_socket.ex
+++ b/lib/realtime_web/channels/user_socket.ex
@@ -77,11 +77,16 @@ defmodule RealtimeWeb.UserSocket do
       else
         nil ->
           log_error("TenantNotFound", "Tenant not found: #{external_id}")
-          :error
+          {:error, :tenant_not_found}
+
+        {:error, :missing_claims} ->
+          log_error("InvalidJWTToken", "Fields `role` and `exp` are required in JWT")
+          {:error, :missing_claims}
 
         error ->
+          IO.inspect(error)
           log_error("ErrorConnectingToWebsocket", error)
-          :error
+          error
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.27",
+      version: "2.30.28",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/channels/auth/channels_authorization_test.exs
+++ b/test/realtime_web/channels/auth/channels_authorization_test.exs
@@ -2,6 +2,7 @@ defmodule RealtimeWeb.ChannelsAuthorizationTest do
   use ExUnit.Case
 
   import Mock
+  import Generators
 
   alias RealtimeWeb.{ChannelsAuthorization, JwtVerification}
 
@@ -28,5 +29,12 @@ defmodule RealtimeWeb.ChannelsAuthorizationTest do
 
   test "authorize/3 when token is not a string" do
     assert :error = ChannelsAuthorization.authorize([], @secret, nil)
+  end
+
+  test "authorize_conn/3 fails when has missing headers" do
+    jwt = generate_jwt_token(@secret, %{})
+
+    assert {:error, :missing_claims} =
+             ChannelsAuthorization.authorize_conn(jwt, @secret, nil)
   end
 end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -194,4 +194,11 @@ defmodule Generators do
     WITH CHECK ( realtime.topic() = '#{name}' AND realtime.messages.extension IN ('presence', 'broadcast') );
     """
   end
+
+  def generate_jwt_token(secret, claims) do
+    signer = Joken.Signer.create("HS256", secret)
+    {:ok, claims} = Joken.generate_claims(%{}, claims)
+    {:ok, jwt, _} = Joken.encode_and_sign(claims, signer)
+    jwt
+  end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improve invalid JWT logs by informing the user of:
* missing claims of the JWT token provided
* inform with claim as a unexpected value