### PR TITLE
fix: move migration to tenant creation

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -5,7 +5,6 @@ defmodule Realtime.Tenants do
 
   require Logger
 
-  alias Realtime.Tenants.Migrations
   alias Realtime.Api.Tenant
   alias Realtime.Tenants.Connect
   alias Realtime.Repo
@@ -85,8 +84,6 @@ defmodule Realtime.Tenants do
 
       {:ok, _health_conn} ->
         connected_cluster = UsersCounter.tenant_users(external_id)
-        tenant = Cache.get_tenant_by_external_id(external_id)
-        Migrations.run_migrations(tenant)
 
         {:ok,
          %{
@@ -100,7 +97,6 @@ defmodule Realtime.Tenants do
       connected_cluster when is_integer(connected_cluster) ->
         tenant = Cache.get_tenant_by_external_id(external_id)
         {:ok, db_conn} = Database.connect(tenant, "realtime_health_check")
-        Migrations.run_migrations(tenant)
         Process.alive?(db_conn) && GenServer.stop(db_conn)
 
         {:ok,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.47",
+      version: "2.34.48",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,6 +1,10 @@
 require Logger
-alias Realtime.{Api.Tenant, Repo}
+
 import Ecto.Adapters.SQL, only: [query: 3]
+
+alias Realtime.Api.Tenant
+alias Realtime.Repo
+alias Realtime.Tenants
 
 tenant_name = System.get_env("SELF_HOST_TENANT_NAME", "realtime-dev")
 env = if :ets.whereis(Mix.State) != :undefined, do: Mix.env(), else: :prod
@@ -36,22 +40,23 @@ Repo.transaction(fn ->
     ]
   })
   |> Repo.insert!()
+
+  tenant = Tenants.get_tenant_by_external_id(tenant_name)
+  Tenants.Migrations.run_migrations(tenant)
 end)
 
 if env in [:dev, :test] do
   publication = "supabase_realtime"
 
-  {:ok, _} =
-    Repo.transaction(fn ->
-      [
-        "drop publication if exists #{publication}",
-        "drop table if exists public.test_tenant;",
-        "create table public.test_tenant ( id SERIAL PRIMARY KEY, details text );",
-        "grant all on table public.test_tenant to anon;",
-        "grant all on table public.test_tenant to postgres;",
-        "grant all on table public.test_tenant to authenticated;",
-        "create publication #{publication} for table public.test_tenant"
-      ]
-      |> Enum.each(&query(Repo, &1, []))
-    end)
+  commands = [
+    "drop publication if exists #{publication}",
+    "drop table if exists public.test_tenant;",
+    "create table public.test_tenant ( id SERIAL PRIMARY KEY, details text );",
+    "grant all on table public.test_tenant to anon;",
+    "grant all on table public.test_tenant to postgres;",
+    "grant all on table public.test_tenant to authenticated;",
+    "create publication #{publication} for table public.test_tenant"
+  ]
+
+  {:ok, _} = Repo.transaction(fn -> Enum.each(commands, &query(Repo, &1, [])) end)
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Move migrations to tenant creation instead of healthcheck. Also change seed so we can migrate on startup instead of waiting for self host / cli healthcheck running

