### PR TITLE
fix: bring back setting log level for debugging

### DIFF
--- a/.github/workflows/manual_prod_build.yml
+++ b/.github/workflows/manual_prod_build.yml
@@ -10,7 +10,7 @@ on:
         required: true
 jobs:
   docker_x86_release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
       arch: amd64

--- a/.github/workflows/prod_build.yml
+++ b/.github/workflows/prod_build.yml
@@ -5,7 +5,7 @@ on:
       - "main"
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.semantic.outputs.new_release_published }}
       version: ${{ steps.semantic.outputs.new_release_version }}
@@ -20,7 +20,7 @@ jobs:
 
   docker_x86_release:
     needs: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: needs.release.outputs.published == 'true'
     timeout-minutes: 120
     env:

--- a/.github/workflows/version_updated.yml
+++ b/.github/workflows/version_updated.yml
@@ -2,14 +2,14 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
-      - 'main'
+      - "main"
 
 name: Default Checks
 
 jobs:
   versions_updated:
     name: Versions Updated
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -19,11 +19,11 @@ jobs:
         id: verify_changed_files
         with:
           files: |
-             mix.exs
+            mix.exs
 
       - name: Fail Unless Versions Updated
         id: fail_unless_changed
         if: steps.verify_changed_files.outputs.any_changed == 'false'
         run: |
-              echo "::error ::Please update the mix.exs version"
-              exit 1
+          echo "::error ::Please update the mix.exs version"
+          exit 1

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -254,7 +254,7 @@ if System.get_env("LOGS_ENGINE") == "logflare" do
   end
 
   config :logger,
-    sync_threshold: 1_000,
-    discard_threshold: 1_000,
+    sync_threshold: 6_000,
+    discard_threshold: 6_000,
     backends: [LogflareLogger.HttpBackend]
 end

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -35,14 +35,14 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   def join("realtime:" <> sub_topic = topic, params, socket) do
     %{
-      assigns: %{tenant: tenant_id, log_level: _log_level, postgres_cdc_module: module},
+      assigns: %{tenant: tenant_id, log_level: log_level, postgres_cdc_module: module},
       channel_pid: channel_pid,
       serializer: serializer,
       transport_pid: transport_pid
     } = socket
 
     Logger.metadata(external_id: tenant_id, project: tenant_id)
-    # Logger.put_process_level(self(), log_level)
+    Logger.put_process_level(self(), log_level)
 
     socket =
       socket

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.44",
+      version: "2.34.46",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -212,7 +212,7 @@ defmodule Realtime.DatabaseTest do
   end
 
   @aux_mod (quote do
-              defmodule Aux do
+              defmodule DatabaseAux do
                 def checker(transaction_conn) do
                   Postgrex.query!(transaction_conn, "SELECT 1", [])
                 end
@@ -234,7 +234,7 @@ defmodule Realtime.DatabaseTest do
       tenant = Containers.checkout_tenant()
       {:ok, node} = Clustered.start(@aux_mod)
       {:ok, db_conn} = Rpc.call(node, Connect, :lookup_or_start_connection, [tenant.external_id])
-      assert {:ok, %Postgrex.Result{rows: [[1]]}} = Database.transaction(db_conn, &Aux.checker/1)
+      assert {:ok, %Postgrex.Result{rows: [[1]]}} = Database.transaction(db_conn, &DatabaseAux.checker/1)
       on_exit(fn -> Containers.checkin_tenant(tenant) end)
     end
 
@@ -242,7 +242,7 @@ defmodule Realtime.DatabaseTest do
       tenant = Containers.checkout_tenant()
       {:ok, node} = Clustered.start(@aux_mod)
       {:ok, db_conn} = Rpc.call(node, Connect, :lookup_or_start_connection, [tenant.external_id])
-      assert {:error, %Postgrex.Error{}} = Database.transaction(db_conn, &Aux.error/1)
+      assert {:error, %Postgrex.Error{}} = Database.transaction(db_conn, &DatabaseAux.error/1)
       on_exit(fn -> Containers.checkin_tenant(tenant) end)
     end
 
@@ -250,7 +250,7 @@ defmodule Realtime.DatabaseTest do
       tenant = Containers.checkout_tenant()
       {:ok, node} = Clustered.start(@aux_mod)
       {:ok, db_conn} = Rpc.call(node, Connect, :lookup_or_start_connection, [tenant.external_id])
-      assert {:error, %RuntimeError{}} = Database.transaction(db_conn, &Aux.exception/1)
+      assert {:error, %RuntimeError{}} = Database.transaction(db_conn, &DatabaseAux.exception/1)
       on_exit(fn -> Containers.checkin_tenant(tenant) end)
     end
   end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bring back setting log level for debugging. We're adding back channel and message level logging so users can see which messages are being sent / received when log_params are set.
