### PR TITLE
fix: Run migrations only when necessary

### DIFF
--- a/lib/realtime/tenants/connect/migrations.ex
+++ b/lib/realtime/tenants/connect/migrations.ex
@@ -4,17 +4,10 @@ defmodule Realtime.Tenants.Connect.Migrations do
   """
   @behaviour Realtime.Tenants.Connect.Piper
   alias Realtime.Tenants.Migrations
-  alias Realtime.Tenants.Cache
-  @impl true
-  def run(acc) do
-    %{tenant_id: tenant_id} = acc
-    tenant = Cache.get_tenant_by_external_id(tenant_id)
-    [%{settings: settings} | _] = tenant.extensions
-    migrations = %Migrations{tenant_external_id: tenant.external_id, settings: settings}
 
-    case Migrations.run_migrations(migrations) do
-      :ok -> {:ok, acc}
-      {:error, error} -> {:error, error}
-    end
+  @impl true
+  def run(%{db_conn_pid: db_conn_pid, tenant_id: tenant_id} = acc) do
+    {:ok, _} = Migrations.maybe_run_migrations(db_conn_pid, tenant_id)
+    {:ok, acc}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.27",
+      version: "2.33.28",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -181,11 +181,12 @@ defmodule Realtime.Tenants.ConnectTest do
     end
 
     test "on migrations failure, stop the process", %{tenant: tenant} do
-      with_mock Realtime.Tenants.Migrations, [], run_migrations: fn _ -> raise("error") end do
+      with_mock Realtime.Tenants.Migrations, [],
+        maybe_run_migrations: fn _, _ -> raise("error") end do
         assert {:error, :tenant_database_unavailable} =
                  Connect.lookup_or_start_connection(tenant.external_id)
 
-        assert_called(Realtime.Tenants.Migrations.run_migrations(:_))
+        assert_called(Realtime.Tenants.Migrations.maybe_run_migrations(:_, :_))
       end
     end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Run migrations only when necessary