### PR TITLE
fix: reject connections if tenant db has low connections available

### DIFF
--- a/lib/realtime/crypto.ex
+++ b/lib/realtime/crypto.ex
@@ -28,21 +28,6 @@ defmodule Realtime.Crypto do
     |> unpad()
   end
 
-  @doc "
-  Decrypts the given credentials
-  "
-  @spec decrypt_creds(binary(), binary(), binary(), binary(), binary()) ::
-          {binary(), binary(), binary(), binary(), binary()}
-  def decrypt_creds(host, port, name, user, pass) do
-    {
-      decrypt!(host),
-      decrypt!(port),
-      decrypt!(name),
-      decrypt!(user),
-      decrypt!(pass)
-    }
-  end
-
   defp pad(data) do
     to_add = 16 - rem(byte_size(data), 16)
     data <> :binary.copy(<<to_add>>, to_add)

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -49,7 +49,7 @@ defmodule Realtime.Tenants.Connect do
   @spec lookup_or_start_connection(binary(), keyword()) ::
           {:ok, pid()} | {:error, term()}
   def lookup_or_start_connection(tenant_id, opts \\ []) do
-    case get_status(tenant_id) |> IO.inspect() do
+    case get_status(tenant_id) do
       {:ok, conn} ->
         {:ok, conn}
 

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -171,7 +171,7 @@ defmodule Realtime.Tenants.Connect do
   def init(%{tenant_id: tenant_id} = state) do
     Logger.metadata(external_id: tenant_id, project: tenant_id)
 
-    with {:ok, acc} <- Piper.run(@pipes, state) |> IO.inspect() do
+    with {:ok, acc} <- Piper.run(@pipes, state) do
       {:ok, acc, {:continue, :run_migrations}}
     else
       {:error, :tenant_not_found} ->

--- a/lib/realtime/tenants/connect/check_connection.ex
+++ b/lib/realtime/tenants/connect/check_connection.ex
@@ -4,13 +4,12 @@ defmodule Realtime.Tenants.Connect.CheckConnection do
   """
   alias Realtime.Database
 
-  @application_name "realtime_connect"
   @behaviour Realtime.Tenants.Connect.Piper
   @impl true
   def run(acc) do
     %{tenant: tenant} = acc
 
-    case Database.check_tenant_connection(tenant, @application_name) do
+    case Database.check_tenant_connection(tenant) do
       {:ok, conn} ->
         {:ok, %{acc | db_conn_pid: conn, db_conn_reference: Process.monitor(conn)}}
 

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -133,6 +133,10 @@ defmodule RealtimeWeb.RealtimeChannel do
         msg = "Please increase your connection pool size"
         Logging.log_error_message(:warning, "IncreaseConnectionPool", msg)
 
+      {:error, :tenant_db_too_many_connections} ->
+        msg = "Database can't accept more connections, Realtime won't connect"
+        Logging.log_error_message(:warning, "DatabaseLackOfConnections", msg)
+
       {:error, :unable_to_set_policies, error} ->
         Logging.log_error_message(:warning, "UnableToSetPolicies", error)
 

--- a/lib/realtime_web/plugs/assign_tenant.ex
+++ b/lib/realtime_web/plugs/assign_tenant.ex
@@ -31,7 +31,6 @@ defmodule RealtimeWeb.Plugs.AssignTenant do
 
       assign(conn, :tenant, tenant)
     else
-      {:error, :tenant_not_found_in_host} -> error_response(conn, "Tenant not found in host")
       nil -> error_response(conn, "Tenant not found in database")
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.15",
+      version: "2.34.17",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/adapters/postgres/protocol_test.exs
+++ b/test/realtime/adapters/postgres/protocol_test.exs
@@ -1,0 +1,16 @@
+defmodule Realtime.Adapters.Postgres.ProtocolTest do
+  use ExUnit.Case
+  alias Realtime.Adapters.Postgres.Protocol
+
+  test "defguard is_write/1" do
+    require Protocol
+    assert Protocol.is_write("w")
+    refute Protocol.is_write("k")
+  end
+
+  test "defguard is_keep_alive/1" do
+    require Protocol
+    assert Protocol.is_keep_alive("k")
+    refute Protocol.is_keep_alive("w")
+  end
+end

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -5,7 +5,6 @@ defmodule Realtime.RepoTest do
   import Ecto.Query
 
   alias Realtime.Api.Message
-  alias Realtime.Crypto
   alias Realtime.Repo
   alias Realtime.Database
   alias Realtime.Tenants.Migrations
@@ -328,34 +327,9 @@ defmodule Realtime.RepoTest do
   end
 
   defp db_config() do
-    tenant = tenant_fixture()
-
-    %{
-      "db_host" => db_host,
-      "db_name" => db_name,
-      "db_password" => db_password,
-      "db_port" => db_port,
-      "db_user" => db_user
-    } = args = tenant.extensions |> hd() |> then(& &1.settings)
-
-    {host, port, name, user, pass} =
-      Crypto.decrypt_creds(
-        db_host,
-        db_port,
-        db_name,
-        db_user,
-        db_password
-      )
-
-    ssl_enforced = Database.default_ssl_param(args)
-
-    [
-      hostname: host,
-      port: port,
-      database: name,
-      password: pass,
-      username: user,
-      ssl_enforced: ssl_enforced
-    ]
+    tenant_fixture()
+    |> Realtime.Database.from_tenant("realtime_test")
+    |> Map.to_list()
+    |> Keyword.new()
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reject connections if tenant db has low connections available