### PR TITLE
fix: use ets for janitor instead of syn

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -40,7 +40,7 @@ defmodule Realtime.Application do
       )
 
     Realtime.PromEx.set_metrics_tags()
-
+    :ets.new(Realtime.Tenants.Connect, [:named_table, :set, :public])
     :syn.set_event_handler(Realtime.SynHandler)
 
     :ok = :syn.add_node_to_scopes([Realtime.Tenants.Connect])

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -225,12 +225,13 @@ defmodule Realtime.Tenants.Connect do
   def handle_continue(:setup_connected_user_events, state) do
     %{
       check_connected_user_interval: check_connected_user_interval,
-      connected_users_bucket: connected_users_bucket
+      connected_users_bucket: connected_users_bucket,
+      tenant_id: tenant_id
     } = state
 
     :ok = Phoenix.PubSub.subscribe(Realtime.PubSub, "realtime:operations:invalidate_cache")
     send_connected_user_check_message(connected_users_bucket, check_connected_user_interval)
-
+    :ets.insert(__MODULE__, {tenant_id})
     {:noreply, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.17",
+      version: "2.34.18",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -20,6 +20,7 @@ defmodule Realtime.Integration.RtChannelTest do
   alias Realtime.Integration.WebsocketClient
   alias Realtime.Repo
   alias Realtime.Tenants
+  alias Realtime.Tenants.Cache
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Migrations
 
@@ -74,6 +75,8 @@ defmodule Realtime.Integration.RtChannelTest do
   end
 
   setup do
+    Cache.invalidate_tenant_cache(@external_id)
+    Process.sleep(500)
     [tenant] = Tenant |> Repo.all() |> Repo.preload(:extensions)
     :ok = Migrations.run_migrations(tenant)
     %{tenant: tenant}
@@ -1371,10 +1374,9 @@ defmodule Realtime.Integration.RtChannelTest do
       realtime_topic = "realtime:#{random_string()}"
       WebsocketClient.join(socket, realtime_topic, %{config: config})
 
-      for _ <- 1..10 do
-        Process.sleep(100)
-
+      for _ <- 1..1000 do
         WebsocketClient.send_event(socket, realtime_topic, "broadcast", %{})
+        1..5 |> Enum.random() |> Process.sleep()
       end
 
       assert_receive %Message{
@@ -1446,8 +1448,9 @@ defmodule Realtime.Integration.RtChannelTest do
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{random_string()}"
 
-      for _ <- 1..15 do
+      for _ <- 1..1000 do
         WebsocketClient.join(socket, realtime_topic, %{config: config})
+        1..10 |> Enum.random() |> Process.sleep()
       end
 
       assert_receive %Message{

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -121,9 +121,13 @@ defmodule Realtime.DatabaseTest do
     test "on checkout error, handles raised exception as an error", %{db_conn: db_conn} do
       assert capture_log(fn ->
                Task.start(fn ->
-                 Database.transaction(db_conn, fn conn ->
-                   Postgrex.query!(conn, "SELECT pg_sleep(14)", [])
-                 end)
+                 Database.transaction(
+                   db_conn,
+                   fn conn ->
+                     Postgrex.query!(conn, "SELECT pg_sleep(20)", [])
+                   end,
+                   timeout: 20000
+                 )
                end)
 
                assert {:error, %DBConnection.ConnectionError{reason: :queue_timeout}} =


### PR DESCRIPTION
## What kind of change does this PR introduce?

ets for janitor instead of syn so we can track users that have disconnected and run cleanup if required.