### PR TITLE
fix: set proper size for realtime_rls pool

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.63",
+      version: "2.33.64",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Connection pool for realtime_rls was not set properly and was using a higher value than it should leading to Realtime attempting to re-use replication slots creating issues upon connecting to listen to changes
    
Now we will set `realtime_rls` and `realtime_broadcast_changes` to hardcoded `1` and `realtime_migrations` to hardcoded `2`