### PR TITLE
fix: Add new healthcheck for infrastructure

### DIFF
--- a/lib/realtime_web/controllers/page_controller.ex
+++ b/lib/realtime_web/controllers/page_controller.ex
@@ -4,4 +4,10 @@ defmodule RealtimeWeb.PageController do
   def index(conn, _params) do
     render(conn, "index.html")
   end
+
+  def healthcheck(conn, _params) do
+    conn
+    |> put_status(:ok)
+    |> text("ok")
+  end
 end

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -46,6 +46,10 @@ defmodule RealtimeWeb.Router do
   end
 
   scope "/", RealtimeWeb do
+    get("/healthcheck", PageController, :healthcheck)
+  end
+
+  scope "/", RealtimeWeb do
     pipe_through(:browser)
 
     live("/", PageLive.Index, :index)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.30.35",
+      version: "2.30.36",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a new healtcheck for infrastructure to check the status of the service with less impact to the system.

The current healtcheck actually goes through a LiveView which could be impactful.


