### PR TITLE
fix: Janitor set to use ETS to reduce load on Database

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -48,6 +48,7 @@ defmodule Realtime.Application do
 
     region = Application.get_env(:realtime, :region)
     :syn.join(RegionNodes, region, self(), node: node())
+    :ets.new(:active_tenants, [:named_table, :set, :public])
 
     children =
       [

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -4,6 +4,7 @@ defmodule Realtime.Tenants do
   """
 
   require Logger
+
   alias Realtime.Tenants.Migrations
   alias Realtime.Api.Tenant
   alias Realtime.Tenants.Connect
@@ -285,6 +286,32 @@ defmodule Realtime.Tenants do
     |> Tenant.management_changeset(attrs)
     |> Repo.update!()
     |> tap(fn _ -> Cache.distributed_invalidate_tenant_cache(tenant_id) end)
+  end
+
+  @doc """
+  Tracks the active tenant by external_id and stores the time when it was tracked in the ETS table named `:active_tenants`.
+  """
+  @spec track_active_tenant(String.t()) :: :ok
+  def track_active_tenant(external_id) do
+    :ets.insert(:active_tenants, {external_id, NaiveDateTime.utc_now()})
+    :ok
+  end
+
+  @doc """
+  Lists all active tenants from the ETS table named `:active_tenants`.
+  """
+  @spec track_active_tenant(String.t()) :: list({String.t(), NaiveDateTime.t()})
+  def list_active_tenants() do
+    :ets.tab2list(:active_tenants)
+  end
+
+  @doc """
+  Untracks the active tenant by external_id from the ETS table named `:active_tenants`.
+  """
+  @spec untrack_active_tenant(String.t()) :: :ok
+  def untrack_active_tenant(external_id) do
+    :ets.delete(:active_tenants, external_id)
+    :ok
   end
 
   defp broadcast_operation_event(action, external_id) do

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -115,7 +115,7 @@ defmodule Realtime.Tenants.Connect do
   def shutdown(tenant_id) do
     case get_status(tenant_id) do
       {:ok, conn} ->
-        Process.exit(conn, :kill)
+        GenServer.stop(conn)
         {:ok, :shutdown}
 
       _ ->
@@ -167,8 +167,10 @@ defmodule Realtime.Tenants.Connect do
       connected_users_bucket: connected_users_bucket
     } = state
 
+    Tenants.track_active_tenant(state.tenant_id)
     :ok = Phoenix.PubSub.subscribe(Realtime.PubSub, "realtime:operations:invalidate_cache")
     send_connected_user_check_message(connected_users_bucket, check_connected_user_interval)
+
     {:noreply, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.26",
+      version: "2.33.27",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -7,7 +7,6 @@ defmodule Realtime.Integration.RtChannelTest do
 
   require Logger
 
-  alias Ecto.Adapters.SQL.Sandbox
   alias Extensions.PostgresCdcRls, as: Rls
   alias Phoenix.Socket.{V1, Message}
   alias Postgrex, as: P
@@ -80,7 +79,6 @@ defmodule Realtime.Integration.RtChannelTest do
   end
 
   setup_all do
-    Sandbox.mode(Realtime.Repo, {:shared, self()})
     capture_log(fn -> start_supervised!(Endpoint) end)
     start_supervised!({Phoenix.PubSub, name: __MODULE__})
     :ok
@@ -892,7 +890,8 @@ defmodule Realtime.Integration.RtChannelTest do
 
   def setup_trigger(%{tenant: tenant, topic: topic} = context) do
     Realtime.Tenants.Connect.shutdown(@external_id)
-    :timer.sleep(1000)
+    :timer.sleep(500)
+
     {:ok, db_conn} = Realtime.Tenants.Connect.connect(@external_id)
 
     random_name = String.downcase("test_#{random_string()}")
@@ -930,7 +929,8 @@ defmodule Realtime.Integration.RtChannelTest do
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", 1)
       query = "DROP TABLE #{random_name} CASCADE"
       Postgrex.query!(db_conn, query, [])
-      Realtime.Tenants.Connect.shutdown(@external_id)
+      Realtime.Tenants.Connect.shutdown(db_conn)
+
       :timer.sleep(500)
     end)
 

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -1,9 +1,11 @@
 defmodule Realtime.Tenants.ConnectTest do
   # async: false due to the fact that multiple operations against the database will use the same connection
+  alias Realtime.Tenants
   use Realtime.DataCase, async: false
 
   import Mock
-
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Realtime.Repo
   alias Realtime.Tenants.Connect
   alias Realtime.UsersCounter
 
@@ -15,10 +17,16 @@ defmodule Realtime.Tenants.ConnectTest do
 
     test "if tenant exists and connected, returns the db connection", %{tenant: tenant} do
       assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-
-      on_exit(fn -> Process.exit(db_conn, :shutdown) end)
-
+      Sandbox.allow(Repo, self(), db_conn)
+      :timer.sleep(100)
       assert is_pid(db_conn)
+    end
+
+    test "on connect, tracks tenant as active", %{tenant: tenant} do
+      assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
+      :timer.sleep(200)
+
+      assert Enum.find(Tenants.list_active_tenants(), &(elem(&1, 0) == tenant.external_id))
     end
 
     test "on database disconnect, returns new connection", %{tenant: tenant} do
@@ -53,7 +61,7 @@ defmodule Realtime.Tenants.ConnectTest do
         }
       ]
 
-      tenant = tenant_fixture(%{"extensions" => extensions})
+      tenant = tenant_fixture(%{extensions: extensions})
 
       assert {:error, :tenant_database_unavailable} =
                Connect.lookup_or_start_connection(tenant.external_id)
@@ -69,6 +77,7 @@ defmodule Realtime.Tenants.ConnectTest do
       {:ok, db_conn} =
         Connect.lookup_or_start_connection(tenant_id, check_connected_user_interval: 50)
 
+      Sandbox.allow(Repo, self(), db_conn)
       # Not enough time has passed, connection still alive
       :timer.sleep(100)
       assert {_, %{conn: _}} = :syn.lookup(Connect, tenant_id)
@@ -87,7 +96,7 @@ defmodule Realtime.Tenants.ConnectTest do
       {:ok, db_conn} =
         Connect.lookup_or_start_connection(tenant_id, check_connected_user_interval: 10)
 
-      on_exit(fn -> Process.exit(db_conn, :shutdown) end)
+      Sandbox.allow(Repo, self(), db_conn)
 
       assert {pid, %{conn: conn_pid}} = :syn.lookup(Connect, tenant_id)
       :timer.sleep(300)
@@ -121,17 +130,21 @@ defmodule Realtime.Tenants.ConnectTest do
       tenant = tenant_fixture()
 
       assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-      Realtime.Tenants.suspend_tenant_by_external_id(tenant.external_id)
+      Sandbox.allow(Repo, self(), db_conn)
 
-      :timer.sleep(200)
+      :timer.sleep(100)
+      Realtime.Tenants.suspend_tenant_by_external_id(tenant.external_id)
+      :timer.sleep(500)
+
       assert {:error, :tenant_suspended} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Process.alive?(db_conn) == false
 
       Realtime.Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
+      :timer.sleep(50)
 
-      :timer.sleep(200)
       assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-      on_exit(fn -> Process.exit(db_conn, :shutdown) end)
+      Sandbox.allow(Repo, self(), db_conn)
+      :timer.sleep(100)
     end
 
     test "properly handles of failing calls by avoid creating too many connections" do
@@ -167,21 +180,12 @@ defmodule Realtime.Tenants.ConnectTest do
       refute_receive :too_many_connections
     end
 
-    test "on migrations failure, process is alive", %{tenant: tenant} do
-      with_mock Ecto.Migrator, [:passthrough], run: fn _, _, _, _ -> nil end do
-        assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-
-        assert_called(Ecto.Migrator.run(:_, :_, :_, :_))
-        assert Process.alive?(db_conn) == true
-      end
-    end
-
     test "on migrations failure, stop the process", %{tenant: tenant} do
-      with_mock Ecto.Migrator, [], run: fn _, _, _, _ -> raise("error") end do
+      with_mock Realtime.Tenants.Migrations, [], run_migrations: fn _ -> raise("error") end do
         assert {:error, :tenant_database_unavailable} =
                  Connect.lookup_or_start_connection(tenant.external_id)
 
-        assert_called(Ecto.Migrator.run(:_, :_, :_, :_))
+        assert_called(Realtime.Tenants.Migrations.run_migrations(:_))
       end
     end
 
@@ -189,6 +193,8 @@ defmodule Realtime.Tenants.ConnectTest do
       tenant = tenant_fixture(%{notify_private_alpha: true})
 
       assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+      Sandbox.allow(Repo, self(), db_conn)
+      :timer.sleep(100)
       assert Process.alive?(db_conn)
       assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Process.alive?(db_conn)

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -163,7 +163,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
         }
       ]
 
-      tenant = tenant_fixture(%{"extensions" => extensions})
+      tenant = tenant_fixture(%{extensions: extensions})
 
       conn_opts = [
         connect_info: %{

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -132,7 +132,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
       start_supervised(Realtime.RateCounter.DynamicSupervisor)
       start_supervised(Realtime.GenCounter.DynamicSupervisor)
 
-      tenant = tenant_fixture(%{"max_events_per_second" => 1})
+      tenant = tenant_fixture(%{max_events_per_second: 1})
       GenCounter.new(Tenants.events_per_second_key(tenant.external_id))
 
       conn =

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -35,6 +35,8 @@ defmodule Realtime.DataCase do
       Sandbox.mode(Realtime.Repo, {:shared, self()})
     end
 
+    :ets.match_delete(:active_tenants, :_)
+
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Current implementation was using a more complex query that would load RDS too much. This approach focuses on using ETS and it will determine which databases with the following flow:
* On Connect, tenant will be registered in ETS as active with {tenant.external_id, DateTime.utc_now()}
* Janitor periodically will fetch the ETS entries, chunk them and run a cleanup
* On each tenant cleanup, we will untrack the user by deleting their entry from ETS

