### PR TITLE
fix: Removes sleep from Connection checking

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -34,7 +34,7 @@ defmodule Realtime.Tenants do
   ## Examples
 
       iex> Realtime.Tenants.get_health_conn(%Realtime.Api.Tenant{external_id: "not_found_tenant"})
-      {:error, :tenant_database_connection_initializing}
+      {:error, :tenant_database_unavailable}
   """
 
   @spec get_health_conn(Tenant.t()) :: {:error, term()} | {:ok, pid()}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.28",
+      version: "2.33.29",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

On connection initialisation / process finding for DB process, we were putting Connect module to sleep which could have a high impact and create an infinite loop.

This removes that code and if Syn as yet to find the process the cache has most likely not been propagated yet.
