### PR TITLE
fix: Use proper RPC timeouts

### DIFF
--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -218,10 +218,7 @@ defmodule Realtime.Database do
     do: transaction_catched(db_conn, func, opts)
 
   def transaction(db_conn, func, opts),
-    do:
-      Rpc.enhanced_call(node(db_conn), __MODULE__, :transaction, [db_conn, func, opts],
-        timeout: 15_000
-      )
+    do: Rpc.enhanced_call(node(db_conn), __MODULE__, :transaction, [db_conn, func, opts])
 
   defp transaction_catched(db_conn, func, opts) do
     Postgrex.transaction(db_conn, func, opts)

--- a/lib/realtime/operations.ex
+++ b/lib/realtime/operations.ex
@@ -33,9 +33,7 @@ defmodule Realtime.Operations do
     [node() | Node.list()]
     |> Task.async_stream(
       fn node ->
-        Rpc.enhanced_call(node, __MODULE__, :kill_connections_to_tenant_id, [tenant_id, reason],
-          timeout: 5000
-        )
+        Rpc.enhanced_call(node, __MODULE__, :kill_connections_to_tenant_id, [tenant_id, reason])
       end,
       timeout: 5000
     )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.32.5",
+      version: "2.32.6",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use proper RPC timeouts as this situations can still create some undesirable RPC errors calls and clash with Postgrex connection issues.