### PR TITLE
fix: Prevent match error on GenCounter

### DIFF
--- a/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
+++ b/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
@@ -20,6 +20,7 @@ defmodule Extensions.PostgresCdcRls.WorkerSupervisor do
 
   @impl true
   def init(%{"id" => tenant} = args) when is_binary(tenant) do
+    Logger.metadata(external_id: tenant, project: tenant)
     unless Api.get_tenant_by_external_id(tenant, :primary), do: raise(Exception)
 
     tid_args = Map.merge(args, %{"subscribers_tid" => :ets.new(__MODULE__, [:public, :bag])})

--- a/lib/extensions/postgres_cdc_stream/replication.ex
+++ b/lib/extensions/postgres_cdc_stream/replication.ex
@@ -49,7 +49,9 @@ defmodule Extensions.PostgresCdcStream.Replication do
   def stop(pid), do: GenServer.stop(pid)
 
   @impl true
-  def init(args) do
+  def init(%{tenant: id} = args) do
+    Logger.metadata(external_id: id, project: id)
+
     tid = :ets.new(__MODULE__, [:public, :set])
     state = %{tid: tid, step: nil, ts: nil}
     {:ok, Map.merge(args, state)}

--- a/lib/extensions/postgres_cdc_stream/worker_supervisor.ex
+++ b/lib/extensions/postgres_cdc_stream/worker_supervisor.ex
@@ -13,7 +13,8 @@ defmodule Extensions.PostgresCdcStream.WorkerSupervisor do
 
   @impl true
   def init(%{"id" => tenant} = args) when is_binary(tenant) do
-    unless Api.get_tenant_by_external_id(tenant, :primary), do: raise(Exception)
+    if !Api.get_tenant_by_external_id(tenant, :primary), do: raise(Exception)
+    Logger.metadata(external_id: tenant, project: tenant)
 
     children = [
       %{

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -101,9 +101,15 @@ defmodule Realtime.Tenants.Connect do
     spec = {__MODULE__, [tenant_id: tenant_id] ++ opts}
 
     case DynamicSupervisor.start_child(supervisor, spec) do
-      {:ok, _} -> get_status(tenant_id)
-      {:error, {:already_started, _}} -> get_status(tenant_id)
-      _ -> {:error, :tenant_database_unavailable}
+      {:ok, _} ->
+        get_status(tenant_id)
+
+      {:error, {:already_started, _}} ->
+        get_status(tenant_id)
+
+      {:error, error} ->
+        log_error("UnableToConnectToTenantDatabase", error)
+        {:error, :tenant_database_unavailable}
     end
   end
 

--- a/lib/realtime_web/plugs/assign_tenant.ex
+++ b/lib/realtime_web/plugs/assign_tenant.ex
@@ -21,6 +21,8 @@ defmodule RealtimeWeb.Plugs.AssignTenant do
   def call(%Plug.Conn{host: host} = conn, _opts) do
     with {:ok, external_id} <- Database.get_external_id(host),
          %Tenant{} = tenant <- Api.get_tenant_by_external_id(external_id) do
+      Logger.metadata(external_id: external_id, project: external_id)
+
       tenant =
         tenant
         |> tap(&initialize_counters/1)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.65",
+      version: "2.33.66",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/e2e/tests.ts
+++ b/test/e2e/tests.ts
@@ -3,7 +3,7 @@ import {
   createClient,
   SupabaseClient,
   RealtimeChannel,
-} from "npm:@supabase/supabase-js@latest";
+} from "npm:@supabase/supabase-js@2.47.3";
 import {
   assert,
   assertEquals,
@@ -125,7 +125,6 @@ describe("postgres changes extension", () => {
       "filipe@supabase.io",
       "test_test"
     );
-    await supabase.realtime.setAuth(accessToken);
 
     let result: Array<any> = [];
     let topic = crypto.randomUUID();
@@ -164,7 +163,6 @@ describe("postgres changes extension", () => {
       "filipe@supabase.io",
       "test_test"
     );
-    await supabase.realtime.setAuth(accessToken);
 
     let result: Array<any> = [];
     let topic = crypto.randomUUID();
@@ -207,7 +205,6 @@ describe("postgres changes extension", () => {
       "filipe@supabase.io",
       "test_test"
     );
-    await supabase.realtime.setAuth(accessToken);
 
     let result: Array<any> = [];
     let topic = crypto.randomUUID();
@@ -275,7 +272,6 @@ describe("authorization check", () => {
       "filipe@supabase.io",
       "test_test"
     );
-    await supabase.realtime.setAuth(accessToken);
 
     const channel = supabase
       .channel(crypto.randomUUID(), { config: { ...config, private: true } })
@@ -303,7 +299,6 @@ describe("broadcast changes", () => {
       "filipe@supabase.io",
       "test_test"
     );
-    await supabase.realtime.setAuth(accessToken);
 
     const channel = supabase
       .channel(`event:${id}`, { config: { ...config, private: true } })

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -56,7 +56,7 @@ defmodule Realtime.DatabaseTest do
                assert {:error, %DBConnection.ConnectionError{reason: :queue_timeout}} =
                         Task.async(fn ->
                           Database.transaction(db_conn, fn conn ->
-                            Postgrex.query!(conn, "SELECT pg_sleep(5)", [])
+                            Postgrex.query!(conn, "SELECT pg_sleep(6)", [])
                           end)
                         end)
                         |> Task.await(15000)

--- a/test/realtime/gen_counter/gen_counter_test.exs
+++ b/test/realtime/gen_counter/gen_counter_test.exs
@@ -5,12 +5,12 @@ defmodule Realtime.GenCounterTest do
 
   describe "new/1" do
     test "starts a new counter from an Erlang term" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       assert {:ok, _} = GenCounter.new(term)
     end
 
     test "counters are unique for an Erlang term" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       assert {:error, {:already_started, _pid}} = GenCounter.new(term)
     end
@@ -18,7 +18,7 @@ defmodule Realtime.GenCounterTest do
 
   describe "add/1" do
     test "incriments a counter" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       :ok = GenCounter.add(term)
       assert {:ok, 1} = GenCounter.get(term)
@@ -27,7 +27,7 @@ defmodule Realtime.GenCounterTest do
 
   describe "add/2" do
     test "incriments a counter by `count`" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       :ok = GenCounter.add(term, 10)
       assert {:ok, 10} = GenCounter.get(term)
@@ -36,7 +36,7 @@ defmodule Realtime.GenCounterTest do
 
   describe "sub/1" do
     test "decriments a counter" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       :ok = GenCounter.add(term)
       :ok = GenCounter.sub(term)
@@ -46,7 +46,7 @@ defmodule Realtime.GenCounterTest do
 
   describe "sub/2" do
     test "decriments a counter by `count`" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       :ok = GenCounter.add(term, 10)
       :ok = GenCounter.sub(term, 5)
@@ -56,7 +56,7 @@ defmodule Realtime.GenCounterTest do
 
   describe "put/2" do
     test "replactes a counter with `count`" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       :ok = GenCounter.put(term, 10)
       assert {:ok, 10} = GenCounter.get(term)
@@ -65,7 +65,7 @@ defmodule Realtime.GenCounterTest do
 
   describe "stop/2" do
     test "stops the child process the counter is linked to" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       :ok = GenCounter.stop(term)
       Process.sleep(100)
@@ -75,7 +75,7 @@ defmodule Realtime.GenCounterTest do
 
   describe "info/2" do
     test "gets some info on a counter" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       assert %{memory: _mem, size: _size} = GenCounter.info(term)
     end
@@ -83,7 +83,7 @@ defmodule Realtime.GenCounterTest do
 
   describe "get/1" do
     test "gets the count of a counter" do
-      term = Ecto.UUID.generate()
+      term = {:domain, :metric, Ecto.UUID.generate()}
       {:ok, _} = GenCounter.new(term)
       assert {:ok, 0} = GenCounter.get(term)
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Handles match error on GenCounter in a more grafecul way
* Adds Logger metadata on multiple processes