### PR TITLE
fix: Improve partition creation on realtime.send

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -92,6 +92,8 @@ if config_env() == :prod do
 end
 
 if config_env() != :test do
+  config :logger, level: System.get_env("LOG_LEVEL", "info") |> String.to_existing_atom()
+
   platform = if System.get_env("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE", do: :aws, else: :fly
 
   config :realtime,
@@ -245,5 +247,3 @@ if System.get_env("LOGS_ENGINE") == "logflare" do
     discard_threshold: 1_000,
     backends: [LogflareLogger.HttpBackend]
 end
-
-config :logger, level: System.get_env("LOG_LEVEL", "info") |> String.to_existing_atom()

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -67,7 +67,8 @@ defmodule Realtime.Tenants.Migrations do
     MessagesPartitioning,
     MessagesUsingUuid,
     FixSendFunction,
-    RecreateEntityIndexUsingBtree
+    RecreateEntityIndexUsingBtree,
+    FixSendFunctionPartitionCreation
   }
 
   @migrations [
@@ -124,7 +125,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_241_030_150_047, MessagesPartitioning},
     {20_241_108_114_728, MessagesUsingUuid},
     {20_241_121_104_152, FixSendFunction},
-    {20_241_130_184_212, RecreateEntityIndexUsingBtree}
+    {20_241_130_184_212, RecreateEntityIndexUsingBtree},
+    {20_241_220_035_512, FixSendFunctionPartitionCreation}
   ]
 
   defstruct [:tenant_external_id, :settings]

--- a/lib/realtime/tenants/repo/migrations/20241220035512_fix_send_function_partition_creation.ex
+++ b/lib/realtime/tenants/repo/migrations/20241220035512_fix_send_function_partition_creation.ex
@@ -1,0 +1,38 @@
+defmodule Realtime.Tenants.Migrations.FixSendFunctionPartitionCreation do
+  @moduledoc false
+  use Ecto.Migration
+
+  # We missed the schema prefix of `realtime.` in the create table partition statement
+  def change do
+    execute("""
+    CREATE OR REPLACE FUNCTION realtime.send(payload jsonb, event text, topic text, private boolean DEFAULT true)
+    RETURNS void
+    AS $$
+    DECLARE
+    partition_name text;
+    partition_start timestamp;
+    partition_end timestamp;
+    BEGIN
+      partition_start := date_trunc('day', NOW());
+      partition_end := partition_start + interval '1 day';
+      partition_name := 'messages_' || to_char(partition_start, 'YYYY_MM_DD');
+
+      BEGIN
+        EXECUTE format(
+          'CREATE TABLE IF NOT EXISTS realtime.%I PARTITION OF realtime.messages FOR VALUES FROM (%L) TO (%L)',
+          partition_name,
+          partition_start,
+          partition_end
+        );
+        EXCEPTION WHEN duplicate_table THEN
+        -- Ignore; table already exists
+      END;
+
+      INSERT INTO realtime.messages (payload, event, topic, private, extension)
+      VALUES (payload, event, topic, private, 'broadcast');
+    END;
+    $$
+    LANGUAGE plpgsql;
+    """)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.70",
+      version: "2.33.71",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

The current approach can lead to some unexpected errors due to the multiple calls to NOW() during the creation and checking of partitions