### PR TITLE
fix: Healthcheck improperly calling postgrex

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -208,7 +208,9 @@ defmodule Realtime.Tenants.Migrations do
       "select * from pg_catalog.pg_tables where schemaname = 'realtime' and tablename = 'schema_migrations';"
 
     %{extensions: [%{settings: settings} | _]} = tenant
-    %{num_rows: num_rows} = Postgrex.query!(db_conn, query, [])
+
+    {:ok, %{num_rows: num_rows}} =
+      Database.transaction(db_conn, fn db_conn -> Postgrex.query!(db_conn, query, []) end)
 
     if num_rows < @expected_migration_count do
       run_migrations(%__MODULE__{tenant_external_id: tenant.external_id, settings: settings})

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.43",
+      version: "2.33.44",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently postgrex was trying to call a pid that was from another node which is not capable to do. We need to wrap it around Realtime.Database.transaction to run the erpc call against the target node
