### PR TITLE
fix: remove migrations from tenant creation

### DIFF
--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -11,7 +11,6 @@ defmodule RealtimeWeb.TenantController do
   alias Realtime.PostgresCdc
   alias Realtime.Tenants
   alias Realtime.Tenants.Cache
-  alias Realtime.Tenants.Migrations
   alias RealtimeWeb.OpenApiSchemas.EmptyResponse
   alias RealtimeWeb.OpenApiSchemas.ErrorResponse
   alias RealtimeWeb.OpenApiSchemas.NotFoundResponse
@@ -147,9 +146,7 @@ defmodule RealtimeWeb.TenantController do
             _e, acc -> acc
           end)
 
-        with {:ok, %Tenant{} = tenant} <-
-               Api.create_tenant(%{tenant_params | "extensions" => extensions}),
-             :ok <- Migrations.run_migrations(tenant) do
+        with {:ok, %Tenant{} = tenant} <- Api.create_tenant(%{tenant_params | "extensions" => extensions}) do
           Logger.metadata(external_id: tenant.external_id, project: tenant.external_id)
 
           conn

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.51",
+      version: "2.34.52",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -225,6 +225,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       end
     end
 
+    @tag skip: "Currently blocks infrastructure due to bottleneck on database startup"
     test "run migrations on creation with put", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()
@@ -245,6 +246,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       end
     end
 
+    @tag skip: "Currently blocks infrastructure due to bottleneck on database startup"
     test "run migrations on creation with post", %{conn: conn} do
       with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
         external_id = random_string()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Due to bottleneck during startup of the database we have accumulating work when we try to run migrations against tenant. This needs to be revisited at a later date when we improve the flow of migrations to be less blocking
