### PR TITLE
fix: Reduce janitor scope to only local tenants

### DIFF
--- a/lib/realtime/tenants/janitor.ex
+++ b/lib/realtime/tenants/janitor.ex
@@ -65,7 +65,7 @@ defmodule Realtime.Tenants.Janitor do
     Logger.info("Janitor started")
     %{chunks: chunks, tasks: tasks} = state
     all_tenants = :ets.select(@table_name, [{{:"$1"}, [], [:"$1"]}])
-    connected_tenants = :ets.select(@syn_table, [{{:"$1", :_, :_, :_, :_, :_}, [], [:"$1"]}])
+    connected_tenants = :ets.select(@syn_table, [{{:"$1", :_, :_, :_, :_, Node.self()}, [], [:"$1"]}])
 
     new_tasks =
       MapSet.new(all_tenants ++ connected_tenants)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.25",
+      version: "2.34.26",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

 Reduce janitor scope to only local tenants
