### PR TITLE
fix: handle nil tenant id and test metrics clustered

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -65,11 +65,13 @@ defmodule Realtime.PromEx.Plugins.Tenant do
       cluster_count = UsersCounter.tenant_users(t)
       tenant = Tenants.Cache.get_tenant_by_external_id(t)
 
-      Telemetry.execute(
-        [:realtime, :connections],
-        %{connected: count, connected_cluster: cluster_count, limit: tenant.max_concurrent_users},
-        %{tenant: t}
-      )
+      if tenant != nil do
+        Telemetry.execute(
+          [:realtime, :connections],
+          %{connected: count, connected_cluster: cluster_count, limit: tenant.max_concurrent_users},
+          %{tenant: t}
+        )
+      end
     end
   end
 

--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -84,6 +84,30 @@ defmodule RealtimeWeb.TenantController do
     end
   end
 
+  operation(:create,
+    summary: "Create or update tenant",
+    parameters: [
+      token: [
+        in: :header,
+        name: "Authorization",
+        schema: %OpenApiSpex.Schema{type: :string},
+        required: true,
+        example:
+          "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY"
+      ],
+      tenant_id: [in: :path, description: "Tenant ID", type: :string]
+    ],
+    request_body: TenantParams.params(),
+    responses: %{
+      200 => TenantResponse.response(),
+      403 => EmptyResponse.response()
+    }
+  )
+
+  def create(conn, params) do
+    update(conn, params)
+  end
+
   operation(:update,
     summary: "Create or update tenant",
     parameters: [

--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -94,8 +94,7 @@ defmodule RealtimeWeb.TenantController do
         required: true,
         example:
           "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY"
-      ],
-      tenant_id: [in: :path, description: "Tenant ID", type: :string]
+      ]
     ],
     request_body: TenantParams.params(),
     responses: %{
@@ -104,8 +103,14 @@ defmodule RealtimeWeb.TenantController do
     }
   )
 
-  def create(conn, params) do
-    update(conn, params)
+  @spec create(any(), map()) :: any()
+  def create(conn, %{"tenant" => params}) do
+    external_id = Map.get(params, "external_id")
+
+    case Tenant.changeset(%Tenant{}, params) do
+      %{valid?: true} -> update(conn, %{"tenant_id" => external_id, "tenant" => params})
+      changeset -> changeset
+    end
   end
 
   operation(:update,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.49",
+      version: "2.34.50",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -98,6 +98,7 @@ defmodule Realtime.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: [
+        "cmd epmd -daemon",
         "ecto.create --quiet",
         "run priv/repo/seeds_before_migration.exs",
         "ecto.migrate --migrations-path=priv/repo/migrations",

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -300,8 +300,9 @@ defmodule Realtime.Integration.RtChannelTest do
     end
 
     @tag policies: [:authenticated_read_broadcast_and_presence]
-    test "private broadcast with valid channel no write permissions won't send message but will receive message",
-         %{topic: topic} do
+    test "private broadcast with valid channel no write permissions won't send message but will receive message", %{
+      topic: topic
+    } do
       config = %{broadcast: %{self: true}, private: true}
       topic = "realtime:#{topic}"
 
@@ -309,12 +310,14 @@ defmodule Realtime.Integration.RtChannelTest do
 
       WebsocketClient.join(service_role_socket, topic, %{config: config})
       assert_receive %Message{event: "phx_reply", topic: ^topic}, 500
-      assert_receive %Message{event: "presence_state"}, 500
+      assert_receive %Message{event: "presence_state"}, 1000
 
       {socket, _} = get_connection("authenticated")
       WebsocketClient.join(socket, topic, %{config: config})
       assert_receive %Message{event: "phx_reply", topic: ^topic}, 500
-      assert_receive %Message{event: "presence_state"}, 500
+      assert_receive %Message{event: "presence_state"}, 1000
+
+      Process.sleep(1000)
 
       payload = %{"event" => "TEST", "payload" => %{"msg" => 1}, "type" => "broadcast"}
       WebsocketClient.send_event(socket, topic, "broadcast", payload)

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -135,6 +135,7 @@ defmodule Realtime.DatabaseTest do
                end)
     end
 
+    @tag db_pool: 1
     test "on checkout error, handles raised exception as an error", %{db_conn: db_conn} do
       for _ <- 1..5 do
         Task.start(fn ->

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -1,0 +1,52 @@
+defmodule Realtime.PromEx.Plugins.TenantTest do
+  use Realtime.DataCase
+
+  alias Realtime.PromEx.Plugins.Tenant
+  alias Realtime.Rpc
+  alias Realtime.UsersCounter
+
+  def handle_telemetry(event, metadata, content, pid: pid), do: send(pid, {event, metadata, content})
+
+  @aux_mod (quote do
+              defmodule FakeUserCounter do
+                def fake_add(external_id) do
+                  :ok = UsersCounter.add(spawn(fn -> Process.sleep(2000) end), external_id)
+                end
+              end
+            end)
+
+  Code.eval_quoted(@aux_mod)
+
+  describe "execute_tenant_metrics/0" do
+    setup do
+      tenant = Containers.checkout_tenant()
+      :telemetry.attach(__MODULE__, [:realtime, :connections], &__MODULE__.handle_telemetry/4, pid: self())
+
+      on_exit(fn ->
+        :telemetry.detach(__MODULE__)
+        Containers.checkin_tenant(tenant)
+      end)
+
+      {:ok, node} = Clustered.start(@aux_mod)
+      %{tenant: tenant, node: node}
+    end
+
+    test "returns a list of tenant metrics and handles bad tenant ids", %{
+      tenant: %{external_id: external_id},
+      node: node
+    } do
+      UsersCounter.add(self(), external_id)
+      # Add bad tenant id
+      UsersCounter.add(self(), random_string())
+
+      _ = Rpc.call(node, FakeUserCounter, :fake_add, [external_id])
+      Process.sleep(500)
+      Tenant.execute_tenant_metrics()
+
+      assert_receive {[:realtime, :connections], %{connected: 1, limit: 200, connected_cluster: 2},
+                      %{tenant: ^external_id}}
+
+      refute_receive :_
+    end
+  end
+end

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -85,7 +85,7 @@ defmodule RealtimeWeb.TenantControllerTest do
   end
 
   describe "create tenant" do
-    test "renders tenant when data is valid", %{conn: conn} do
+    test "renders tenant when data is valid with put", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
         port = Enum.random(5000..9000)
@@ -105,7 +105,27 @@ defmodule RealtimeWeb.TenantControllerTest do
       end
     end
 
-    test "encrypt creds", %{conn: conn} do
+    test "renders tenant when data is valid with post", %{conn: conn} do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
+        external_id = random_string()
+        port = Enum.random(5000..9000)
+        attrs = default_tenant_attrs(port)
+
+        Containers.initialize_no_tenant(external_id, port)
+        on_exit(fn -> Containers.stop_container(external_id) end)
+
+        conn = post(conn, Routes.tenant_path(conn, :update, external_id), tenant: attrs)
+        assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
+        conn = get(conn, Routes.tenant_path(conn, :show, external_id))
+        assert ^external_id = json_response(conn, 200)["data"]["external_id"]
+        assert 200 = json_response(conn, 200)["data"]["max_concurrent_users"]
+        assert 100 = json_response(conn, 200)["data"]["max_channels_per_client"]
+        assert 100 = json_response(conn, 200)["data"]["max_events_per_second"]
+        assert 100 = json_response(conn, 200)["data"]["max_joins_per_second"]
+      end
+    end
+
+    test "encrypt creds with put", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
         port = Enum.random(5000..9000)
@@ -129,21 +149,80 @@ defmodule RealtimeWeb.TenantControllerTest do
       end
     end
 
-    test "renders errors when data is invalid", %{conn: conn} do
+    test "encrypt creds with post", %{conn: conn} do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
+        external_id = random_string()
+        port = Enum.random(5000..9000)
+        attrs = default_tenant_attrs(port)
+
+        Containers.initialize_no_tenant(external_id, port)
+        on_exit(fn -> Containers.stop_container(external_id) end)
+
+        conn = post(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
+
+        [%{"settings" => settings}] = json_response(conn, 201)["data"]["extensions"]
+
+        assert Crypto.encrypt!("127.0.0.1") == settings["db_host"]
+        assert Crypto.encrypt!("postgres") == settings["db_name"]
+        assert Crypto.encrypt!("supabase_admin") == settings["db_user"]
+        refute settings["db_password"]
+
+        %{extensions: [%{settings: settings}]} = Tenants.get_tenant_by_external_id(external_id)
+
+        assert Crypto.encrypt!("postgres") == settings["db_password"]
+      end
+    end
+
+    test "renders errors when data is invalid with put", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         conn = put(conn, ~p"/api/tenants/#{random_string()}", tenant: @invalid_attrs)
         assert json_response(conn, 422)["errors"] != %{}
       end
     end
 
-    test "returns 403 when jwt is invalid", %{conn: conn} do
+    test "returns 403 when jwt is invalid with put", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:error, "invalid"} end do
         conn = put(conn, ~p"/api/tenants/external_id", tenant: @default_tenant_attrs)
         assert response(conn, 403)
       end
     end
 
-    test "run migrations on creation", %{conn: conn} do
+    test "renders errors when data is invalid with post", %{conn: conn} do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
+        conn = post(conn, ~p"/api/tenants/#{random_string()}", tenant: @invalid_attrs)
+        assert json_response(conn, 422)["errors"] != %{}
+      end
+    end
+
+    test "returns 403 when jwt is invalid with post", %{conn: conn} do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:error, "invalid"} end do
+        conn = post(conn, ~p"/api/tenants/external_id", tenant: @default_tenant_attrs)
+        assert response(conn, 403)
+      end
+    end
+
+    test "run migrations on creation with post", %{conn: conn} do
+      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
+        external_id = random_string()
+        port = Enum.random(5500..9000)
+        Containers.initialize_no_tenant(external_id, port)
+        on_exit(fn -> Containers.stop_container(external_id) end)
+
+        assert nil == Tenants.get_tenant_by_external_id(external_id)
+
+        conn =
+          post(conn, Routes.tenant_path(conn, :update, external_id), tenant: default_tenant_attrs(port))
+
+        assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
+
+        tenant = Tenants.get_tenant_by_external_id(external_id)
+
+        {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+        assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
+      end
+    end
+
+    test "run migrations on creation with put", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
         port = Enum.random(5500..9000)

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -88,7 +88,14 @@ defmodule RealtimeWeb.TenantControllerTest do
     test "renders tenant when data is valid with put", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
-        port = Enum.random(5000..9000)
+
+        port =
+          5500..9000
+          |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+          |> Enum.random()
+
+        :ets.insert(:test_ports, {port})
+
         attrs = default_tenant_attrs(port)
 
         Containers.initialize_no_tenant(external_id, port)
@@ -109,7 +116,12 @@ defmodule RealtimeWeb.TenantControllerTest do
     test "renders tenant when data is valid with post", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
-        port = Enum.random(5000..9000)
+
+        port =
+          5500..9000
+          |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+          |> Enum.random()
+
         attrs = default_tenant_attrs(port)
         attrs = Map.put(attrs, "external_id", external_id)
 
@@ -131,7 +143,12 @@ defmodule RealtimeWeb.TenantControllerTest do
     test "encrypt creds with put", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
-        port = Enum.random(5000..9000)
+
+        port =
+          5500..9000
+          |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+          |> Enum.random()
+
         Containers.initialize_no_tenant(external_id, port)
         on_exit(fn -> Containers.stop_container(external_id) end)
 
@@ -154,7 +171,12 @@ defmodule RealtimeWeb.TenantControllerTest do
     test "encrypt creds with post", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
-        port = Enum.random(5000..9000)
+
+        port =
+          5500..9000
+          |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+          |> Enum.random()
+
         Containers.initialize_no_tenant(external_id, port)
         on_exit(fn -> Containers.stop_container(external_id) end)
 

--- a/test/support/clustered.ex
+++ b/test/support/clustered.ex
@@ -23,9 +23,21 @@ defmodule Clustered do
   end
   ```
   """
+  @spec start(any()) :: {:ok, node}
   def start(aux_mod \\ nil) do
-    :net_kernel.start([:"main@127.0.0.1"])
-    :erlang.set_cookie(:cookie)
+    :ok =
+      case :net_kernel.start([:"main@127.0.0.1"]) do
+        {:ok, _} ->
+          :ok
+
+        {:error, {:already_started, _}} ->
+          :ok
+
+        {:error, reason} ->
+          raise "Failed to start node: #{inspect(reason)}"
+      end
+
+    true = :erlang.set_cookie(:cookie)
 
     {:ok, pid, node} =
       :peer.start_link(%{

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -9,7 +9,14 @@ defmodule Generators do
 
   @spec tenant_fixture(map()) :: Realtime.Api.Tenant.t()
   def tenant_fixture(override \\ %{}) do
-    port = Enum.random(5500..9000)
+    if :ets.whereis(:test_ports) == :undefined, do: :ets.new(:test_ports, [:named_table, :set, :public])
+
+    port =
+      5500..9000
+      |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+      |> Enum.random()
+
+    :ets.insert(:test_ports, {port})
 
     create_attrs = %{
       "external_id" => random_string(),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Handle nil tenant id and test metrics clustered 