### PR TITLE
This PR adds region and instance ID

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -51,7 +51,7 @@ config :tailwind,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id, :project, :external_id, :application_name, :sub, :error_code]
+  metadata: [:request_id, :project, :external_id, :application_name, :sub, :error_code, :region, :instance_id]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -18,7 +18,10 @@ defmodule Realtime.Application do
     :ok =
       :logger.set_primary_config(
         :metadata,
-        Enum.into([region: System.get_env("REGION")], primary_config.metadata)
+        Enum.into(
+          [region: System.get_env("REGION"), instance_id: System.get_env("INSTANCE_ID")],
+          primary_config.metadata
+        )
       )
 
     topologies = Application.get_env(:libcluster, :topologies) || []


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Feature**: Adds `region` and `instance_id` to logger metadata ([#627](https://github.com/supabase/realtime/issues/627))

---

## What is the current behavior?

This metadata is currently not included in logs, as described in issue [#627](https://github.com/supabase/realtime/issues/627).

---

## What is the new behavior?

Adds `region` and `instance_id` metadata to the logger using values from the environment:

```elixir
System.get_env("REGION")
System.get_env("INSTANCE_ID")
```

This allows these fields to be available in log output for observability and debugging.

---

## Additional context

I also considered adding a helper to make required env vars safer and more expressive:

```elixir
defp require_env!(key) do
  case System.get_env(key) do
    nil -> raise "Required environment variable #{key} is not set"
    val -> val
  end
end
```

Which would allow replacing direct `System.get_env/1` calls with:

```elixir
Enum.into(
  [region: require_env!("REGION"), instance_id: require_env!("INSTANCE_ID")],
  primary_config.metadata
)
```
I also briefly considered defaulting to safe fallbacks in dev/test environments:

```elixir
:ok =
  :logger.set_primary_config(
    :metadata,
    Enum.into(
      [
        region: System.get_env("REGION") || "unknown",
        instance_id: System.get_env("INSTANCE_ID") || "local"
      ],
      primary_config.metadata
    )
  )
```

But I wasn't sure if that was necessary, or if it might obscure misconfigured environments. If preferred, I’m happy to incorporate either approach. 😊