### PR TITLE
fix: Add new view to fetch process dumps

### DIFF
--- a/lib/realtime/operations.ex
+++ b/lib/realtime/operations.ex
@@ -98,9 +98,4 @@ defmodule Realtime.Operations do
       # credo:disable-for-next-line
       IO.inspect({"Failed to stop", tenant, kind, reason})
   end
-
-  def dump_processes do
-    term = Process.list() |> Enum.map(&Process.info/1) |> :erlang.term_to_binary()
-    File.write!("/tmp/erlang_process_dump.csv", term)
-  end
 end

--- a/lib/realtime_web/dashboard/process_dump.ex
+++ b/lib/realtime_web/dashboard/process_dump.ex
@@ -1,0 +1,40 @@
+defmodule Realtime.Dashboard.ProcessDump do
+  @moduledoc """
+  Live Dashboard page to dump the current processes tree
+  """
+  use Phoenix.LiveDashboard.PageBuilder
+
+  @impl true
+  def menu_link(_, _) do
+    {:ok, "Process Dump"}
+  end
+
+  @impl true
+  def mount(_, _, socket) do
+    ts = :os.system_time(:millisecond)
+    name = "process_dump_#{ts}"
+    content = dump_processes(name)
+    {:ok, socket |> assign(content: content) |> assign(name: name)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="prose">
+      <h1>Process Dump</h1>
+      <a download={"#{@name}.tar.gz"} href={"data:application/x-compressed;base64,#{@content}"}>
+        Download
+      </a>
+      <br />After you untar the file, you can use `File.read!("filename") |> :erlang.binary_to_term` to check the contents
+    </div>
+    """
+  end
+
+  defp dump_processes(name) do
+    term = Process.list() |> Enum.map(&Process.info/1) |> :erlang.term_to_binary()
+    path = "/tmp/#{name}"
+    File.write!(path, term)
+    System.cmd("tar", ["-czf", "#{path}.tar.gz", path])
+    "#{path}.tar.gz" |> File.read!() |> Base.encode64()
+  end
+end

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -129,7 +129,10 @@ defmodule RealtimeWeb.Router do
         Realtime.Repo.Replica.SJC
       ],
       ecto_psql_extras_options: [long_running_queries: [threshold: "200 milliseconds"]],
-      metrics: RealtimeWeb.Telemetry
+      metrics: RealtimeWeb.Telemetry,
+      additional_pages: [
+        route_name: Realtime.Dashboard.ProcessDump
+      ]
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.32.4",
+      version: "2.32.5",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add new view to fetch process dumps
