### PR TITLE
fix: typo in error message for expired token

### DIFF
--- a/lib/realtime_web/channels/auth/channels_authorization.ex
+++ b/lib/realtime_web/channels/auth/channels_authorization.ex
@@ -31,7 +31,7 @@ defmodule RealtimeWeb.ChannelsAuthorization do
 
       {:error, [message: validation_timer, claim: "exp", claim_val: claim_val]}
       when is_integer(validation_timer) ->
-        msg = "Token as expired #{validation_timer - claim_val} seconds ago"
+        msg = "Token has expired #{validation_timer - claim_val} seconds ago"
         {:error, :expired_token, msg}
 
       {:error, reason} ->

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -540,7 +540,7 @@ defmodule Realtime.Integration.RtChannelTest do
     test "invalid JWT with expired token" do
       assert capture_log(fn ->
                get_connection("authenticated", %{:exp => System.system_time(:second) - 1000})
-             end) =~ "InvalidJWTToken: Token as expired 1000 seconds ago"
+             end) =~ "InvalidJWTToken: Token has expired 1000 seconds ago"
     end
 
     test "token required the role key" do
@@ -720,13 +720,13 @@ defmodule Realtime.Integration.RtChannelTest do
             event: "system",
             payload: %{
               "extension" => "system",
-              "message" => "Token as expired 1000 seconds ago",
+              "message" => "Token has expired 1000 seconds ago",
               "status" => "error"
             }
           }
         end)
 
-      assert log =~ "ChannelShutdown: Token as expired 1000 seconds ago"
+      assert log =~ "ChannelShutdown: Token has expired 1000 seconds ago"
     end
 
     test "ChannelShutdown include sub if available in jwt claims",
@@ -820,7 +820,7 @@ defmodule Realtime.Integration.RtChannelTest do
 
       assert_receive %Message{event: "phx_close"}
 
-      assert msg =~ "Token as expired"
+      assert msg =~ "Token has expired"
     end
 
     test "token expires in between joins", %{topic: topic} do
@@ -845,7 +845,7 @@ defmodule Realtime.Integration.RtChannelTest do
                        event: "phx_reply",
                        payload: %{
                          "status" => "error",
-                         "response" => %{"reason" => "Token as expired 0 seconds ago"}
+                         "response" => %{"reason" => "Token has expired 0 seconds ago"}
                        },
                        topic: ^realtime_topic
                      },
@@ -1311,7 +1311,7 @@ defmodule Realtime.Integration.RtChannelTest do
           get_connection("authenticated", %{:exp => System.system_time(:second) - 1000})
         end)
 
-      assert log =~ "InvalidJWTToken: Token as expired 1000 seconds ago"
+      assert log =~ "InvalidJWTToken: Token has expired 1000 seconds ago"
     end
   end
 

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -137,7 +137,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     test "expired token returns a error" do
       with_mock ChannelsAuthorization, [],
         authorize_conn: fn _, _, _ ->
-          {:error, :expired_token, "InvalidJWTToken: Token as expired 1000 seconds ago"}
+          {:error, :expired_token, "InvalidJWTToken: Token has expired 1000 seconds ago"}
         end do
         sub = random_string()
         conn_opts = conn_opts(@tenant_external_id, %{sub: sub})
@@ -150,7 +150,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
             Process.sleep(300)
           end)
 
-        assert log =~ "InvalidJWTToken: Token as expired 1000 seconds ago"
+        assert log =~ "InvalidJWTToken: Token has expired 1000 seconds ago"
         assert log =~ "sub=#{sub}"
       end
     end
@@ -158,7 +158,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     test "expired token returns a error with sub in metadata if available" do
       with_mock ChannelsAuthorization, [],
         authorize_conn: fn _, _, _ ->
-          {:error, :expired_token, "InvalidJWTToken: Token as expired 1000 seconds ago"}
+          {:error, :expired_token, "InvalidJWTToken: Token has expired 1000 seconds ago"}
         end do
         log =
           capture_log(fn ->
@@ -168,7 +168,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
             Process.sleep(300)
           end)
 
-        assert log =~ "InvalidJWTToken: Token as expired 1000 seconds ago"
+        assert log =~ "InvalidJWTToken: Token has expired 1000 seconds ago"
       end
     end
   end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a typo on the error messages for expired tokens. For some reason it was "Token **as** expired x seconds ago".

## What is the current behavior?

Closes #1297 

## What is the new behavior?

Changed the string to say "Token has expired x seconds ago".