### PR TITLE
fix: add back migration on healthcheck

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -6,13 +6,13 @@ defmodule Realtime.Tenants do
   require Logger
 
   alias Realtime.Api.Tenant
-  alias Realtime.Tenants.Connect
+  alias Realtime.Database
   alias Realtime.Repo
   alias Realtime.Repo.Replica
   alias Realtime.Tenants.Cache
+  alias Realtime.Tenants.Connect
+  alias Realtime.Tenants.Migrations
   alias Realtime.UsersCounter
-  alias Realtime.Database
-  alias Realtime.Tenants.Cache
 
   @doc """
   Gets a list of connected tenant `external_id` strings in the cluster or a node.
@@ -98,6 +98,7 @@ defmodule Realtime.Tenants do
         tenant = Cache.get_tenant_by_external_id(external_id)
         {:ok, db_conn} = Database.connect(tenant, "realtime_health_check")
         Process.alive?(db_conn) && GenServer.stop(db_conn)
+        Migrations.run_migrations(tenant)
 
         {:ok,
          %{

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.50",
+      version: "2.34.51",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Due to a limitation in the way we create tenants we can't remove the migration code from the healthcheck
