### PR TITLE
fix: Separate read and write authorization and add telemetry

### DIFF
--- a/lib/realtime/rpc.ex
+++ b/lib/realtime/rpc.ex
@@ -2,8 +2,8 @@ defmodule Realtime.Rpc do
   @moduledoc """
   RPC module for Realtime with the intent of standardizing the RPC interface and collect telemetry
   """
-  alias Realtime.Telemetry
   import Realtime.Logs
+  alias Realtime.Telemetry
 
   @doc """
   Calls external node using :rpc.call/5 and collects telemetry

--- a/lib/realtime/tenants/authorization/policies/broadcast_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/broadcast_policies.ex
@@ -4,10 +4,10 @@ defmodule Realtime.Tenants.Authorization.Policies.BroadcastPolicies do
   """
   require Logger
 
-  defstruct read: false, write: false
+  defstruct read: nil, write: nil
 
   @type t :: %__MODULE__{
-          read: boolean(),
-          write: boolean()
+          read: boolean() | nil,
+          write: boolean() | nil
         }
 end

--- a/lib/realtime/tenants/authorization/policies/presence_policies.ex
+++ b/lib/realtime/tenants/authorization/policies/presence_policies.ex
@@ -4,10 +4,10 @@ defmodule Realtime.Tenants.Authorization.Policies.PresencePolicies do
   """
   require Logger
 
-  defstruct read: false, write: false
+  defstruct read: nil, write: nil
 
   @type t :: %__MODULE__{
-          read: boolean(),
-          write: boolean()
+          read: boolean() | nil,
+          write: boolean() | nil
         }
 end

--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -120,7 +120,7 @@ defmodule Realtime.Tenants.BatchBroadcast do
   defp permissions_for_message(auth_params, {:ok, db_conn}, topic) do
     with auth_params = Map.put(auth_params, :topic, topic),
          auth_params = Authorization.build_authorization_params(auth_params),
-         {:ok, policies} <- Authorization.get_authorizations(db_conn, auth_params) do
+         {:ok, policies} <- Authorization.get_write_authorizations(db_conn, db_conn, auth_params) do
       policies
     else
       {:error, :not_found} -> nil

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -47,7 +47,7 @@ defmodule Realtime.Tenants.Connect do
   Returns the database connection for a tenant. If the tenant is not connected, it will attempt to connect to the tenant's database.
   """
   @spec lookup_or_start_connection(binary(), keyword()) ::
-          {:ok, DBConnection.t()} | {:error, term()}
+          {:ok, pid()} | {:error, term()}
   def lookup_or_start_connection(tenant_id, opts \\ []) do
     case get_status(tenant_id) do
       {:ok, conn} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.2",
+      version: "2.34.3",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Separates read and write flows for authorization to ensure we are able to only check writes when user tries to broadcast or track presence
* Adds telemetry to Database.transaction so we can check latency of queries
* Add latency on Authorization queries
