### PR TITLE
fix: Use UUID for message identifiers

### DIFF
--- a/lib/realtime/api/message.ex
+++ b/lib/realtime/api/message.ex
@@ -8,7 +8,7 @@ defmodule Realtime.Api.Message do
   @schema_prefix "realtime"
 
   schema "messages" do
-    field :uuid, :string
+    field :uuid, :string, default: Ecto.UUID.generate()
     field :topic, :string
     field :extension, Ecto.Enum, values: [:broadcast, :presence]
     field :payload, :map

--- a/lib/realtime/broadcast_changes/handler.ex
+++ b/lib/realtime/broadcast_changes/handler.ex
@@ -278,7 +278,7 @@ defmodule Realtime.BroadcastChanges.Handler do
             {:noreply, state}
 
           payload ->
-            id = Map.fetch!(to_broadcast, "id")
+            id = Map.fetch!(to_broadcast, "uuid")
 
             to_broadcast =
               %{

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.4",
+      version: "2.33.5",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use UUID for message identifiers