### PR TITLE
fix: Use syn for Replication connection and Listen

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -46,6 +46,9 @@ defmodule Realtime.Application do
     :syn.set_event_handler(Realtime.SynHandler)
 
     :ok = :syn.add_node_to_scopes([Realtime.Tenants.Connect])
+    :ok = :syn.add_node_to_scopes([Realtime.Tenants.ReplicationConnection])
+    :ok = :syn.add_node_to_scopes([Realtime.Tenants.Listen])
+
     :ok = :syn.add_node_to_scopes([:users, RegionNodes])
 
     region = Application.get_env(:realtime, :region)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.51",
+      version: "2.34.52",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/listen_test.exs
+++ b/test/realtime/tenants/listen_test.exs
@@ -3,7 +3,6 @@ defmodule Realtime.Tenants.ListenTest do
   import ExUnit.CaptureLog
 
   alias Realtime.Tenants.Listen
-  alias Realtime.Tenants.Migrations
   alias Realtime.Database
 
   describe("start/1") do
@@ -17,7 +16,6 @@ defmodule Realtime.Tenants.ListenTest do
 
       {:ok, _} = Listen.start(tenant, self())
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
-      Migrations.run_migrations(tenant)
 
       {:ok, tenant: tenant, db_conn: db_conn}
     end


### PR DESCRIPTION


## What kind of change does this PR introduce?

Currently we have this two modules using Registries that are local so it's difficult to understand the status of the system.

syn will prevent this and allow us to search from any machine in our cluster for the status of the connection