### PR TITLE
fix: realtime schema prefix not set in send function

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -65,7 +65,8 @@ defmodule Realtime.Tenants.Migrations do
     ChangeMessagesIdType,
     UuidAutoGeneration,
     MessagesPartitioning,
-    MessagesUsingUuid
+    MessagesUsingUuid,
+    FixSendFunction
   }
 
   @migrations [
@@ -120,7 +121,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_240_919_163_305, ChangeMessagesIdType},
     {20_241_019_105_805, UuidAutoGeneration},
     {20_241_030_150_047, MessagesPartitioning},
-    {20_241_108_114_728, MessagesUsingUuid}
+    {20_241_108_114_728, MessagesUsingUuid},
+    {20_241_121_104_152, FixSendFunction}
   ]
 
   defstruct [:tenant_external_id, :settings]

--- a/lib/realtime/tenants/repo/migrations/20241121104152_fix_send_function_.ex
+++ b/lib/realtime/tenants/repo/migrations/20241121104152_fix_send_function_.ex
@@ -1,0 +1,38 @@
+defmodule Realtime.Tenants.Migrations.FixSendFunction do
+  @moduledoc false
+  use Ecto.Migration
+
+  # We missed the schema prefix of `realtime.` in the create table partition statement
+  def change do
+    execute("""
+    CREATE OR REPLACE FUNCTION realtime.send(payload jsonb, event text, topic text, private boolean DEFAULT true)
+    RETURNS void
+    AS $$
+    DECLARE
+      partition_name text;
+    BEGIN
+      partition_name := 'messages_' || to_char(NOW(), 'YYYY_MM_DD');
+
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'realtime'
+        AND c.relname = partition_name
+      ) THEN
+        EXECUTE format(
+          'CREATE TABLE realtime.%I PARTITION OF realtime.messages FOR VALUES FROM (%L) TO (%L)',
+          partition_name,
+          NOW(),
+          (NOW() + interval '1 day')::timestamp
+        );
+      END IF;
+
+      INSERT INTO realtime.messages (payload, event, topic, private, extension)
+      VALUES (payload, event, topic, private, 'broadcast');
+    END;
+    $$
+    LANGUAGE plpgsql;
+    """)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.52",
+      version: "2.33.53",
       elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

`realtime` schema prefix not set in send function
