### PR TITLE
fix: remove compromised action

### DIFF
--- a/.github/workflows/version_updated.yml
+++ b/.github/workflows/version_updated.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Verify Versions Updated
-        uses: tj-actions/changed-files@v41
+        uses: step-security/changed-files@v45
         id: verify_changed_files
         with:
           files: |


### PR DESCRIPTION
Have not tested to make sure this works as expected, especially as
we're upgrading from v41 to v45. Will leave that up to the team.