### PR TITLE
fix: expose authorization metrics

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Start epmd
         run: epmd -daemon
       - name: Run tests
-        run: MIX_ENV=test MAX_CASES=2 mix coveralls.github --trace
+        run: MIX_ENV=test MAX_CASES=1 mix coveralls.github --trace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/test.exs
+++ b/config/test.exs
@@ -45,7 +45,7 @@ config :joken,
 # Print only errors during test
 config :logger,
   compile_time_purge_matching: [[module: Postgrex], [module: DBConnection]],
-  level: :error
+  level: :warning
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/config/test.exs
+++ b/config/test.exs
@@ -45,7 +45,7 @@ config :joken,
 # Print only errors during test
 config :logger,
   compile_time_purge_matching: [[module: Postgrex], [module: DBConnection]],
-  level: :warning
+  level: :error
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/coveralls.json
+++ b/coveralls.json
@@ -22,6 +22,7 @@
         "lib/realtime/tenants/authorization/policies/broadcast_policies.ex",
         "lib/realtime/tenants/authorization/policies/presence_policies.ex",
         "lib/realtime/tenants/repo/migrations/",
+        "/lib/realtime/tenants/cache_supervisor.ex",
         "test/"
     ]
 }

--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -149,7 +149,7 @@ defmodule Realtime.Database do
   @doc """
   Runs database transaction in local node or against a target node withing a Postgrex transaction
   """
-  @spec transaction(pid | DBConnection.t(), fun(), keyword()) :: {:ok, any()} | {:error, any()}
+  @spec transaction(pid | DBConnection.t(), fun(), keyword(), keyword()) :: {:ok, any()} | {:error, any()}
   def transaction(db_conn, func, opts \\ [], metadata \\ [])
 
   def transaction(%DBConnection{} = db_conn, func, opts, metadata),
@@ -173,8 +173,9 @@ defmodule Realtime.Database do
     telemetry = Keyword.get(opts, :telemetry, nil)
 
     if telemetry do
+      tenant_id = Keyword.get(opts, :tenant_id, nil)
       {latency, value} = :timer.tc(Postgrex, :transaction, [db_conn, func, opts], :millisecond)
-      Telemetry.execute(telemetry, %{latency: latency}, %{})
+      Telemetry.execute(telemetry, %{latency: latency}, %{tenant_id: tenant_id})
       value
     else
       Postgrex.transaction(db_conn, func, opts)

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -152,6 +152,20 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           measurement: :sum,
           description: "Sum of presence messages sent on a Realtime Channel.",
           tags: [:tenant]
+        ),
+        last_value(
+          [:realtime, :tenants, :read_authorization_check],
+          event_name: [:realtime, :tenants, :read_authorization_check],
+          measurement: :count,
+          description: "Last value of read authorization checks.",
+          tags: [:tenant]
+        ),
+        last_value(
+          [:realtime, :tenants, :write_authorization_check],
+          event_name: [:realtime, :tenants, :write_authorization_check],
+          measurement: :count,
+          description: "Last value of write authorization checks.",
+          tags: [:tenant]
         )
       ]
     )

--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -29,6 +29,7 @@ defmodule Realtime.Tenants.BatchBroadcast do
 
   def broadcast(%Plug.Conn{} = conn, %Tenant{} = tenant, messages, super_user) do
     auth_params = %{
+      tenant_id: tenant.external_id,
       headers: conn.req_headers,
       jwt: conn.assigns.jwt,
       claims: conn.assigns.claims,

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -698,6 +698,7 @@ defmodule RealtimeWeb.RealtimeChannel do
   defp assign_authorization_context(socket, topic, access_token, claims) do
     authorization_context =
       Authorization.build_authorization_params(%{
+        tenant_id: socket.assigns.tenant,
         topic: topic,
         headers: Map.get(socket.assigns, :headers, []),
         jwt: access_token,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.43",
+      version: "2.34.44",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -329,6 +329,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
            :authenticated_read_broadcast_and_presence,
            :authenticated_write_broadcast_and_presence
          ]
+
     test "sends telemetry event", context do
       with_mock Realtime.Telemetry, execute: fn _, _, _ -> :ok end do
         {:ok, conn} =
@@ -349,7 +350,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
           Realtime.Telemetry.execute(
             [:realtime, :tenants, :read_authorization_check],
             %{latency: :_},
-            %{}
+            %{tenant_id: context.authorization_context.tenant_id}
           )
         )
 
@@ -357,7 +358,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
           Realtime.Telemetry.execute(
             [:realtime, :tenants, :write_authorization_check],
             %{latency: :_},
-            %{}
+            %{tenant_id: context.authorization_context.tenant_id}
           )
         )
       end
@@ -380,6 +381,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
 
     authorization_context =
       Authorization.build_authorization_params(%{
+        tenant_id: tenant.external_id,
         topic: topic,
         jwt: jwt,
         claims: claims,

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -224,6 +224,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
     authorization_context =
       Authorization.build_authorization_params(%{
+        tenant_id: tenant.external_id,
         topic: topic,
         jwt: jwt,
         claims: claims,

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -207,6 +207,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
     authorization_context =
       Authorization.build_authorization_params(%{
+        tenant_id: tenant.external_id,
         topic: topic,
         jwt: jwt,
         claims: claims,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Exposes two new tenant metrics to measure time til RLS policies are verified during realtime authorization

