### PR TITLE
fix: add back sleep on connect initialization

### DIFF
--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -87,6 +87,7 @@ defmodule Realtime.Tenants.Connect do
 
       :undefined ->
         Logger.warning("Connection process starting up")
+        :timer.sleep(100)
         {:error, :tenant_database_connection_initializing}
 
       error ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.39",
+      version: "2.33.40",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

add back sleep on connect initialization