### PR TITLE
fix: Properly handle error on handle_continue

### DIFF
--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -180,7 +180,7 @@ defmodule Realtime.Tenants.Connect do
 
       error ->
         log_error("UnableToStartHandler", error)
-        {:stop, :shutdown}
+        {:stop, :shutdown, state}
     end
   end
 
@@ -218,7 +218,10 @@ defmodule Realtime.Tenants.Connect do
       ) do
     Logger.info("Tenant has no connected users, database connection will be terminated")
     :ok = GenServer.stop(db_conn_pid, :normal, 500)
-    broadcast_changes_pid && GenServer.stop(broadcast_changes_pid, :normal, 500)
+
+    broadcast_changes_pid && Process.alive?(broadcast_changes_pid) &&
+      GenServer.stop(broadcast_changes_pid, :normal, 500)
+
     {:stop, :normal, state}
   end
 
@@ -228,7 +231,10 @@ defmodule Realtime.Tenants.Connect do
       ) do
     Logger.warning("Tenant was suspended, database connection will be terminated")
     :ok = GenServer.stop(db_conn_pid, :normal, 500)
-    broadcast_changes_pid && GenServer.stop(broadcast_changes_pid, :normal, 500)
+
+    broadcast_changes_pid && Process.alive?(broadcast_changes_pid) &&
+      GenServer.stop(broadcast_changes_pid, :normal, 500)
+
     {:stop, :normal, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.5",
+      version: "2.33.6",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/broadcast_changes/handler_test.exs
+++ b/test/realtime/broadcast_changes/handler_test.exs
@@ -12,7 +12,6 @@ defmodule Realtime.BroadcastChanges.HandlerTest do
   alias Realtime.Tenants.Migrations
 
   setup do
-    Application.put_env(:realtime, :slot_name_suffix, random_string())
     start_supervised(Realtime.Tenants.CacheSupervisor)
     tenant = tenant_fixture()
     [%{settings: settings} | _] = tenant.extensions


### PR DESCRIPTION
## What kind of change does this PR introduce?

Trying to stop process that is dead leads to error => `** (stop) exited in: GenServer.stop(#PID<0.43330.0>, :normal, 500)`
handle_continue does not shutdown properly => `** (stop) bad return value: {:stop, :shutdown}`
