### PR TITLE
fix: Change realtime.subcription to be unlogged

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -70,7 +70,8 @@ defmodule Realtime.Tenants.Migrations do
     RecreateEntityIndexUsingBtree,
     FixSendFunctionPartitionCreation,
     RealtimeSendHandleExceptionsRemovePartitionCreation,
-    RealtimeSendSetsConfig
+    RealtimeSendSetsConfig,
+    RealtimeSubscriptionUnlogged
   }
 
   @migrations [
@@ -130,7 +131,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_241_130_184_212, RecreateEntityIndexUsingBtree},
     {20_241_220_035_512, FixSendFunctionPartitionCreation},
     {20_241_220_123_912, RealtimeSendHandleExceptionsRemovePartitionCreation},
-    {20_241_224_161_212, RealtimeSendSetsConfig}
+    {20_241_224_161_212, RealtimeSendSetsConfig},
+    {20_250_107_150_512, RealtimeSubscriptionUnlogged}
   ]
 
   defstruct [:tenant_external_id, :settings]

--- a/lib/realtime/tenants/repo/migrations/20250107150512_realtime_subscription_unlogged.ex
+++ b/lib/realtime/tenants/repo/migrations/20250107150512_realtime_subscription_unlogged.ex
@@ -1,0 +1,11 @@
+defmodule Realtime.Tenants.Migrations.RealtimeSubscriptionUnlogged do
+  @moduledoc false
+  use Ecto.Migration
+
+  # We missed the schema prefix of `realtime.` in the create table partition statement
+  def change do
+    execute("""
+    ALTER TABLE realtime.subscription SET UNLOGGED;
+    """)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.77",
+      version: "2.33.78",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

The information we store in realtime.subscripition it's not intended to be long lived so we can reduce the impact on WAL by making this table unlogged