### PR TITLE
fix: properly set the params on creation to be fed by sub domain

### DIFF
--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -104,12 +104,14 @@ defmodule RealtimeWeb.TenantController do
     }
   )
 
-  def update(conn, %{"tenant_id" => id, "tenant" => tenant_params}) do
-    Logger.metadata(external_id: id, project: id)
-    tenant = Api.get_tenant_by_external_id(id)
+  def update(conn, %{"tenant_id" => external_id, "tenant" => tenant_params}) do
+    Logger.metadata(external_id: external_id, project: external_id)
+    tenant = Api.get_tenant_by_external_id(external_id)
 
     case tenant do
       nil ->
+        tenant_params = tenant_params |> Map.put("external_id", external_id) |> Map.put("name", external_id)
+
         extensions =
           Enum.reduce(tenant_params["extensions"], [], fn
             %{"type" => type, "settings" => settings}, acc -> [%{"type" => type, "settings" => settings} | acc]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.48",
+      version: "2.34.49",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -89,7 +89,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
         port = Enum.random(5000..9000)
-        attrs = default_tenant_attrs(external_id, port)
+        attrs = default_tenant_attrs(port)
 
         Containers.initialize_no_tenant(external_id, port)
         on_exit(fn -> Containers.stop_container(external_id) end)
@@ -109,7 +109,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
         port = Enum.random(5000..9000)
-        attrs = default_tenant_attrs(external_id, port)
+        attrs = default_tenant_attrs(port)
 
         Containers.initialize_no_tenant(external_id, port)
         on_exit(fn -> Containers.stop_container(external_id) end)
@@ -153,7 +153,7 @@ defmodule RealtimeWeb.TenantControllerTest do
         assert nil == Tenants.get_tenant_by_external_id(external_id)
 
         conn =
-          put(conn, Routes.tenant_path(conn, :update, external_id), tenant: default_tenant_attrs(external_id, port))
+          put(conn, Routes.tenant_path(conn, :update, external_id), tenant: default_tenant_attrs(port))
 
         assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
 
@@ -375,10 +375,8 @@ defmodule RealtimeWeb.TenantControllerTest do
     %{tenant: tenant}
   end
 
-  defp default_tenant_attrs(external_id, port) do
+  defp default_tenant_attrs(port) do
     %{
-      "external_id" => external_id,
-      "name" => external_id,
       "extensions" => [
         %{
           "type" => "postgres_cdc_rls",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Sets the external_id properly based on sub domain.
