### PR TITLE
hotfix: Prevent migrations to run everytime

### DIFF
--- a/.github/workflows/manual_prod_build.yml
+++ b/.github/workflows/manual_prod_build.yml
@@ -1,0 +1,128 @@
+name: Manual Build Production
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to run the workflow"
+        required: true
+      docker_tag:
+        description: "Tag to be used by the docker image on push"
+        required: true
+jobs:
+  docker_x86_release:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 120
+    env:
+      arch: amd64
+    outputs:
+      image_digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            supabase/realtime
+          tags: |
+            type=raw,value=v${{ github.event.inputs.docker_tag }}_${{ env.arch }}
+
+      - uses: docker/setup-buildx-action@v2
+
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - id: build
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ env.arch }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker_arm_release:
+    runs-on: arm-runner
+    timeout-minutes: 120
+    env:
+      arch: arm64
+    outputs:
+      image_digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            supabase/realtime
+          tags: |
+            type=raw,value=v${{ github.event.inputs.docker_tag }}_${{ env.arch }}
+
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
+          driver-opts: |
+            image=moby/buildkit:master
+            network=host
+
+      - id: build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ env.arch }}
+          no-cache: true
+
+  merge_manifest:
+    needs: [docker_x86_release, docker_arm_release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: docker/setup-buildx-action@v2
+
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Merge multi-arch manifests for custom output
+        run: |
+          docker buildx imagetools create -t supabase/realtime:v${{ github.event.inputs.docker_tag }} \
+          supabase/realtime@${{ needs.docker_x86_release.outputs.image_digest }} \
+          supabase/realtime@${{ needs.docker_arm_release.outputs.image_digest }}
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror to ECR
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: docker.io/supabase/realtime:v${{ github.event.inputs.docker_tag }}
+          dst: |
+            public.ecr.aws/supabase/realtime:v${{ github.event.inputs.docker_tag }}
+            ghcr.io/supabase/realtime:v${{ github.event.inputs.docker_tag }}

--- a/lib/realtime/broadcast_changes/handler.ex
+++ b/lib/realtime/broadcast_changes/handler.ex
@@ -70,7 +70,7 @@ defmodule Realtime.BroadcastChanges.Handler do
 
     ssl =
       if connection_opts.ssl_enforced,
-        do: [ssl: true, ssl_opts: [verify: :verify_none]],
+        do: [ssl: [verify: :verify_none]],
         else: [ssl: false]
 
     connection_opts =

--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -179,7 +179,7 @@ defmodule Realtime.Database do
   end
 
   defp enforce_ssl_config(db_config) when is_list(db_config) do
-    db_config ++ [ssl: true, ssl_opts: [verify: :verify_none]]
+    db_config ++ [ssl: [verify: :verify_none]]
   end
 
   @doc """

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -66,44 +66,13 @@ defmodule Realtime.Tenants do
 
       {:ok, health_conn} ->
         connected_cluster = UsersCounter.tenant_users(external_id)
-        %{extensions: [%{settings: settings} | _]} = Cache.get_tenant_by_external_id(external_id)
-
-        query =
-          "select * from pg_catalog.pg_tables where schemaname = 'realtime' and tablename = 'schema_migrations';"
-
-        Database.transaction(health_conn, fn transaction_conn ->
-          res = Postgrex.query!(transaction_conn, query, [])
-
-          if res.rows == [] do
-            Migrations.run_migrations(%Migrations{
-              tenant_external_id: external_id,
-              settings: settings
-            })
-          end
-        end)
-
+        Migrations.maybe_run_migrations(health_conn, external_id)
         {:ok, %{healthy: true, db_connected: true, connected_cluster: connected_cluster}}
 
       connected_cluster when is_integer(connected_cluster) ->
         tenant = Cache.get_tenant_by_external_id(external_id)
         {:ok, db_conn} = Database.connect(tenant, "realtime_health_check", 1)
-
-        Database.transaction(db_conn, fn transaction_conn ->
-          query =
-            "select * from pg_catalog.pg_tables where schemaname = 'realtime' and tablename = 'schema_migrations';"
-
-          res = Postgrex.query!(transaction_conn, query, [])
-
-          if res.rows == [] do
-            %{extensions: [%{settings: settings} | _]} = tenant
-
-            Migrations.run_migrations(%Migrations{
-              tenant_external_id: external_id,
-              settings: settings
-            })
-          end
-        end)
-
+        Migrations.maybe_run_migrations(db_conn, external_id)
         Process.alive?(db_conn) && GenServer.stop(db_conn)
         {:ok, %{healthy: true, db_connected: false, connected_cluster: connected_cluster}}
     end

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -33,7 +33,7 @@ defmodule Realtime.Tenants do
   ## Examples
 
       iex> Realtime.Tenants.get_health_conn(%Realtime.Api.Tenant{external_id: "not_found_tenant"})
-      {:error, :tenant_database_connection_initializing}
+      {:error, :tenant_database_unavailable}
   """
 
   @spec get_health_conn(Tenant.t()) :: {:error, term()} | {:ok, pid()}

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -51,18 +51,9 @@ defmodule Realtime.Tenants.Connect do
           {:ok, DBConnection.t()} | {:error, term()}
   def lookup_or_start_connection(tenant_id, opts \\ []) do
     case get_status(tenant_id) do
-      {:ok, conn} ->
-        {:ok, conn}
-
-      {:error, :tenant_database_unavailable} ->
-        call_external_node(tenant_id, opts)
-
-      {:error, :tenant_database_connection_initializing} ->
-        :timer.sleep(100)
-        call_external_node(tenant_id, opts)
-
-      {:error, :initializing} ->
-        {:error, :tenant_database_unavailable}
+      {:ok, conn} -> {:ok, conn}
+      {:error, :tenant_database_unavailable} -> call_external_node(tenant_id, opts)
+      {:error, :initializing} -> {:error, :tenant_database_unavailable}
     end
   end
 
@@ -82,10 +73,6 @@ defmodule Realtime.Tenants.Connect do
 
       {_, %{conn: nil}} ->
         {:error, :initializing}
-
-      :undefined ->
-        Logger.warning("Connection process starting up")
-        {:error, :tenant_database_connection_initializing}
 
       error ->
         log_error("SynInitializationError", error)

--- a/lib/realtime/tenants/connect/migrations.ex
+++ b/lib/realtime/tenants/connect/migrations.ex
@@ -5,16 +5,10 @@ defmodule Realtime.Tenants.Connect.Migrations do
   @behaviour Realtime.Tenants.Connect.Piper
   alias Realtime.Tenants.Migrations
   alias Realtime.Tenants.Cache
-  @impl true
-  def run(acc) do
-    %{tenant_id: tenant_id} = acc
-    tenant = Cache.get_tenant_by_external_id(tenant_id)
-    [%{settings: settings} | _] = tenant.extensions
-    migrations = %Migrations{tenant_external_id: tenant.external_id, settings: settings}
 
-    case Migrations.run_migrations(migrations) do
-      :ok -> {:ok, acc}
-      {:error, error} -> {:error, error}
-    end
+  @impl true
+  def run(%{db_conn_pid: db_conn_pid, tenant_id: tenant_id} = acc) do
+    {:ok, _} = Migrations.maybe_run_migrations(db_conn_pid, tenant_id)
+    {:ok, acc}
   end
 end

--- a/lib/realtime/tenants/connect/migrations.ex
+++ b/lib/realtime/tenants/connect/migrations.ex
@@ -4,7 +4,6 @@ defmodule Realtime.Tenants.Connect.Migrations do
   """
   @behaviour Realtime.Tenants.Connect.Piper
   alias Realtime.Tenants.Migrations
-  alias Realtime.Tenants.Cache
 
   @impl true
   def run(%{db_conn_pid: db_conn_pid, tenant_id: tenant_id} = acc) do

--- a/lib/realtime/tenants/connect/start_counters.ex
+++ b/lib/realtime/tenants/connect/start_counters.ex
@@ -33,7 +33,7 @@ defmodule Realtime.Tenants.Connect.StartCounters do
       telemetry: %{
         event_name: [:channel, :joins],
         measurements: %{limit: max_joins_per_second},
-        metadata: %{tenant: tenant}
+        metadata: %{tenant: tenant.external_id}
       }
     )
   end
@@ -50,7 +50,7 @@ defmodule Realtime.Tenants.Connect.StartCounters do
       telemetry: %{
         event_name: [:channel, :events],
         measurements: %{limit: max_events_per_second},
-        metadata: %{tenant: tenant}
+        metadata: %{tenant: tenant.external_id}
       }
     )
   end
@@ -64,7 +64,7 @@ defmodule Realtime.Tenants.Connect.StartCounters do
       telemetry: %{
         event_name: [:channel, :db_events],
         measurements: %{},
-        metadata: %{tenant: tenant}
+        metadata: %{tenant: tenant.external_id}
       }
     )
   end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -10,8 +10,9 @@ defmodule Realtime.Tenants.Migrations do
 
   alias Realtime.Crypto
   alias Realtime.Database
-  alias Realtime.Repo
   alias Realtime.Registry.Unique
+  alias Realtime.Repo
+  alias Realtime.Tenants.Cache
 
   alias Realtime.Tenants.Migrations.{
     CreateRealtimeSubscriptionTable,
@@ -179,6 +180,28 @@ defmodule Realtime.Tenants.Migrations do
         error ->
           log_error("MigrationsFailedToRun", error)
           {:error, error}
+      end
+    end)
+  end
+
+  @expected_migration_count length(@migrations)
+  @doc """
+  Checks if the number of migrations ran in the database is equal to the expected number of migrations.
+  If not all migrations have been run, it will run the missing migrations.
+  """
+  @spec maybe_run_migrations(pid(), String.t()) :: {:ok, any()} | {:error, any()}
+  def maybe_run_migrations(db_conn, tenant_external_id) do
+    query =
+      "select * from pg_catalog.pg_tables where schemaname = 'realtime' and tablename = 'schema_migrations';"
+
+    %{extensions: [%{settings: settings} | _]} =
+      Cache.get_tenant_by_external_id(tenant_external_id)
+
+    Database.transaction(db_conn, fn transaction_conn ->
+      %{num_rows: num_rows} = Postgrex.query!(transaction_conn, query, [])
+
+      if num_rows < @expected_migration_count do
+        run_migrations(%__MODULE__{tenant_external_id: tenant_external_id, settings: settings})
       end
     end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.18",
+      version: "2.33.18.hotfix.4",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.18.hotfix.4",
+      version: "2.33.18-hotfix.4",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -177,11 +177,12 @@ defmodule Realtime.Tenants.ConnectTest do
     end
 
     test "on migrations failure, stop the process", %{tenant: tenant} do
-      with_mock Ecto.Migrator, [], run: fn _, _, _, _ -> raise("error") end do
+      with_mock Realtime.Tenants.Migrations, [],
+        maybe_run_migrations: fn _, _ -> raise("error") end do
         assert {:error, :tenant_database_unavailable} =
                  Connect.lookup_or_start_connection(tenant.external_id)
 
-        assert_called(Ecto.Migrator.run(:_, :_, :_, :_))
+        assert_called(Realtime.Tenants.Migrations.maybe_run_migrations(:_, :_))
       end
     end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The migrations module includes a potential bottleneck to the connect module on ipv6 check. This PR will make it so we can avoid running this bottleneck code everytime

**Do not merge, this is only intended to build an hotfix image from tag v2.33.18**
