### PR TITLE
fix: enable auto reconnect on replication connection

### DIFF
--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -117,9 +117,8 @@ defmodule Realtime.Tenants.ReplicationConnection do
         ssl: connection_opts.ssl,
         backoff_type: :stop,
         sync_connect: true,
-        parameters: [
-          application_name: "realtime_replication_connection"
-        ]
+        auto_reconnect: true,
+        parameters: [application_name: "realtime_replication_connection"]
       ]
 
     case Postgrex.ReplicationConnection.start_link(__MODULE__, attrs, connection_opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.44",
+      version: "2.34.46",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enable auto reconnect on replication connection to handle failure automatically