### PR TITLE
fix: Make realtime.subscription logged

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -71,7 +71,8 @@ defmodule Realtime.Tenants.Migrations do
     FixSendFunctionPartitionCreation,
     RealtimeSendHandleExceptionsRemovePartitionCreation,
     RealtimeSendSetsConfig,
-    RealtimeSubscriptionUnlogged
+    RealtimeSubscriptionUnlogged,
+    RealtimeSubscriptionLogged
   }
 
   @migrations [
@@ -132,7 +133,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_241_220_035_512, FixSendFunctionPartitionCreation},
     {20_241_220_123_912, RealtimeSendHandleExceptionsRemovePartitionCreation},
     {20_241_224_161_212, RealtimeSendSetsConfig},
-    {20_250_107_150_512, RealtimeSubscriptionUnlogged}
+    {20_250_107_150_512, RealtimeSubscriptionUnlogged},
+    {20_250_110_162_412, RealtimeSubscriptionLogged}
   ]
 
   defstruct [:tenant_external_id, :settings]

--- a/lib/realtime/tenants/repo/migrations/20250107150512_realtime_subscription_unlogged.ex
+++ b/lib/realtime/tenants/repo/migrations/20250107150512_realtime_subscription_unlogged.ex
@@ -2,7 +2,6 @@ defmodule Realtime.Tenants.Migrations.RealtimeSubscriptionUnlogged do
   @moduledoc false
   use Ecto.Migration
 
-  # We missed the schema prefix of `realtime.` in the create table partition statement
   def change do
     execute("""
     ALTER TABLE realtime.subscription SET UNLOGGED;

--- a/lib/realtime/tenants/repo/migrations/20250110162412_realtime_subscription_logged.ex
+++ b/lib/realtime/tenants/repo/migrations/20250110162412_realtime_subscription_logged.ex
@@ -1,0 +1,11 @@
+defmodule Realtime.Tenants.Migrations.RealtimeSubscriptionLogged do
+  @moduledoc false
+  use Ecto.Migration
+
+  # Due to issues on PG Updates we can't use UNLOGGED tables due to the fact that Sequences on PG14 still need to be logged
+  def change do
+    execute("""
+    ALTER TABLE realtime.subscription SET LOGGED;
+    """)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.33.78",
+      version: "2.33.80",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION

## What kind of change does this PR introduce?

Due to incompatability with PG14, namely the lack of unlogged sequences, we need to revert back to a logged table for realtime.subcription.
