### PR TITLE
fix: listen on notifications for error handling

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -78,7 +78,11 @@ defmodule Realtime.Application do
         {PartitionSupervisor,
          child_spec: DynamicSupervisor,
          strategy: :one_for_one,
-         name: Realtime.BroadcastChanges.Handler.DynamicSupervisor},
+         name: Realtime.Tenants.BroadcastChanges.Handler.DynamicSupervisor},
+        {PartitionSupervisor,
+         child_spec: DynamicSupervisor,
+         strategy: :one_for_one,
+         name: Realtime.Tenants.Listen.DynamicSupervisor},
         RealtimeWeb.Endpoint,
         RealtimeWeb.Presence,
         Realtime.MetricsCleaner

--- a/lib/realtime/tenants/broadcast_changes/handler.ex
+++ b/lib/realtime/tenants/broadcast_changes/handler.ex
@@ -1,4 +1,4 @@
-defmodule Realtime.BroadcastChanges.Handler do
+defmodule Realtime.Tenants.BroadcastChanges.Handler do
   @moduledoc """
   BroadcastChanges is a module that provides a way to stream data from a PostgreSQL database using logical replication.
 
@@ -327,7 +327,8 @@ defmodule Realtime.BroadcastChanges.Handler do
 
   @spec supervisor_spec(Tenant.t()) :: term()
   def supervisor_spec(%Tenant{external_id: tenant_id}) do
-    {:via, PartitionSupervisor, {Realtime.BroadcastChanges.Handler.DynamicSupervisor, tenant_id}}
+    {:via, PartitionSupervisor,
+     {Realtime.Tenants.BroadcastChanges.Handler.DynamicSupervisor, tenant_id}}
   end
 
   def publication_name(%__MODULE__{table: table, schema: schema}) do

--- a/lib/realtime/tenants/listen.ex
+++ b/lib/realtime/tenants/listen.ex
@@ -1,0 +1,95 @@
+defmodule Realtime.Tenants.Listen do
+  @moduledoc """
+  Listen for Postgres notifications to identify issues with the functions that are being called in tenants database
+  """
+  use GenServer, restart: :transient
+  require Logger
+  alias Realtime.Logs
+  alias Realtime.Api.Tenant
+  alias Realtime.Database
+  alias Realtime.PostgresCdc
+  alias Realtime.Registry.Unique
+
+  defstruct tenant_id: nil, listen_conn: nil
+
+  @cdc "postgres_cdc_rls"
+  @topic "realtime:system"
+  def start_link(%Tenant{} = tenant) do
+    name = {:via, Registry, {Unique, {__MODULE__, :tenant_id, tenant.external_id}}}
+    GenServer.start_link(__MODULE__, tenant, name: name)
+  end
+
+  def init(%Tenant{external_id: external_id} = tenant) do
+    Logger.metadata(external_id: external_id, project: external_id)
+
+    settings =
+      tenant
+      |> then(&PostgresCdc.filter_settings(@cdc, &1.extensions))
+      |> then(&Database.from_settings(&1, "realtime_listen", :rand_exp, true))
+      |> Map.from_struct()
+
+    name =
+      {:via, Registry,
+       {Realtime.Registry.Unique, {Postgrex.Notifications, :tenant_id, tenant.external_id}}}
+
+    settings =
+      settings
+      |> Map.put(:hostname, settings[:host])
+      |> Map.put(:database, settings[:name])
+      |> Map.put(:password, settings[:pass])
+      |> Map.put(:username, "postgres")
+      |> Map.put(:port, String.to_integer(settings[:port]))
+      |> Map.put(:ssl, settings[:ssl_enforced])
+      |> Map.put(:auto_reconnect, true)
+      |> Map.put(:name, name)
+      |> Enum.to_list()
+
+    Logger.info("Listening for notifications on #{@topic}")
+
+    case Postgrex.Notifications.start_link(settings) do
+      {:ok, conn} ->
+        Postgrex.Notifications.listen!(conn, @topic)
+        {:ok, %{tenant_id: tenant.external_id, listen_conn: conn}}
+
+      {:error, {:already_started, conn}} ->
+        Postgrex.Notifications.listen!(conn, @topic)
+        {:ok, %{tenant_id: tenant.external_id, listen_conn: conn}}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  catch
+    e -> {:stop, e}
+  end
+
+  @spec start(Realtime.Api.Tenant.t()) :: {:ok, pid()} | {:error, any()}
+  def start(%Tenant{} = tenant) do
+    supervisor = {:via, PartitionSupervisor, {Realtime.Tenants.Listen.DynamicSupervisor, self()}}
+    spec = {__MODULE__, tenant}
+
+    case DynamicSupervisor.start_child(supervisor, spec) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      error -> {:error, error}
+    end
+  catch
+    e -> {:error, e}
+  end
+
+  def handle_info({:notification, _, _, @topic, payload}, state) do
+    case Jason.decode(payload) do
+      {:ok, %{"function" => "realtime.send"} = parsed} when is_map_key(parsed, "error") ->
+        Logs.log_error("FailedSendFromDatabase", parsed)
+
+      {:error, _} ->
+        Logs.log_error("FailedToParseDiagnosticMessage", payload)
+
+      _ ->
+        :ok
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -68,7 +68,8 @@ defmodule Realtime.Tenants.Migrations do
     MessagesUsingUuid,
     FixSendFunction,
     RecreateEntityIndexUsingBtree,
-    FixSendFunctionPartitionCreation
+    FixSendFunctionPartitionCreation,
+    RealtimeSendHandleExceptionsRemovePartitionCreation
   }
 
   @migrations [
@@ -126,7 +127,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_241_108_114_728, MessagesUsingUuid},
     {20_241_121_104_152, FixSendFunction},
     {20_241_130_184_212, RecreateEntityIndexUsingBtree},
-    {20_241_220_035_512, FixSendFunctionPartitionCreation}
+    {20_241_220_035_512, FixSendFunctionPartitionCreation},
+    {20_241_220_123_912, RealtimeSendHandleExceptionsRemovePartitionCreation}
   ]
 
   defstruct [:tenant_external_id, :settings]
@@ -252,9 +254,9 @@ defmodule Realtime.Tenants.Migrations do
     Logger.info("Creating partitions for realtime.messages")
     today = Date.utc_today()
     yesterday = Date.add(today, -1)
-    tomorrow = Date.add(today, 1)
+    future = Date.add(today, 10)
 
-    dates = [yesterday, today, tomorrow]
+    dates = Date.range(yesterday, future)
 
     Enum.each(dates, fn date ->
       partition_name = "messages_#{date |> Date.to_iso8601() |> String.replace("-", "_")}"

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -254,7 +254,7 @@ defmodule Realtime.Tenants.Migrations do
     Logger.info("Creating partitions for realtime.messages")
     today = Date.utc_today()
     yesterday = Date.add(today, -1)
-    future = Date.add(today, 10)
+    future = Date.add(today, 3)
 
     dates = Date.range(yesterday, future)
 

--- a/lib/realtime/tenants/repo/migrations/20241220123912_realtime_send_handle_exceptions_remove_partition_creation.ex
+++ b/lib/realtime/tenants/repo/migrations/20241220123912_realtime_send_handle_exceptions_remove_partition_creation.ex
@@ -1,0 +1,34 @@
+defmodule Realtime.Tenants.Migrations.RealtimeSendHandleExceptionsRemovePartitionCreation do
+  @moduledoc false
+  use Ecto.Migration
+
+  # We missed the schema prefix of `realtime.` in the create table partition statement
+  def change do
+    execute("""
+    CREATE OR REPLACE FUNCTION realtime.send(payload jsonb, event text, topic text, private boolean DEFAULT true ) RETURNS void
+    AS $$
+    BEGIN
+      BEGIN
+        -- Attempt to insert the message
+        INSERT INTO realtime.messages (payload, event, topic, private, extension)
+        VALUES (payload, event, topic, private, 'broadcast');
+      EXCEPTION
+        WHEN OTHERS THEN
+          -- Capture and notify the error
+          PERFORM pg_notify(
+              'realtime:system',
+              jsonb_build_object(
+                  'error', SQLERRM,
+                  'function', 'realtime.send',
+                  'event', event,
+                  'topic', topic,
+                  'private', private
+              )::text
+          );
+      END;
+    END;
+    $$
+    LANGUAGE plpgsql;
+    """)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.71",
+      version: "2.33.72",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/e2e/tests.ts
+++ b/test/e2e/tests.ts
@@ -120,17 +120,14 @@ describe("broadcast extension", () => {
 describe("postgres changes extension", () => {
   it("user is able to receive INSERT only events from a subscribed table with filter applied", async () => {
     let supabase = await createClient(url, token, { realtime });
-    let accessToken = await signInUser(
-      supabase,
-      "filipe@supabase.io",
-      "test_test"
-    );
+    await signInUser(supabase, "filipe@supabase.io", "test_test");
+    await supabase.realtime.setAuth();
 
     let result: Array<any> = [];
     let topic = crypto.randomUUID();
 
     let previousId = await executeCreateDatabaseActions(supabase, "pg_changes");
-    let dummyId = await executeCreateDatabaseActions(supabase, "dummy");
+    await executeCreateDatabaseActions(supabase, "dummy");
 
     const activeChannel = supabase
       .channel(topic, config)
@@ -145,10 +142,10 @@ describe("postgres changes extension", () => {
         (payload) => result.push(payload)
       )
       .subscribe();
-    await sleep(2);
+    await sleep(4);
     await executeCreateDatabaseActions(supabase, "pg_changes");
     await executeCreateDatabaseActions(supabase, "pg_changes");
-    await sleep(2);
+    await sleep(4);
     await stopClient(supabase, [activeChannel]);
 
     assertEquals(result.length, 1);
@@ -158,11 +155,8 @@ describe("postgres changes extension", () => {
 
   it("user is able to receive UPDATE only events from a subscribed table with filter applied", async () => {
     let supabase = await createClient(url, token, { realtime });
-    let accessToken = await signInUser(
-      supabase,
-      "filipe@supabase.io",
-      "test_test"
-    );
+    await signInUser(supabase, "filipe@supabase.io", "test_test");
+    await supabase.realtime.setAuth();
 
     let result: Array<any> = [];
     let topic = crypto.randomUUID();
@@ -184,13 +178,13 @@ describe("postgres changes extension", () => {
         (payload) => result.push(payload)
       )
       .subscribe();
-    await sleep(2);
+    await sleep(4);
 
     executeModifyDatabaseActions(supabase, "pg_changes", mainId);
     executeModifyDatabaseActions(supabase, "pg_changes", fakeId);
     executeModifyDatabaseActions(supabase, "dummy", dummyId);
 
-    await sleep(2);
+    await sleep(4);
     await stopClient(supabase, [activeChannel]);
 
     assertEquals(result.length, 1);
@@ -200,11 +194,8 @@ describe("postgres changes extension", () => {
 
   it("user is able to receive DELETE only events from a subscribed table with filter applied", async () => {
     let supabase = await createClient(url, token, { realtime });
-    let accessToken = await signInUser(
-      supabase,
-      "filipe@supabase.io",
-      "test_test"
-    );
+    await signInUser(supabase, "filipe@supabase.io", "test_test");
+    await supabase.realtime.setAuth();
 
     let result: Array<any> = [];
     let topic = crypto.randomUUID();
@@ -226,13 +217,13 @@ describe("postgres changes extension", () => {
         (payload) => result.push(payload)
       )
       .subscribe();
-    await sleep(2);
+    await sleep(4);
 
     executeModifyDatabaseActions(supabase, "pg_changes", mainId);
     executeModifyDatabaseActions(supabase, "pg_changes", fakeId);
     executeModifyDatabaseActions(supabase, "dummy", dummyId);
 
-    await sleep(2);
+    await sleep(4);
     await stopClient(supabase, [activeChannel]);
 
     assertEquals(result.length, 1);
@@ -267,11 +258,8 @@ describe("authorization check", () => {
 
   it("user using private channel can connect if they have enough permissions", async () => {
     let supabase = await createClient(url, token, { realtime });
-    let accessToken = await signInUser(
-      supabase,
-      "filipe@supabase.io",
-      "test_test"
-    );
+    await signInUser(supabase, "filipe@supabase.io", "test_test");
+    await supabase.realtime.setAuth();
 
     const channel = supabase
       .channel(crypto.randomUUID(), { config: { ...config, private: true } })
@@ -294,14 +282,11 @@ describe("broadcast changes", () => {
 
   it("authenticated user receives insert broadcast change from a specific topic based on id", async () => {
     let supabase = await createClient(url, token, { realtime });
-    let accessToken = await signInUser(
-      supabase,
-      "filipe@supabase.io",
-      "test_test"
-    );
+    await signInUser(supabase, "filipe@supabase.io", "test_test");
+    await supabase.realtime.setAuth();
 
     const channel = supabase
-      .channel(`event:${id}`, { config: { ...config, private: true } })
+      .channel(`event:${id}`, { config: { private: true } })
       .on("broadcast", { event: "INSERT" }, (res) => (insertResult = res))
       .on("broadcast", { event: "DELETE" }, (res) => (deleteResult = res))
       .on("broadcast", { event: "UPDATE" }, (res) => (updateResult = res))

--- a/test/realtime/tenants/broadcast_changes/handler_test.exs
+++ b/test/realtime/tenants/broadcast_changes/handler_test.exs
@@ -1,4 +1,4 @@
-defmodule Realtime.BroadcastChanges.HandlerTest do
+defmodule Realtime.Tenants.BroadcastChanges.HandlerTest do
   # async: false due to the fact that we're using the database to intercept messages created which will interfer with other tests
   use Realtime.DataCase, async: false
 
@@ -6,7 +6,7 @@ defmodule Realtime.BroadcastChanges.HandlerTest do
   import Mock
 
   alias Realtime.Api.Message
-  alias Realtime.BroadcastChanges.Handler
+  alias Realtime.Tenants.BroadcastChanges.Handler
   alias Realtime.Database
   alias Realtime.Tenants.BatchBroadcast
   alias Realtime.Tenants.Migrations

--- a/test/realtime/tenants/listen_test.exs
+++ b/test/realtime/tenants/listen_test.exs
@@ -1,0 +1,68 @@
+defmodule Realtime.Tenants.ListenTest do
+  # async: false due to the fact that it's doing Postgres NOTIFY and could interfere with other tests
+  use Realtime.DataCase, async: false
+  import ExUnit.CaptureLog
+
+  import Mock
+
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
+  alias Realtime.Tenants.Listen
+  alias Realtime.Tenants.Migrations
+  alias Realtime.Database
+  alias RealtimeWeb.Endpoint
+
+  describe("start/1") do
+    setup do
+      start_supervised(RealtimeWeb.Joken.CurrentTime.Mock)
+      start_supervised(Realtime.RateCounter.DynamicSupervisor)
+      start_supervised(Realtime.GenCounter.DynamicSupervisor)
+
+      tenant = tenant_fixture()
+      RateCounter.new({:channel, :events, tenant.external_id})
+
+      {:ok, listen_conn} = Listen.start(tenant)
+      {:ok, db_conn} = Database.connect(tenant, "realtime_test")
+      [%{settings: settings} | _] = tenant.extensions
+      migrations = %Migrations{tenant_external_id: tenant.external_id, settings: settings}
+      Migrations.run_migrations(migrations)
+
+      on_exit(fn ->
+        Process.exit(listen_conn, :normal)
+        Process.exit(db_conn, :normal)
+      end)
+
+      {:ok, tenant: tenant, db_conn: db_conn}
+    end
+
+    test "on realtime.send error, notify will capture and log error", %{db_conn: db_conn} do
+      with_mocks [
+        {Endpoint, [:passthrough], broadcast_from: fn _, _, _, _ -> :ok end},
+        {GenCounter, [:passthrough], add: fn _ -> :ok end},
+        {RateCounter, [:passthrough], get: fn _ -> {:ok, %{avg: 0}} end}
+      ] do
+        assert capture_log(fn ->
+                 Postgrex.query!(
+                   db_conn,
+                   """
+                   DO $$
+                   BEGIN
+                     INSERT INTO realtime.messages (payload, event, topic, private, extension, inserted_at) VALUES (null, 'event', 'topic', false, 'broadcast', NOW() - INTERVAL '10 days');
+                   EXCEPTION
+                   WHEN OTHERS THEN
+                     PERFORM pg_notify(
+                       'realtime:system',
+                       jsonb_build_object('error', SQLERRM , 'function', 'realtime.send', 'event', 'event', 'topic', 'topic', 'private', false )::text
+                     );
+                   END
+                   $$;
+                   """,
+                   []
+                 )
+
+                 :timer.sleep(100)
+               end) =~ "FailedSendFromDatabase"
+      end
+    end
+  end
+end

--- a/test/support/tenant_connection.ex
+++ b/test/support/tenant_connection.ex
@@ -6,23 +6,6 @@ defmodule TenantConnection do
   alias Realtime.Database
   alias Realtime.Repo
 
-  def broadcast_test_message(conn, private, topic, event, payload) do
-    query =
-      """
-      select pg_notify(
-          'realtime:broadcast',
-          json_build_object(
-              'private', $1::boolean,
-              'topic', $2::text,
-              'event', $3::text,
-              'payload', $4::jsonb
-          )::text
-      );
-      """
-
-    Postgrex.query!(conn, query, [private, topic, event, %{payload: payload}])
-  end
-
   def create_message(attrs, conn, opts \\ [mode: :savepoint]) do
     channel = Message.changeset(%Message{}, attrs)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Adds Realtime.Tenants.Listen to receive error messages from functions so we can better inform our users
* Changes send function to not handle any partition creation
* Changes send function to pg_notify to `realtime:system` so we can capture and handle in Realtime


