### PR TITLE
fix: On Replication Connection and Listen failure, Connect shuts down

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.51",
+      version: "2.34.52",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

On ReplicationConnection or Listen module exits we also kill the Connect module to ensure all required elements are properly started up with the next incoming connection from a client.
