### PR TITLE
allow default self-hosted tenant name to be configurable via ENV

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -2,7 +2,7 @@ require Logger
 alias Realtime.{Api.Tenant, Repo}
 import Ecto.Adapters.SQL, only: [query: 3]
 
-tenant_name = "realtime-dev"
+tenant_name = System.get_env("TENANT_NAME", "realtime-dev")
 
 env = if :ets.whereis(Mix.State) != :undefined, do: Mix.env(), else: :prod
 default_db_host = if env in [:dev, :test], do: "localhost", else: "host.docker.internal"


### PR DESCRIPTION
## What kind of change does this PR introduce?

self-hosted seed update to allow tenant_name to be configurable via environment variable. 

## What is the current behavior?

The current behavior requires the container name to be "realtime-dev". If it isn't then it will not match the default tenant. In cases where the container name will be different (i.e. kubernetes deployments) it is impossible to use default tenant. 

## What is the new behavior?

The new behavior allows to configure the default tenant_name via an environment variable named TENANT_NAME with fallback behavior to the original "realtime-dev".

## Additional context

This was an issue for the supabase-kubernetes project. I have submitted a PR there as well to overwrite the seeds.exs file in https://github.com/supabase-community/supabase-kubernetes/pull/91

Ultimately it would be better to have this be configuration change upstream in this repo.