### PR TITLE
fix: improve rpc metric; remove ecto metric

### DIFF
--- a/lib/realtime/monitoring/prom_ex.ex
+++ b/lib/realtime/monitoring/prom_ex.ex
@@ -73,8 +73,7 @@ defmodule Realtime.PromEx do
       {OsMon, poll_rate: poll_rate},
       {Tenants, poll_rate: poll_rate},
       {Tenant, poll_rate: poll_rate},
-      {Channels, poll_rate: poll_rate},
-      {PromEx.Plugins.Ecto, otp_app: :realtime, poll_rate: poll_rate, metric_prefix: [:ecto]}
+      {Channels, poll_rate: poll_rate}
     ]
   end
 

--- a/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
@@ -18,7 +18,8 @@ defmodule Realtime.PromEx.Plugins.Tenants do
         description: "Latency of rpc calls triggered by a tenant action",
         measurement: :latency,
         unit: {:microsecond, :millisecond},
-        reporter_options: [buckets: [10, 50, 250, 1500, 15_000]]
+        tags: [:success],
+        reporter_options: [buckets: [10, 250, 5000, 15_000]]
       )
     ])
   end

--- a/lib/realtime/rpc.ex
+++ b/lib/realtime/rpc.ex
@@ -35,8 +35,8 @@ defmodule Realtime.Rpc do
         {:ok, _} ->
           Telemetry.execute(
             [:realtime, :rpc],
-            %{latency: latency, success?: true},
-            %{mod: mod, func: func, target_node: node, origin_node: node()}
+            %{latency: latency},
+            %{mod: mod, func: func, target_node: node, origin_node: node(), success: true}
           )
 
           response
@@ -44,8 +44,8 @@ defmodule Realtime.Rpc do
         {:error, response} ->
           Telemetry.execute(
             [:realtime, :rpc],
-            %{latency: latency, success?: false},
-            %{mod: mod, func: func, target_node: node, origin_node: node()}
+            %{latency: latency},
+            %{mod: mod, func: func, target_node: node, origin_node: node(), success: false}
           )
 
           {:error, response}
@@ -55,8 +55,8 @@ defmodule Realtime.Rpc do
     kind, reason ->
       Telemetry.execute(
         [:realtime, :rpc],
-        %{latency: 0, success?: false},
-        %{mod: mod, func: func, target_node: node, origin_node: node()}
+        %{latency: 0},
+        %{mod: mod, func: func, target_node: node, origin_node: node(), success: false}
       )
 
       log_error(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.30",
+      version: "2.34.31",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Improves RPC metrics to be tagged by success
* Removes the Ecto metrics as they created bloat due to dynamic repo
