### PR TITLE
fix: Make notification connection sync on connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ This is the list of operational codes that can help you understand your deployme
 | UnableToConnectToTenantDatabase    | Realtime was not able to connect to the tenant's database                                                                           |
 | RealtimeNodeDisconnected           | Realtime is a distributed application and this means that one the system is unable to communicate with one of the distributed nodes |
 | MigrationsFailedToRun              | Error when running the migrations against the Tenant database that are required by Realtime                                         |
+| StartListenAndReplicationFailed    | Error when starting the replication and listening of errors for database broadcasting                                               |
 | MigrationCheckFailed               | Check to see if we require to run migrations fails                                                                                  |
 | PartitionCreationFailed            | Error when creating partitions for realtime.messages                                                                                |
 | ErrorStartingPostgresCDCStream     | Error when starting the Postgres CDC stream which is used for Postgres Changes                                                      |

--- a/lib/realtime/tenants/listen.ex
+++ b/lib/realtime/tenants/listen.ex
@@ -40,7 +40,8 @@ defmodule Realtime.Tenants.Listen do
       |> Map.put(:username, "postgres")
       |> Map.put(:port, String.to_integer(settings[:port]))
       |> Map.put(:ssl, settings[:ssl_enforced])
-      |> Map.put(:auto_reconnect, true)
+      |> Map.put(:sync_connect, true)
+      |> Map.put(:auto_reconnect, false)
       |> Map.put(:name, name)
       |> Enum.to_list()
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.74",
+      version: "2.33.75",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/e2e/tests.ts
+++ b/test/e2e/tests.ts
@@ -322,14 +322,12 @@ describe("broadcast changes", () => {
     await supabase.realtime.setAuth();
 
     const channel = supabase
-      .channel("test", { config: { private: true } })
+      .channel("topic:test", { config: { private: true } })
       .on("broadcast", { event: "INSERT" }, (res) => (insertResult = res))
       .on("broadcast", { event: "DELETE" }, (res) => (deleteResult = res))
       .on("broadcast", { event: "UPDATE" }, (res) => (updateResult = res))
       .subscribe(async (status) => {
         if (status == "SUBSCRIBED") {
-          await sleep(1);
-
           await supabase.from(table).insert({ value: originalValue, id });
 
           await supabase


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make notification connection sync on connect fixing:
```
"MigrationsFailedToRun: {:error,
 {:error,
  {{:badmatch, {:eventually, #Reference<0.3789860767.1689255938.13723>}},
   [
     {Postgrex.Notifications, :listen!, 3,
      [file: ~c\"lib/postgrex/notifications.ex\", line: 163]},
     {Realtime.Tenants.Listen, :init, 1,
      [file: ~c\"lib/realtime/tenants/listen.ex\", line: 51]},
     {:gen_server, :init_it, 2, [file: ~c\"gen_server.erl\", line: 2229]},
     {:gen_server, :init_it, 6, [file: ~c\"gen_server.erl\", line: 2184]},
     {:proc_lib, :init_p_do_apply, 3, [file: ~c\"proc_lib.erl\", line: 329]}
   ]}}}"
```