### PR TITLE
fix: Stop SSL warning

### DIFF
--- a/lib/realtime/broadcast_changes/handler.ex
+++ b/lib/realtime/broadcast_changes/handler.ex
@@ -70,7 +70,7 @@ defmodule Realtime.BroadcastChanges.Handler do
 
     ssl =
       if connection_opts.ssl_enforced,
-        do: [ssl: true, ssl_opts: [verify: :verify_none]],
+        do: [ssl: [verify: :verify_none]],
         else: [ssl: false]
 
     connection_opts =

--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -179,7 +179,7 @@ defmodule Realtime.Database do
   end
 
   defp enforce_ssl_config(db_config) when is_list(db_config) do
-    db_config ++ [ssl: true, ssl_opts: [verify: :verify_none]]
+    db_config ++ [ssl: [verify: :verify_none]]
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.20",
+      version: "2.33.21",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes warning by not verifying peer certificate. Removes ssl_opts based on Postgrex starting opts https://hexdocs.pm/postgrex/Postgrex.html#t:start_option/0 