### PR TITLE
fix: oriole compatibility by avoiding LOGGED / UNLOGGED migrations

### DIFF
--- a/lib/realtime/tenants/repo/migrations/20240801235015_unlogged_messages_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20240801235015_unlogged_messages_table.ex
@@ -4,6 +4,7 @@ defmodule Realtime.Tenants.Migrations.UnloggedMessagesTable do
 
   def change do
     execute """
+    -- Commented to have oriole compatability
     -- ALTER TABLE realtime.messages SET UNLOGGED;
     """
   end

--- a/lib/realtime/tenants/repo/migrations/20240805133720_logged_messages_table.ex
+++ b/lib/realtime/tenants/repo/migrations/20240805133720_logged_messages_table.ex
@@ -4,6 +4,7 @@ defmodule Realtime.Tenants.Migrations.LoggedMessagesTable do
 
   def change do
     execute """
+    -- Commented to have oriole compatability
     -- ALTER TABLE realtime.messages SET LOGGED;
     """
   end

--- a/lib/realtime/tenants/repo/migrations/20250107150512_realtime_subscription_unlogged.ex
+++ b/lib/realtime/tenants/repo/migrations/20250107150512_realtime_subscription_unlogged.ex
@@ -4,7 +4,8 @@ defmodule Realtime.Tenants.Migrations.RealtimeSubscriptionUnlogged do
 
   def change do
     execute("""
-    ALTER TABLE realtime.subscription SET UNLOGGED;
+    -- Commented to have oriole compatability
+    -- ALTER TABLE realtime.subscription SET UNLOGGED;
     """)
   end
 end

--- a/lib/realtime/tenants/repo/migrations/20250110162412_realtime_subscription_logged.ex
+++ b/lib/realtime/tenants/repo/migrations/20250110162412_realtime_subscription_logged.ex
@@ -5,7 +5,8 @@ defmodule Realtime.Tenants.Migrations.RealtimeSubscriptionLogged do
   # PG Updates doesn't allow us to use UNLOGGED tables due to the fact that Sequences on PG14 still need to be logged
   def change do
     execute("""
-    ALTER TABLE realtime.subscription SET LOGGED;
+    -- Commented to have oriole compatability
+    -- ALTER TABLE realtime.subscription SET LOGGED;
     """)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.46",
+      version: "2.34.47",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

oriole compatibility by avoiding LOGGED / UNLOGGED migrations
