### PR TITLE
fix: Change the approach used in our healthcheck

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.32.12",
+      version: "2.32.13",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -221,9 +221,29 @@ defmodule RealtimeWeb.TenantControllerTest do
     end
 
     test "unhealthy tenant with 1 client connections", %{
-      conn: conn,
-      tenant: %Tenant{external_id: ext_id}
+      conn: conn
     } do
+      %Tenant{external_id: ext_id} =
+        tenant_fixture(%{
+          extensions: [
+            %{
+              "type" => "postgres_cdc_rls",
+              "settings" => %{
+                "db_host" => "localhost",
+                "db_name" => "false",
+                "db_user" => "false",
+                "db_password" => "false",
+                "db_port" => "5433",
+                "poll_interval" => 100,
+                "poll_max_changes" => 100,
+                "poll_max_record_bytes" => 1_048_576,
+                "region" => "us-east-1",
+                "ssl_enforced" => false
+              }
+            }
+          ]
+        })
+
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         # Fake adding a connected client here
         # No connection to the tenant database


### PR DESCRIPTION


## What kind of change does this PR introduce?

Since we were using Realtime.Tenants.Connect we would actually be creating more connections against our tenants database to check if the database was alive. This will avoid that flow and uses a simpler approach to check if the database is alive on dashboard open.
