### PR TITLE
fix: Prefix replication slot and publication name

### DIFF
--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -349,11 +349,11 @@ defmodule Realtime.Tenants.ReplicationConnection do
   end
 
   def publication_name(%__MODULE__{table: table, schema: schema}) do
-    "#{schema}_#{table}_publication_#{slot_suffix()}"
+    "supabase_#{schema}_#{table}_publication_#{slot_suffix()}"
   end
 
   def replication_slot_name(%__MODULE__{table: table, schema: schema}) do
-    "#{schema}_#{table}_replication_slot_#{slot_suffix()}"
+    "supabase_#{schema}_#{table}_replication_slot_#{slot_suffix()}"
   end
 
   defp slot_suffix(), do: Application.get_env(:realtime, :slot_name_suffix)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.1",
+      version: "2.34.2",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -164,7 +164,7 @@ defmodule RealtimeWeb.TenantControllerTest do
 
         {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
 
-        assert %{rows: [["realtime_messages_replication_slot_"]]} =
+        assert %{rows: [["supabase_realtime_messages_replication_slot_"]]} =
                  Postgrex.query!(db_conn, "SELECT slot_name FROM pg_replication_slots", [])
 
         conn = delete(conn, Routes.tenant_path(conn, :delete, tenant.external_id))


### PR DESCRIPTION
## What kind of change does this PR introduce?

To make it easier to manage supabase specific elements we're adding the prefix supabase to the replication slot and publication

