### PR TITLE
fix: include Channel topic in authz error

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -654,11 +654,11 @@ defmodule RealtimeWeb.RealtimeChannel do
     with {:ok, socket} <- Authorization.get_authorizations(socket, db_conn, authorization_context) do
       cond do
         match?(%Policies{broadcast: %BroadcastPolicies{read: false}}, socket.assigns.policies) ->
-          {:error, "You do not have permissions to read from this Topic"}
+          {:error, "You do not have permissions to read from this Channel topic: #{topic}"}
 
         using_broadcast? and
             match?(%Policies{broadcast: %BroadcastPolicies{read: false}}, socket.assigns.policies) ->
-          {:error, "You do not have permissions to read Broadcast messages from this channel"}
+          {:error, "You do not have permissions to read from this Channel topic: #{topic}"}
 
         true ->
           {:ok, socket}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.32.10",
+      version: "2.32.12",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/e2e/tests.ts
+++ b/test/e2e/tests.ts
@@ -252,7 +252,7 @@ describe("authorization check", () => {
     await stopClient(supabase, [channel]);
     assertEquals(
       result,
-      '"You do not have permissions to read from this Topic"'
+      `"You do not have permissions to read from this Channel topic: ${topic}"`
     );
   });
 

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -548,13 +548,15 @@ defmodule Realtime.Integration.RtChannelTest do
         "access_token" => new_token
       })
 
+      error_message =
+        "Received an invalid access token from client: You do not have permissions to read from this Channel topic: #{topic}"
+
       assert_receive %Phoenix.Socket.Message{
         event: "system",
         payload: %{
           "channel" => ^topic,
           "extension" => "system",
-          "message" =>
-            "Received an invalid access token from client: You do not have permissions to read from this Topic",
+          "message" => ^error_message,
           "status" => "error"
         },
         topic: ^realtime_topic


### PR DESCRIPTION
Includes Channel topic in authz error so developers can see why clients can't join a topic.