### PR TITLE
fix: realtime.send sets the proper value for realtime.topic

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -69,7 +69,8 @@ defmodule Realtime.Tenants.Migrations do
     FixSendFunction,
     RecreateEntityIndexUsingBtree,
     FixSendFunctionPartitionCreation,
-    RealtimeSendHandleExceptionsRemovePartitionCreation
+    RealtimeSendHandleExceptionsRemovePartitionCreation,
+    RealtimeSendSetsConfig
   }
 
   @migrations [
@@ -128,7 +129,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_241_121_104_152, FixSendFunction},
     {20_241_130_184_212, RecreateEntityIndexUsingBtree},
     {20_241_220_035_512, FixSendFunctionPartitionCreation},
-    {20_241_220_123_912, RealtimeSendHandleExceptionsRemovePartitionCreation}
+    {20_241_220_123_912, RealtimeSendHandleExceptionsRemovePartitionCreation},
+    {20_241_224_161_212, RealtimeSendSetsConfig}
   ]
 
   defstruct [:tenant_external_id, :settings]

--- a/lib/realtime/tenants/repo/migrations/20241224161212_realtime_send_sets_config.ex
+++ b/lib/realtime/tenants/repo/migrations/20241224161212_realtime_send_sets_config.ex
@@ -10,7 +10,7 @@ defmodule Realtime.Tenants.Migrations.RealtimeSendSetsConfig do
     BEGIN
       BEGIN
         -- Set the topic configuration
-        SET SESSION realtime.topic TO topic;
+        SET LOCAL realtime.topic TO topic;
 
         -- Attempt to insert the message
         INSERT INTO realtime.messages (payload, event, topic, private, extension)

--- a/lib/realtime/tenants/repo/migrations/20241224161212_realtime_send_sets_config.ex
+++ b/lib/realtime/tenants/repo/migrations/20241224161212_realtime_send_sets_config.ex
@@ -1,0 +1,37 @@
+defmodule Realtime.Tenants.Migrations.RealtimeSendSetsConfig do
+  @moduledoc false
+  use Ecto.Migration
+
+  # We missed the schema prefix of `realtime.` in the create table partition statement
+  def change do
+    execute("""
+    CREATE OR REPLACE FUNCTION realtime.send(payload jsonb, event text, topic text, private boolean DEFAULT true ) RETURNS void
+    AS $$
+    BEGIN
+      BEGIN
+        -- Set the topic configuration
+        SET SESSION realtime.topic TO topic;
+
+        -- Attempt to insert the message
+        INSERT INTO realtime.messages (payload, event, topic, private, extension)
+        VALUES (payload, event, topic, private, 'broadcast');
+      EXCEPTION
+        WHEN OTHERS THEN
+          -- Capture and notify the error
+          PERFORM pg_notify(
+              'realtime:system',
+              jsonb_build_object(
+                  'error', SQLERRM,
+                  'function', 'realtime.send',
+                  'event', event,
+                  'topic', topic,
+                  'private', private
+              )::text
+          );
+      END;
+    END;
+    $$
+    LANGUAGE plpgsql;
+    """)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.72",
+      version: "2.33.73",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -69,7 +69,7 @@ CREATE OR REPLACE FUNCTION broadcast_changes_for_table_trigger ()
 DECLARE
     topic text;
 BEGIN
-    topic = 'event:' || COALESCE(NEW.id::text, OLD.id::text);
+    topic = 'test';
     PERFORM
         realtime.broadcast_changes (topic, TG_OP, TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD, TG_LEVEL);
     RETURN NULL;

--- a/test/e2e/tests.ts
+++ b/test/e2e/tests.ts
@@ -286,7 +286,7 @@ describe("broadcast changes", () => {
     await supabase.realtime.setAuth();
 
     const channel = supabase
-      .channel(`event:${id}`, { config: { private: true } })
+      .channel("test", { config: { private: true } })
       .on("broadcast", { event: "INSERT" }, (res) => (insertResult = res))
       .on("broadcast", { event: "DELETE" }, (res) => (deleteResult = res))
       .on("broadcast", { event: "UPDATE" }, (res) => (updateResult = res))


### PR DESCRIPTION
## What kind of change does this PR introduce?

`realtime.send` sets the proper value for realtime.topic so RLS policies are applied properly.
