### PR TITLE
fix: Improve migration resiliency

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -75,7 +75,10 @@ defmodule Realtime.Tenants do
           res = Postgrex.query!(transaction_conn, query, [])
 
           if res.rows == [] do
-            Migrations.run_migrations(settings)
+            Migrations.run_migrations(%Migrations{
+              tenant_external_id: external_id,
+              settings: settings
+            })
           end
         end)
 
@@ -92,7 +95,10 @@ defmodule Realtime.Tenants do
           res = Postgrex.query!(transaction_conn, query, [])
 
           if res.rows == [] do
-            Migrations.run_migrations(settings)
+            Migrations.run_migrations(%Migrations{
+              tenant_external_id: external_id,
+              settings: settings
+            })
           end
         end)
 

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -98,7 +98,11 @@ defmodule Realtime.Tenants.Connect do
          {:ok, conn} <- Database.check_tenant_connection(tenant, @application_name),
          ref = Process.monitor(conn),
          [%{settings: settings} | _] <- tenant.extensions,
-         :ok <- Migrations.run_migrations(settings) do
+         :ok <-
+           Migrations.run_migrations(%Migrations{
+             tenant_external_id: tenant.external_id,
+             settings: settings
+           }) do
       :syn.update_registry(__MODULE__, tenant_id, fn _pid, meta -> %{meta | conn: conn} end)
       state = %{state | db_conn_reference: ref, db_conn_pid: conn}
       {:ok, state, {:continue, :setup_connected_user_events}}

--- a/lib/realtime/tenants/repo/migrations/20211116024918_create_realtime_subscription_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20211116024918_create_realtime_subscription_table.ex
@@ -28,7 +28,7 @@ defmodule Realtime.Tenants.Migrations.CreateRealtimeSubscriptionTable do
     END$$;
     """)
 
-    execute("create table realtime.subscription (
+    execute("create table if not exists realtime.subscription (
       -- Tracks which users are subscribed to each table
       id bigint not null generated always as identity,
       user_id uuid not null,
@@ -43,7 +43,7 @@ defmodule Realtime.Tenants.Migrations.CreateRealtimeSubscriptionTable do
     )")
 
     execute(
-      "create index ix_realtime_subscription_entity on realtime.subscription using hash (entity)"
+      "create index if not exists ix_realtime_subscription_entity on realtime.subscription using hash (entity)"
     )
   end
 end

--- a/lib/realtime/tenants/repo/migrations/20240523004032_redefine_authorization_tables.ex
+++ b/lib/realtime/tenants/repo/migrations/20240523004032_redefine_authorization_tables.ex
@@ -8,13 +8,13 @@ defmodule Realtime.Tenants.Migrations.RedefineAuthorizationTables do
     drop table(:presences, mode: :cascade)
     drop table(:channels, mode: :cascade)
 
-    create table(:messages) do
+    create_if_not_exists table(:messages) do
       add :topic, :text, null: false
       add :extension, :text, null: false
       timestamps()
     end
 
-    create index(:messages, [:topic])
+    create_if_not_exists index(:messages, [:topic])
 
     execute("ALTER TABLE realtime.messages ENABLE row level security")
     execute("GRANT SELECT ON realtime.messages TO postgres, anon, authenticated, service_role")

--- a/lib/realtime/tenants/repo/migrations/20240801235015_unlogged_messages_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20240801235015_unlogged_messages_table.ex
@@ -4,7 +4,7 @@ defmodule Realtime.Tenants.Migrations.UnloggedMessagesTable do
 
   def change do
     execute """
-    ALTER TABLE realtime.messages SET UNLOGGED;
+    -- ALTER TABLE realtime.messages SET UNLOGGED;
     """
   end
 end

--- a/lib/realtime/tenants/repo/migrations/20240805133720_logged_messages_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20240805133720_logged_messages_table.ex
@@ -4,7 +4,7 @@ defmodule Realtime.Tenants.Migrations.LoggedMessagesTable do
 
   def change do
     execute """
-    ALTER TABLE realtime.messages SET LOGGED;
+    -- ALTER TABLE realtime.messages SET LOGGED;
     """
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.32.7",
+      version: "2.32.8",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/migrations_test.exs
+++ b/test/realtime/tenants/migrations_test.exs
@@ -20,7 +20,12 @@ defmodule Realtime.Tenants.MigrationsTest do
 
       res =
         for _ <- 0..10 do
-          Task.async(fn -> Migrations.run_migrations(settings) end)
+          Task.async(fn ->
+            Migrations.run_migrations(%Migrations{
+              settings: settings,
+              tenant_external_id: tenant.external_id
+            })
+          end)
         end
         |> Task.await_many()
         |> Enum.uniq()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently we have migrations that are breaking for certain users, this improves the resiliency of said migrations. We also comment out the unlogged/logged as that is redudant
    
Also adds context to the logs when running migrations as those were missing at the moment.

