### PR TITLE
fix: partition Connect DynamicSupervisors correctly

### DIFF
--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -102,7 +102,7 @@ defmodule Extensions.PostgresCdcRls do
     Logger.debug("Starting #{__MODULE__} extension with args: #{inspect(args, pretty: true)}")
 
     DynamicSupervisor.start_child(
-      {:via, PartitionSupervisor, {Rls.DynamicSupervisor, self()}},
+      {:via, PartitionSupervisor, {Rls.DynamicSupervisor, tenant}},
       %{
         id: tenant,
         start: {Rls.WorkerSupervisor, :start_link, [args]},

--- a/lib/extensions/postgres_cdc_stream/cdc_stream.ex
+++ b/lib/extensions/postgres_cdc_stream/cdc_stream.ex
@@ -90,7 +90,7 @@ defmodule Extensions.PostgresCdcStream do
     Logger.debug("Starting #{__MODULE__} extension with args: #{inspect(args, pretty: true)}")
 
     DynamicSupervisor.start_child(
-      {:via, PartitionSupervisor, {Stream.DynamicSupervisor, self()}},
+      {:via, PartitionSupervisor, {Stream.DynamicSupervisor, tenant}},
       %{
         id: tenant,
         start: {Stream.WorkerSupervisor, :start_link, [args]},

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -98,7 +98,9 @@ defmodule Realtime.Tenants.Connect do
   """
   @spec connect(binary(), keyword()) :: {:ok, DBConnection.t()} | {:error, term()}
   def connect(tenant_id, opts \\ []) do
-    supervisor = {:via, PartitionSupervisor, {Realtime.Tenants.Connect.DynamicSupervisor, self()}}
+    supervisor =
+      {:via, PartitionSupervisor, {Realtime.Tenants.Connect.DynamicSupervisor, tenant_id}}
+
     spec = {__MODULE__, [tenant_id: tenant_id] ++ opts}
 
     case DynamicSupervisor.start_child(supervisor, spec) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.16",
+      version: "2.33.17",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- Connect process should start on the same partition for a `tenant_id` now
- Found in CdcRls and CdcStream too