### PR TITLE
Fix: detect IPv6 and use appropriate socket for Realtime.Repo

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,15 @@
 import Config
 
+detect_ip_version = fn host when is_binary(host) ->
+  host = String.to_charlist(host)
+
+  cond do
+    match?({:ok, _}, :inet6_tcp.getaddr(host)) -> {:ok, :inet6}
+    match?({:ok, _}, :inet.gethostbyname(host)) -> {:ok, :inet}
+    true -> {:error, :nxdomain}
+  end
+end
+
 config :logflare_logger_backend,
   url: System.get_env("LOGFLARE_LOGGER_BACKEND_URL", "https://api.logflare.app")
 
@@ -9,6 +19,10 @@ username = System.get_env("DB_USER", "postgres")
 password = System.get_env("DB_PASSWORD", "postgres")
 database = System.get_env("DB_NAME", "postgres")
 port = System.get_env("DB_PORT", "5432")
+socket_options = case detect_ip_version.(default_db_host) do
+  {:ok, ip_version} -> [ ip_version ]
+  {:error, reason} -> raise "Failed to detect IP version for DB_HOST: #{reason}"
+end
 slot_name_suffix = System.get_env("SLOT_NAME_SUFFIX")
 
 config :realtime,
@@ -114,6 +128,7 @@ if config_env() != :test do
     password: password,
     database: database,
     port: port,
+    socket_options: socket_options,
     pool_size: System.get_env("DB_POOL_SIZE", "5") |> String.to_integer(),
     queue_target: queue_target,
     queue_interval: queue_interval,
@@ -191,6 +206,7 @@ cluster_topologies =
               password: password,
               database: database,
               port: port,
+              socket_options: socket_options,
               parameters: [
                 application_name: "cluster_node_#{node()}"
               ],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -19,10 +19,13 @@ username = System.get_env("DB_USER", "postgres")
 password = System.get_env("DB_PASSWORD", "postgres")
 database = System.get_env("DB_NAME", "postgres")
 port = System.get_env("DB_PORT", "5432")
-socket_options = case detect_ip_version.(default_db_host) do
-  {:ok, ip_version} -> [ ip_version ]
-  {:error, reason} -> raise "Failed to detect IP version for DB_HOST: #{reason}"
-end
+
+socket_options =
+  case detect_ip_version.(default_db_host) do
+    {:ok, ip_version} -> [ip_version]
+    {:error, reason} -> raise "Failed to detect IP version for DB_HOST: #{reason}"
+  end
+
 slot_name_suffix = System.get_env("SLOT_NAME_SUFFIX")
 
 config :realtime,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.18",
+      version: "2.33.19",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change allows to use a `DB_HOST` connected via IPv6.

## What is the current behavior?

When the `DB_HOST` resolves to an IPv6, connecting to the database fails with `:nxdomain`.

## What is the new behavior?

The connection is established successfully.

## Additional context

Uses logic from `Realtime.Database.detect_ip_version/1` and applies it to the `Realtime.Repo` `socket_options`, too. Unfortunately, I was not able to directly call `Realtime.Database.detect_ip_version/1` from `runtime.exs`. I am an Elixir newbie, so there may be a more elegant way.

