### PR TITLE
fix: fetch correct pool value from settings by application name

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -28,13 +28,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
   def init(args) do
     tenant = args["id"]
     Logger.metadata(external_id: tenant, project: tenant)
-
-    # higher number of pool connections leads to issues
-    realtime_rls_settings =
-      args
-      |> Database.from_settings("realtime_rls")
-      |> Map.put(:pool, 1)
-
+    realtime_rls_settings = Database.from_settings(args, "realtime_rls")
     {:ok, conn} = Database.connect_db(realtime_rls_settings)
 
     state = %{

--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -99,11 +99,11 @@ defmodule Realtime.Database do
         "realtime_subscription_manager_pub" -> settings["subs_pool_size"]
         "realtime_subscription_checker" -> settings["subs_pool_size"]
         "realtime_rls" -> settings["db_pool"]
-        "realtime_health_check" -> settings["db_pool"]
+        "realtime_connect" -> settings["db_pool"]
+        "realtime_health_check" -> 1
         "realtime_broadcast_changes" -> 1
         "realtime_migrations" -> 2
         "realtime_janitor" -> 1
-        "realtime_connect" -> 1
         _ -> 1
       end
 

--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -17,8 +17,8 @@ defmodule Realtime.Database do
     :pass,
     :pool,
     :queue_target,
+    :application_name,
     ssl_enforced: true,
-    application_name: "realtime_supabase",
     backoff: :rand_exp
   ]
 
@@ -39,9 +39,14 @@ defmodule Realtime.Database do
 
   @spec from_settings(map(), binary(), :stop | :exp | :rand | :rand_exp, boolean()) ::
           Realtime.Database.t()
-  def from_settings(settings, application_name, backoff \\ :rand_exp, decrypt \\ false) do
-    pool =
-      settings["subs_pool_size"] || settings["subcriber_pool_size"] || settings["db_pool"] || 1
+  def from_settings(
+        settings,
+        application_name,
+        backoff \\ :rand_exp,
+        decrypt \\ false,
+        pool \\ nil
+      ) do
+    pool = pool_size_by_application_name(application_name, settings, pool)
 
     settings =
       if decrypt do
@@ -66,6 +71,43 @@ defmodule Realtime.Database do
       application_name: application_name,
       backoff: backoff
     }
+  end
+
+  @doc """
+  Returns the pool size for a given application name. Override pool size if provided.
+
+  ## Examples
+
+      iex> Realtime.Database.pool_size_by_application_name("realtime_rls", %{}, 1)
+      1
+
+      iex> Realtime.Database.pool_size_by_application_name("realtime_rls", %{"db_pool" => 10}, 1)
+      1
+
+      iex> Realtime.Database.pool_size_by_application_name("realtime_rls", %{"db_pool" => 10}, nil)
+      10
+
+      iex> Realtime.Database.pool_size_by_application_name("realtime_potato", %{}, nil)
+      1
+
+  """
+  @spec pool_size_by_application_name(binary(), map(), non_neg_integer()) :: non_neg_integer()
+  def pool_size_by_application_name(application_name, settings, override_pool \\ nil) do
+    pool =
+      case application_name do
+        "realtime_subscription_manager" -> settings["subcriber_pool_size"]
+        "realtime_subscription_manager_pub" -> settings["subs_pool_size"]
+        "realtime_subscription_checker" -> settings["subs_pool_size"]
+        "realtime_rls" -> settings["db_pool"]
+        "realtime_health_check" -> settings["db_pool"]
+        "realtime_broadcast_changes" -> 1
+        "realtime_migrations" -> 2
+        "realtime_janitor" -> 1
+        "realtime_connect" -> 1
+        _ -> 1
+      end
+
+    if override_pool, do: override_pool, else: pool
   end
 
   @spec from_tenant(
@@ -147,8 +189,7 @@ defmodule Realtime.Database do
   def connect(tenant, application_name, pool, backoff \\ :stop) do
     tenant
     |> then(&Realtime.PostgresCdc.filter_settings(@cdc, &1.extensions))
-    |> then(&Realtime.Database.from_settings(&1, application_name, backoff))
-    |> then(&%{&1 | pool: pool})
+    |> then(&Realtime.Database.from_settings(&1, application_name, backoff, false, pool))
     |> connect_db()
   end
 

--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -91,7 +91,8 @@ defmodule Realtime.Database do
       1
 
   """
-  @spec pool_size_by_application_name(binary(), map(), non_neg_integer()) :: non_neg_integer()
+  @spec pool_size_by_application_name(binary(), map(), non_neg_integer() | nil) ::
+          non_neg_integer()
   def pool_size_by_application_name(application_name, settings, override_pool \\ nil) do
     pool =
       case application_name do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.62",
+      version: "2.33.63",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fetch correct pool value from settings by application name but also allows overrides
