### PR TITLE
fix: Selectively run migrations

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -15,6 +15,9 @@ slot_name_suffix = System.get_env("SLOT_NAME_SUFFIX")
 migration_partition_slots =
   System.get_env("MIGRATION_PARTITION_SLOTS", "#{System.schedulers_online() * 2}") |> String.to_integer()
 
+connect_partition_slots =
+  System.get_env("CONNECT_PARTITION_SLOTS", "#{System.schedulers_online() * 2}") |> String.to_integer()
+
 if !(db_version in [nil, "ipv6", "ipv4"]),
   do: raise("Invalid IP version, please set either ipv6 or ipv4")
 
@@ -35,6 +38,7 @@ socket_options =
 
 config :realtime,
   migration_partition_slots: migration_partition_slots,
+  connect_partition_slots: connect_partition_slots,
   tenant_max_bytes_per_second: System.get_env("TENANT_MAX_BYTES_PER_SECOND", "100000") |> String.to_integer(),
   tenant_max_channels_per_client: System.get_env("TENANT_MAX_CHANNELS_PER_CLIENT", "100") |> String.to_integer(),
   tenant_max_concurrent_users: System.get_env("TENANT_MAX_CONCURRENT_USERS", "200") |> String.to_integer(),

--- a/config/test.exs
+++ b/config/test.exs
@@ -35,12 +35,9 @@ config :realtime,
   secure_channels: true,
   db_enc_key: "1234567890123456",
   jwt_claim_validators: System.get_env("JWT_CLAIM_VALIDATORS", "{}"),
-  api_jwt_secret: System.get_env("API_JWT_SECRET"),
+  api_jwt_secret: System.get_env("API_JWT_SECRET", "secret"),
   metrics_jwt_secret: "test",
   prom_poll_rate: 5_000
-
-config :joken,
-  current_time_adapter: RealtimeWeb.Joken.CurrentTime.Mock
 
 # Print only errors during test
 config :logger,

--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -26,6 +26,7 @@ defmodule Realtime.Api.Tenant do
     field(:events_per_second_rolling, :float, virtual: true)
     field(:events_per_second_now, :integer, virtual: true)
     field(:private_only, :boolean, default: false)
+    field(:migrations_ran, :integer, default: 0)
 
     has_many(:extensions, Realtime.Api.Extensions,
       foreign_key: :tenant_external_id,
@@ -73,7 +74,8 @@ defmodule Realtime.Api.Tenant do
       :max_channels_per_client,
       :max_joins_per_second,
       :suspend,
-      :private_only
+      :private_only,
+      :migrations_ran
     ])
     |> validate_required([
       :external_id,

--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -51,6 +51,7 @@ defmodule Realtime.Application do
     region = Application.get_env(:realtime, :region)
     :syn.join(RegionNodes, region, self(), node: node())
     migration_partition_slots = Application.get_env(:realtime, :migration_partition_slots)
+    connect_partition_slots = Application.get_env(:realtime, :connect_partition_slots)
 
     children =
       [
@@ -75,7 +76,10 @@ defmodule Realtime.Application do
          name: Realtime.Tenants.Migrations.DynamicSupervisor,
          partitions: migration_partition_slots},
         {PartitionSupervisor,
-         child_spec: DynamicSupervisor, strategy: :one_for_one, name: Realtime.Tenants.Connect.DynamicSupervisor},
+         child_spec: DynamicSupervisor,
+         strategy: :one_for_one,
+         name: Realtime.Tenants.Connect.DynamicSupervisor,
+         partitions: connect_partition_slots},
         {PartitionSupervisor,
          child_spec: DynamicSupervisor,
          strategy: :one_for_one,

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -125,12 +125,12 @@ defmodule Realtime.Tenants.Connect do
   end
 
   @doc """
-  Returns the pid of the tenant Connection process
+  Returns the pid of the tenant Database connection process
   """
   @spec whereis(binary()) :: pid | nil
   def whereis(tenant_id) do
     case :syn.lookup(__MODULE__, tenant_id) do
-      {pid, _} -> pid
+      {_, %{conn: pid}} -> pid
       :undefined -> nil
     end
   end
@@ -141,7 +141,7 @@ defmodule Realtime.Tenants.Connect do
   @spec shutdown(binary()) :: :ok | nil
   def shutdown(tenant_id) do
     case whereis(tenant_id) do
-      pid when is_pid(pid) -> GenServer.stop(pid)
+      pid when is_pid(pid) -> Process.exit(pid, :shutdown)
       _ -> :ok
     end
   end

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -142,8 +142,8 @@ defmodule Realtime.Tenants.Connect do
   def shutdown(tenant_id) do
     case whereis(tenant_id) do
       pid when is_pid(pid) ->
-        Logger.info("Shutting down tenant connection for #{tenant_id}")
-        GenServer.stop(pid)
+        send(pid, :shutdown_connect)
+        :ok
 
       _ ->
         :ok
@@ -277,42 +277,19 @@ defmodule Realtime.Tenants.Connect do
     {:noreply, %{state | connected_users_bucket: connected_users_bucket}}
   end
 
-  def handle_info(:shutdown, state) do
-    %{
-      db_conn_pid: db_conn_pid,
-      replication_connection_pid: replication_connection_pid,
-      listen_pid: listen_pid
-    } = state
-
+  def handle_info(:shutdown_no_connected_users, state) do
     Logger.info("Tenant has no connected users, database connection will be terminated")
-    :ok = GenServer.stop(db_conn_pid, :shutdown, 500)
-
-    replication_connection_pid && Process.alive?(replication_connection_pid) &&
-      GenServer.stop(replication_connection_pid, :normal, 500)
-
-    listen_pid && Process.alive?(listen_pid) &&
-      GenServer.stop(listen_pid, :normal, 500)
-
-    {:stop, :normal, state}
+    shutdown_connect_process(state)
   end
 
   def handle_info(:suspend_tenant, state) do
-    %{
-      db_conn_pid: db_conn_pid,
-      replication_connection_pid: replication_connection_pid,
-      listen_pid: listen_pid
-    } = state
-
     Logger.warning("Tenant was suspended, database connection will be terminated")
-    :ok = GenServer.stop(db_conn_pid, :shutdown, 500)
+    shutdown_connect_process(state)
+  end
 
-    replication_connection_pid && Process.alive?(replication_connection_pid) &&
-      GenServer.stop(replication_connection_pid, :normal, 500)
-
-    listen_pid && Process.alive?(listen_pid) &&
-      GenServer.stop(listen_pid, :normal, 500)
-
-    {:stop, :normal, state}
+  def handle_info(:shutdown_connect, state) do
+    Logger.warning("Shutdowning tenant connection")
+    shutdown_connect_process(state)
   end
 
   # Handle database connection termination
@@ -375,7 +352,7 @@ defmodule Realtime.Tenants.Connect do
          @connected_users_bucket_shutdown,
          check_connected_user_interval
        ) do
-    Process.send_after(self(), :shutdown, check_connected_user_interval)
+    Process.send_after(self(), :shutdown_no_connected_users, check_connected_user_interval)
   end
 
   defp send_connected_user_check_message(connected_users_bucket, check_connected_user_interval) do
@@ -385,4 +362,22 @@ defmodule Realtime.Tenants.Connect do
 
   defp tenant_suspended?(%Tenant{suspend: true}), do: {:error, :tenant_suspended}
   defp tenant_suspended?(_), do: :ok
+
+  defp shutdown_connect_process(state) do
+    %{
+      db_conn_pid: db_conn_pid,
+      replication_connection_pid: replication_connection_pid,
+      listen_pid: listen_pid
+    } = state
+
+    :ok = GenServer.stop(db_conn_pid, :shutdown, 500)
+
+    replication_connection_pid && Process.alive?(replication_connection_pid) &&
+      GenServer.stop(replication_connection_pid, :normal, 500)
+
+    listen_pid && Process.alive?(listen_pid) &&
+      GenServer.stop(listen_pid, :normal, 500)
+
+    {:stop, :normal, state}
+  end
 end

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -196,7 +196,7 @@ defmodule Realtime.Tenants.Connect do
   def handle_continue(:run_migrations, state) do
     %{tenant: tenant, db_conn_pid: db_conn_pid} = state
 
-    with :ok <- Migrations.run_migrations(tenant),
+    with res when res in [:ok, :noop] <- Migrations.run_migrations(tenant),
          :ok <- Migrations.create_partitions(db_conn_pid) do
       {:noreply, state, {:continue, :start_listen_and_replication}}
     else

--- a/lib/realtime/tenants/connect/check_connection.ex
+++ b/lib/realtime/tenants/connect/check_connection.ex
@@ -10,8 +10,13 @@ defmodule Realtime.Tenants.Connect.CheckConnection do
     %{tenant: tenant} = acc
 
     case Database.check_tenant_connection(tenant) do
-      {:ok, conn} -> {:ok, %{acc | db_conn_pid: conn, db_conn_reference: Process.monitor(conn)}}
-      {:error, error} -> {:error, error}
+      {:ok, conn} ->
+        Process.link(conn)
+        db_conn_reference = Process.monitor(conn)
+        {:ok, %{acc | db_conn_pid: conn, db_conn_reference: db_conn_reference}}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -179,7 +179,7 @@ defmodule Realtime.Tenants.Migrations do
     Logger.metadata(external_id: tenant_external_id, project: tenant_external_id)
 
     case migrate(settings) do
-      {:ok, _} ->
+      :ok ->
         Tenants.update_migrations_ran(tenant_external_id, Enum.count(@migrations))
         :ignore
 
@@ -208,9 +208,9 @@ defmodule Realtime.Tenants.Migrations do
 
       try do
         opts = [all: true, prefix: "realtime", dynamic_repo: repo]
-        res = Ecto.Migrator.run(Repo, @migrations, :up, opts)
+        Ecto.Migrator.run(Repo, @migrations, :up, opts)
 
-        {:ok, res}
+        :ok
       rescue
         error ->
           log_error("MigrationsFailedToRun", error)

--- a/lib/realtime_web/channels/user_socket.ex
+++ b/lib/realtime_web/channels/user_socket.ex
@@ -30,7 +30,7 @@ defmodule RealtimeWeb.UserSocket do
       %{uri: %{host: host}, x_headers: headers} = opts
 
       {:ok, external_id} = Database.get_external_id(host)
-
+      external_id = String.upcase(external_id)
       Logger.metadata(external_id: external_id, project: external_id)
       Logger.put_process_level(self(), :error)
 

--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -147,9 +147,8 @@ defmodule RealtimeWeb.TenantController do
             _e, acc -> acc
           end)
 
-        with {:ok, %Tenant{} = tenant} <-
-               Api.create_tenant(%{tenant_params | "extensions" => extensions}),
-             :ok <- Migrations.run_migrations(tenant) do
+        with {:ok, %Tenant{} = tenant} <- Api.create_tenant(%{tenant_params | "extensions" => extensions}),
+             res when res in [:ok, :noop] <- Migrations.run_migrations(tenant) do
           Logger.metadata(external_id: tenant.external_id, project: tenant.external_id)
 
           conn

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -128,7 +128,6 @@ defmodule RealtimeWeb.Router do
 
   defp check_auth(conn, [secret_key, blocklist_key]) do
     secret = Application.fetch_env!(:realtime, secret_key)
-
     blocklist = Application.get_env(:realtime, blocklist_key, [])
 
     with ["Bearer " <> token] <- get_req_header(conn, "authorization"),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.52",
+      version: "2.34.53",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20250424203323_add_migrations_ran_to_tenant.exs
+++ b/priv/repo/migrations/20250424203323_add_migrations_ran_to_tenant.exs
@@ -1,0 +1,9 @@
+defmodule Realtime.Repo.Migrations.AddMigrationsRanToTenant do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenants) do
+      add(:migrations_ran, :integer, default: 0)
+    end
+  end
+end

--- a/test/api_jwt_secret_test.exs
+++ b/test/api_jwt_secret_test.exs
@@ -1,25 +1,20 @@
 defmodule RealtimeWeb.ApiJwtSecretTest do
-  # async: false due to usage of mock
   use RealtimeWeb.ConnCase, async: false
-  import Mock
-  alias RealtimeWeb.JwtVerification
 
   test "no api key", %{conn: conn} do
+    previous = Application.get_env(:realtime, :api_jwt_secret)
     Application.put_env(:realtime, :api_jwt_secret, nil)
+    on_exit(fn -> Application.put_env(:realtime, :api_jwt_secret, previous) end)
+
     conn = get(conn, Routes.tenant_path(conn, :index))
     assert conn.status == 403
   end
 
   test "api key is right", %{conn: conn} do
-    with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-      jwt = "jwt_token"
-
-      conn =
-        conn
-        |> Plug.Conn.put_req_header("authorization", "Bearer " <> jwt)
-
-      conn = get(conn, Routes.tenant_path(conn, :index))
-      assert conn.status == 200
-    end
+    api_jwt_secret = Application.get_env(:realtime, :api_jwt_secret)
+    jwt = generate_jwt_token(api_jwt_secret)
+    conn = Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> jwt)
+    conn = get(conn, Routes.tenant_path(conn, :index))
+    assert conn.status == 200
   end
 end

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -13,20 +13,19 @@ defmodule Realtime.Integration.RtChannelTest do
   alias Phoenix.Socket.Message
   alias Phoenix.Socket.V1
   alias Postgrex
+  alias Realtime.Api.Tenant
   alias Realtime.Database
   alias Realtime.GenCounter
   alias Realtime.Integration.WebsocketClient
   alias Realtime.RateCounter
   alias Realtime.Tenants
   alias Realtime.Tenants.Authorization
-  alias Realtime.Tenants.Cache
 
   @moduletag :capture_log
   @port 4002
   @serializer V1.JSONSerializer
-  @external_id "dev_tenant"
-  @uri "ws://#{@external_id}.localhost:#{@port}/socket/websocket"
-  @secret "secure_jwt_secret"
+
+  defp uri(tenant), do: "ws://#{tenant.external_id}.localhost:#{@port}/socket/websocket"
 
   defmodule TestEndpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
@@ -64,19 +63,9 @@ defmodule Realtime.Integration.RtChannelTest do
     secret_key_base: String.duplicate("a", 64)
   )
 
-  Application.delete_env(:joken, :current_time_adapter)
-
-  defmodule Token do
-    use Joken.Config
-  end
-
   setup do
-    RateCounter.stop(@external_id)
-    GenCounter.stop(@external_id)
-    Cache.invalidate_tenant_cache(@external_id)
-    Process.sleep(500)
-
-    tenant = Tenants.get_tenant_by_external_id(@external_id)
+    tenant = Containers.checkout_tenant(true)
+    on_exit(fn -> Containers.checkin_tenant(tenant) end)
 
     %{tenant: tenant}
   end
@@ -87,124 +76,150 @@ defmodule Realtime.Integration.RtChannelTest do
     :ok
   end
 
-  test "handle postgres extension" do
-    {socket, _} = get_connection()
-    topic = "realtime:any"
-    config = %{postgres_changes: [%{event: "*", schema: "public"}]}
+  describe "postgres changes" do
+    setup %{tenant: tenant} do
+      {:ok, conn} = Database.connect(tenant, "realtime_test")
 
-    WebsocketClient.join(socket, topic, %{config: config})
-    sub_id = :erlang.phash2(%{"event" => "*", "schema" => "public"})
+      Database.transaction(conn, fn db_conn ->
+        queries = [
+          "create sequence if not exists test_id_seq;",
+          """
+          create table "public"."test" (
+          "id" int4 not null default nextval('test_id_seq'::regclass),
+          "details" text,
+          primary key ("id"));
+          """,
+          "grant all on table public.test to anon;",
+          "grant all on table public.test to postgres;",
+          "grant all on table public.test to authenticated;",
+          "create publication supabase_realtime_test for all tables"
+        ]
 
-    assert_receive %Message{
-                     event: "phx_reply",
-                     payload: %{
-                       "response" => %{
-                         "postgres_changes" => [
-                           %{"event" => "*", "id" => ^sub_id, "schema" => "public"}
-                         ]
+        Enum.each(queries, &Postgrex.query!(db_conn, &1, []))
+      end)
+
+      :ok
+    end
+
+    test "handle postgres extension", %{tenant: tenant} do
+      {socket, _} = get_connection(tenant)
+      topic = "realtime:any"
+      config = %{postgres_changes: [%{event: "*", schema: "public"}]}
+
+      WebsocketClient.join(socket, topic, %{config: config})
+      sub_id = :erlang.phash2(%{"event" => "*", "schema" => "public"})
+
+      assert_receive %Message{
+                       event: "phx_reply",
+                       payload: %{
+                         "response" => %{
+                           "postgres_changes" => [
+                             %{"event" => "*", "id" => ^sub_id, "schema" => "public"}
+                           ]
+                         },
+                         "status" => "ok"
                        },
-                       "status" => "ok"
+                       ref: "1",
+                       topic: ^topic
                      },
-                     ref: "1",
-                     topic: ^topic
-                   },
-                   200
+                     200
 
-    assert_receive %Phoenix.Socket.Message{event: "presence_state", payload: %{}, topic: ^topic}, 500
+      assert_receive %Phoenix.Socket.Message{event: "presence_state", payload: %{}, topic: ^topic}, 500
 
-    assert_receive %Message{
-                     event: "system",
-                     payload: %{
-                       "channel" => "any",
-                       "extension" => "postgres_changes",
-                       "message" => "Subscribed to PostgreSQL",
-                       "status" => "ok"
-                     },
-                     ref: nil,
-                     topic: ^topic
-                   },
-                   8000
-
-    {:ok, _, conn} = PostgresCdcRls.get_manager_conn(@external_id)
-    Postgrex.query!(conn, "insert into test (details) values ('test')", [])
-
-    assert_receive %Message{
-                     event: "postgres_changes",
-                     payload: %{
-                       "data" => %{
-                         "columns" => [
-                           %{"name" => "id", "type" => "int4"},
-                           %{"name" => "details", "type" => "text"}
-                         ],
-                         "commit_timestamp" => _ts,
-                         "errors" => nil,
-                         "record" => %{"details" => "test", "id" => id},
-                         "schema" => "public",
-                         "table" => "test",
-                         "type" => "INSERT"
+      assert_receive %Message{
+                       event: "system",
+                       payload: %{
+                         "channel" => "any",
+                         "extension" => "postgres_changes",
+                         "message" => "Subscribed to PostgreSQL",
+                         "status" => "ok"
                        },
-                       "ids" => [^sub_id]
+                       ref: nil,
+                       topic: ^topic
                      },
-                     ref: nil,
-                     topic: "realtime:any"
-                   },
-                   500
+                     8000
 
-    Postgrex.query!(conn, "update test set details = 'test' where id = #{id}", [])
+      {:ok, _, conn} = PostgresCdcRls.get_manager_conn(tenant.external_id)
+      Postgrex.query!(conn, "insert into test (details) values ('test')", [])
 
-    assert_receive %Message{
-                     event: "postgres_changes",
-                     payload: %{
-                       "data" => %{
-                         "columns" => [
-                           %{"name" => "id", "type" => "int4"},
-                           %{"name" => "details", "type" => "text"}
-                         ],
-                         "commit_timestamp" => _ts,
-                         "errors" => nil,
-                         "old_record" => %{"id" => ^id},
-                         "record" => %{"details" => "test", "id" => ^id},
-                         "schema" => "public",
-                         "table" => "test",
-                         "type" => "UPDATE"
+      assert_receive %Message{
+                       event: "postgres_changes",
+                       payload: %{
+                         "data" => %{
+                           "columns" => [
+                             %{"name" => "id", "type" => "int4"},
+                             %{"name" => "details", "type" => "text"}
+                           ],
+                           "commit_timestamp" => _ts,
+                           "errors" => nil,
+                           "record" => %{"details" => "test", "id" => id},
+                           "schema" => "public",
+                           "table" => "test",
+                           "type" => "INSERT"
+                         },
+                         "ids" => [^sub_id]
                        },
-                       "ids" => [^sub_id]
+                       ref: nil,
+                       topic: "realtime:any"
                      },
-                     ref: nil,
-                     topic: "realtime:any"
-                   },
-                   500
+                     500
 
-    Postgrex.query!(conn, "delete from test where id = #{id}", [])
+      Postgrex.query!(conn, "update test set details = 'test' where id = #{id}", [])
 
-    assert_receive %Message{
-                     event: "postgres_changes",
-                     payload: %{
-                       "data" => %{
-                         "columns" => [
-                           %{"name" => "id", "type" => "int4"},
-                           %{"name" => "details", "type" => "text"}
-                         ],
-                         "commit_timestamp" => _ts,
-                         "errors" => nil,
-                         "old_record" => %{"id" => ^id},
-                         "schema" => "public",
-                         "table" => "test",
-                         "type" => "DELETE"
+      assert_receive %Message{
+                       event: "postgres_changes",
+                       payload: %{
+                         "data" => %{
+                           "columns" => [
+                             %{"name" => "id", "type" => "int4"},
+                             %{"name" => "details", "type" => "text"}
+                           ],
+                           "commit_timestamp" => _ts,
+                           "errors" => nil,
+                           "old_record" => %{"id" => ^id},
+                           "record" => %{"details" => "test", "id" => ^id},
+                           "schema" => "public",
+                           "table" => "test",
+                           "type" => "UPDATE"
+                         },
+                         "ids" => [^sub_id]
                        },
-                       "ids" => [^sub_id]
+                       ref: nil,
+                       topic: "realtime:any"
                      },
-                     ref: nil,
-                     topic: "realtime:any"
-                   },
-                   500
+                     500
+
+      Postgrex.query!(conn, "delete from test where id = #{id}", [])
+
+      assert_receive %Message{
+                       event: "postgres_changes",
+                       payload: %{
+                         "data" => %{
+                           "columns" => [
+                             %{"name" => "id", "type" => "int4"},
+                             %{"name" => "details", "type" => "text"}
+                           ],
+                           "commit_timestamp" => _ts,
+                           "errors" => nil,
+                           "old_record" => %{"id" => ^id},
+                           "schema" => "public",
+                           "table" => "test",
+                           "type" => "DELETE"
+                         },
+                         "ids" => [^sub_id]
+                       },
+                       ref: nil,
+                       topic: "realtime:any"
+                     },
+                     500
+    end
   end
 
   describe "handle broadcast extension" do
     setup [:rls_context]
 
-    test "public broadcast" do
-      {socket, _} = get_connection()
+    test "public broadcast", %{tenant: tenant} do
+      {socket, _} = get_connection(tenant)
 
       config = %{
         broadcast: %{self: true},
@@ -228,9 +243,10 @@ defmodule Realtime.Integration.RtChannelTest do
            :authenticated_write_broadcast_and_presence
          ]
     test "private broadcast with valid channel with permissions sends message", %{
+      tenant: tenant,
       topic: topic
     } do
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: true}
       topic = "realtime:#{topic}"
       WebsocketClient.join(socket, topic, %{config: config})
@@ -265,9 +281,9 @@ defmodule Realtime.Integration.RtChannelTest do
          ],
          topic: "topic"
     test "private broadcast with valid channel a colon character sends message and won't intercept in public channels",
-         %{topic: topic} do
-      {anon_socket, _} = get_connection("anon")
-      {socket, _} = get_connection("authenticated")
+         %{topic: topic, tenant: tenant} do
+      {anon_socket, _} = get_connection(tenant, "anon")
+      {socket, _} = get_connection(tenant, "authenticated")
       valid_topic = "realtime:#{topic}"
       malicious_topic = "realtime:private:#{topic}"
 
@@ -300,18 +316,19 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence]
     test "private broadcast with valid channel no write permissions won't send message but will receive message", %{
+      tenant: tenant,
       topic: topic
     } do
       config = %{broadcast: %{self: true}, private: true}
       topic = "realtime:#{topic}"
 
-      {service_role_socket, _} = get_connection("service_role")
+      {service_role_socket, _} = get_connection(tenant, "service_role")
 
       WebsocketClient.join(service_role_socket, topic, %{config: config})
       assert_receive %Message{event: "phx_reply", topic: ^topic}, 500
       assert_receive %Message{event: "presence_state"}, 1000
 
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       WebsocketClient.join(socket, topic, %{config: config})
       assert_receive %Message{event: "phx_reply", topic: ^topic}, 500
       assert_receive %Message{event: "presence_state"}, 1000
@@ -347,13 +364,13 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag policies: []
     test "private broadcast with valid channel and no read permissions won't join",
-         %{topic: topic} do
+         %{tenant: tenant, topic: topic} do
       config = %{private: true}
 
       expected = "You do not have permissions to read from this Channel topic: #{topic}"
 
       topic = "realtime:#{topic}"
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
 
       log =
         capture_log(fn ->
@@ -378,8 +395,8 @@ defmodule Realtime.Integration.RtChannelTest do
   describe "handle presence extension" do
     setup [:rls_context]
 
-    test "public presence" do
-      {socket, _} = get_connection()
+    test "public presence", %{tenant: tenant} do
+      {socket, _} = get_connection(tenant)
       config = %{presence: %{key: ""}, private: false}
       topic = "realtime:any"
 
@@ -409,8 +426,8 @@ defmodule Realtime.Integration.RtChannelTest do
            :authenticated_write_broadcast_and_presence
          ]
     test "private presence with read and write permissions will be able to track and receive presence changes",
-         %{topic: topic} do
-      {socket, _} = get_connection("authenticated")
+         %{tenant: tenant, topic: topic} do
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{presence: %{key: ""}, private: true}
       topic = "realtime:#{topic}"
       WebsocketClient.join(socket, topic, %{config: config})
@@ -433,9 +450,9 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence]
     test "private presence with read permissions will be able to receive presence changes but won't be able to track",
-         %{topic: topic} do
-      {socket, _} = get_connection("authenticated")
-      {secondary_socket, _} = get_connection("service_role")
+         %{tenant: tenant, topic: topic} do
+      {socket, _} = get_connection(tenant, "authenticated")
+      {secondary_socket, _} = get_connection(tenant, "service_role")
       config = fn key -> %{presence: %{key: key}, private: true} end
       topic = "realtime:#{topic}"
 
@@ -492,20 +509,24 @@ defmodule Realtime.Integration.RtChannelTest do
            :authenticated_read_broadcast_and_presence,
            :authenticated_write_broadcast_and_presence
          ]
-    test "invalid JWT with expired token" do
-      log = capture_log(fn -> get_connection("authenticated", %{:exp => System.system_time(:second) - 1000}) end)
+    test "invalid JWT with expired token", %{tenant: tenant} do
+      log =
+        capture_log(fn -> get_connection(tenant, "authenticated", %{:exp => System.system_time(:second) - 1000}) end)
+
       assert log =~ "InvalidJWTToken: Token has expired"
     end
 
-    test "token required the role key" do
-      {:ok, token} = token_no_role()
-      assert {:error, %{status_code: 403}} = WebsocketClient.connect(self(), @uri, @serializer, [{"x-api-key", token}])
+    test "token required the role key", %{tenant: tenant} do
+      {:ok, token} = token_no_role(tenant)
+
+      assert {:error, %{status_code: 403}} =
+               WebsocketClient.connect(self(), uri(tenant), @serializer, [{"x-api-key", token}])
     end
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "on new access_token and channel is private policies are reevaluated for read policy",
-         %{topic: topic} do
-      {socket, access_token} = get_connection("authenticated")
+         %{tenant: tenant, topic: topic} do
+      {socket, access_token} = get_connection(tenant, "authenticated")
 
       realtime_topic = "realtime:#{topic}"
 
@@ -517,7 +538,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
 
-      {:ok, new_token} = token_valid("anon")
+      {:ok, new_token} = token_valid(tenant, "anon")
 
       WebsocketClient.send_event(socket, realtime_topic, "access_token", %{"access_token" => new_token})
 
@@ -537,7 +558,7 @@ defmodule Realtime.Integration.RtChannelTest do
       topic: topic,
       tenant: tenant
     } do
-      {socket, access_token} = get_connection("authenticated")
+      {socket, access_token} = get_connection(tenant, "authenticated")
       realtime_topic = "realtime:#{topic}"
       config = %{broadcast: %{self: true}, private: true}
       WebsocketClient.join(socket, realtime_topic, %{config: config, access_token: access_token})
@@ -559,7 +580,7 @@ defmodule Realtime.Integration.RtChannelTest do
 
       # Set new token to recheck policies
       {:ok, new_token} =
-        generate_token(%{exp: System.system_time(:second) + 1000, role: "authenticated", sub: random_string()})
+        generate_token(tenant, %{exp: System.system_time(:second) + 1000, role: "authenticated", sub: random_string()})
 
       WebsocketClient.send_event(socket, realtime_topic, "access_token", %{"access_token" => new_token})
 
@@ -575,9 +596,9 @@ defmodule Realtime.Integration.RtChannelTest do
                      1500
     end
 
-    test "on new access_token and channel is public policies are not reevaluated", %{topic: topic} do
-      {socket, access_token} = get_connection("authenticated")
-      {:ok, new_token} = token_valid("anon")
+    test "on new access_token and channel is public policies are not reevaluated", %{tenant: tenant, topic: topic} do
+      {socket, access_token} = get_connection(tenant, "authenticated")
+      {:ok, new_token} = token_valid(tenant, "anon")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
@@ -591,8 +612,8 @@ defmodule Realtime.Integration.RtChannelTest do
       refute_receive %Message{}
     end
 
-    test "on empty string access_token the socket sends an error message", %{topic: topic} do
-      {socket, access_token} = get_connection("authenticated")
+    test "on empty string access_token the socket sends an error message", %{tenant: tenant, topic: topic} do
+      {socket, access_token} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
@@ -610,10 +631,10 @@ defmodule Realtime.Integration.RtChannelTest do
       }
     end
 
-    test "on expired access_token the socket sends an error message", %{topic: topic} do
+    test "on expired access_token the socket sends an error message", %{tenant: tenant, topic: topic} do
       sub = random_string()
 
-      {socket, access_token} = get_connection("authenticated", %{sub: sub})
+      {socket, access_token} = get_connection(tenant, "authenticated", %{sub: sub})
 
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
@@ -622,7 +643,7 @@ defmodule Realtime.Integration.RtChannelTest do
 
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
-      {:ok, token} = generate_token(%{:exp => System.system_time(:second) - 1000, sub: sub})
+      {:ok, token} = generate_token(tenant, %{:exp => System.system_time(:second) - 1000, sub: sub})
 
       log =
         capture_log([log_level: :warning], fn ->
@@ -638,15 +659,15 @@ defmodule Realtime.Integration.RtChannelTest do
       assert log =~ "ChannelShutdown: Token has expired 1000 seconds ago"
     end
 
-    test "ChannelShutdown include sub if available in jwt claims", %{topic: topic} do
+    test "ChannelShutdown include sub if available in jwt claims", %{tenant: tenant, topic: topic} do
       sub = random_string()
 
-      {socket, access_token} = get_connection("authenticated", %{sub: sub}, %{log_level: :warning})
+      {socket, access_token} = get_connection(tenant, "authenticated", %{sub: sub}, %{log_level: :warning})
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
       WebsocketClient.join(socket, realtime_topic, %{config: config, access_token: access_token})
-      {:ok, token} = generate_token(%{:exp => System.system_time(:second) - 1000, sub: sub})
+      {:ok, token} = generate_token(tenant, %{:exp => System.system_time(:second) - 1000, sub: sub})
 
       log =
         capture_log([level: :warning], fn ->
@@ -659,8 +680,8 @@ defmodule Realtime.Integration.RtChannelTest do
       assert log =~ "sub=#{sub}"
     end
 
-    test "missing claims close connection", %{topic: topic} do
-      {socket, access_token} = get_connection("authenticated")
+    test "missing claims close connection", %{tenant: tenant, topic: topic} do
+      {socket, access_token} = get_connection(tenant, "authenticated")
 
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
@@ -669,7 +690,7 @@ defmodule Realtime.Integration.RtChannelTest do
 
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
-      {:ok, token} = generate_token(%{:exp => System.system_time(:second) + 2000})
+      {:ok, token} = generate_token(tenant, %{:exp => System.system_time(:second) + 2000})
 
       # Update token to be a near expiring token
       WebsocketClient.send_event(socket, realtime_topic, "access_token", %{"access_token" => token})
@@ -687,8 +708,8 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_close"}
     end
 
-    test "checks token periodically", %{topic: topic} do
-      {socket, access_token} = get_connection("authenticated")
+    test "checks token periodically", %{tenant: tenant, topic: topic} do
+      {socket, access_token} = get_connection(tenant, "authenticated")
 
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
@@ -698,7 +719,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
 
-      {:ok, token} = generate_token(%{:exp => System.system_time(:second) + 2, role: "authenticated"})
+      {:ok, token} = generate_token(tenant, %{:exp => System.system_time(:second) + 2, role: "authenticated"})
 
       # Update token to be a near expiring token
       WebsocketClient.send_event(socket, realtime_topic, "access_token", %{"access_token" => token})
@@ -715,8 +736,8 @@ defmodule Realtime.Integration.RtChannelTest do
       assert msg =~ "Token has expired"
     end
 
-    test "token expires in between joins", %{topic: topic} do
-      {socket, access_token} = get_connection("authenticated")
+    test "token expires in between joins", %{tenant: tenant, topic: topic} do
+      {socket, access_token} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
@@ -725,7 +746,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
 
-      {:ok, access_token} = generate_token(%{:exp => System.system_time(:second) + 1, role: "authenticated"})
+      {:ok, access_token} = generate_token(tenant, %{:exp => System.system_time(:second) + 1, role: "authenticated"})
 
       # token expires in between joins so it needs to be handled by the channel and not the socket
       Process.sleep(1000)
@@ -742,8 +763,8 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_close"}
     end
 
-    test "token loses claims in between joins", %{topic: topic} do
-      {socket, access_token} = get_connection("authenticated")
+    test "token loses claims in between joins", %{tenant: tenant, topic: topic} do
+      {socket, access_token} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
@@ -752,7 +773,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
 
-      {:ok, access_token} = generate_token(%{:exp => System.system_time(:second) + 10})
+      {:ok, access_token} = generate_token(tenant, %{:exp => System.system_time(:second) + 10})
 
       # token breaks claims in between joins so it needs to be handled by the channel and not the socket
       Process.sleep(1000)
@@ -772,8 +793,8 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_close"}
     end
 
-    test "token is badly formatted in between joins", %{topic: topic} do
-      {socket, access_token} = get_connection("authenticated")
+    test "token is badly formatted in between joins", %{tenant: tenant, topic: topic} do
+      {socket, access_token} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
@@ -797,13 +818,13 @@ defmodule Realtime.Integration.RtChannelTest do
     end
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
-    test "handles RPC error on token refreshed", %{topic: topic} do
+    test "handles RPC error on token refreshed", %{tenant: tenant, topic: topic} do
       with_mocks [
         {Authorization, [:passthrough], build_authorization_params: &passthrough([&1])},
         {Authorization, [:passthrough],
          get_read_authorizations: [in_series([:_, :_, :_], [&passthrough([&1, &2, &3]), {:error, "RPC Error"}])]}
       ] do
-        {socket, access_token} = get_connection("authenticated")
+        {socket, access_token} = get_connection(tenant, "authenticated")
         config = %{broadcast: %{self: true}, private: true}
         realtime_topic = "realtime:#{topic}"
 
@@ -813,7 +834,8 @@ defmodule Realtime.Integration.RtChannelTest do
         assert_receive %Phoenix.Socket.Message{event: "presence_state"}, 500
 
         # Update token to force update
-        {:ok, access_token} = generate_token(%{:exp => System.system_time(:second) + 1000, role: "authenticated"})
+        {:ok, access_token} =
+          generate_token(tenant, %{:exp => System.system_time(:second) + 1000, role: "authenticated"})
 
         log =
           capture_log([log_level: :warning], fn ->
@@ -843,11 +865,12 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "broadcast insert event changes on insert in table with trigger", %{
+      tenant: tenant,
       topic: topic,
       db_conn: db_conn,
       table_name: table_name
     } do
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: true}
       topic = "realtime:#{topic}"
 
@@ -883,12 +906,13 @@ defmodule Realtime.Integration.RtChannelTest do
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence],
          requires_data: true
     test "broadcast update event changes on update in table with trigger", %{
+      tenant: tenant,
       topic: topic,
       db_conn: db_conn,
       table_name: table_name
     } do
       value = random_string()
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: true}
       topic = "realtime:#{topic}"
 
@@ -927,11 +951,12 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "broadcast delete event changes on delete in table with trigger", %{
+      tenant: tenant,
       topic: topic,
       db_conn: db_conn,
       table_name: table_name
     } do
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: true}
       topic = "realtime:#{topic}"
 
@@ -968,10 +993,11 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "broadcast event when function 'send' is called with private topic", %{
+      tenant: tenant,
       topic: topic,
       db_conn: db_conn
     } do
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: true}
       full_topic = "realtime:#{topic}"
 
@@ -1005,10 +1031,11 @@ defmodule Realtime.Integration.RtChannelTest do
     end
 
     test "broadcast event when function 'send' is called with public topic", %{
+      tenant: tenant,
       topic: topic,
       db_conn: db_conn
     } do
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       full_topic = "realtime:#{topic}"
 
@@ -1044,9 +1071,12 @@ defmodule Realtime.Integration.RtChannelTest do
     setup [:rls_context]
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
-    test "user with only private channels enabled will not be able to join public channels", %{topic: topic} do
-      change_tenant_configuration(:private_only, true)
-      {socket, _} = get_connection("authenticated")
+    test "user with only private channels enabled will not be able to join public channels", %{
+      tenant: tenant,
+      topic: topic
+    } do
+      change_tenant_configuration(tenant, :private_only, true)
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       topic = "realtime:#{topic}"
 
@@ -1061,34 +1091,35 @@ defmodule Realtime.Integration.RtChannelTest do
                      },
                      500
 
-      change_tenant_configuration(:private_only, false)
+      change_tenant_configuration(tenant, :private_only, false)
     end
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "user with only private channels enabled will be able to join private channels", %{
+      tenant: tenant,
       topic: topic
     } do
-      change_tenant_configuration(:private_only, true)
+      change_tenant_configuration(tenant, :private_only, true)
 
-      Realtime.Tenants.Cache.invalidate_tenant_cache(@external_id)
+      Realtime.Tenants.Cache.invalidate_tenant_cache(tenant.external_id)
 
       Process.sleep(100)
 
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: true}
       topic = "realtime:#{topic}"
       WebsocketClient.join(socket, topic, %{config: config})
 
       assert_receive %Message{event: "phx_reply"}, 500
-      change_tenant_configuration(:private_only, false)
+      change_tenant_configuration(tenant, :private_only, false)
     end
   end
 
   describe "sensitive information updates" do
     setup [:rls_context]
 
-    test "on jwks the socket closes and sends a system message", %{topic: topic} do
-      {socket, _} = get_connection("authenticated")
+    test "on jwks the socket closes and sends a system message", %{tenant: tenant, topic: topic} do
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
@@ -1096,7 +1127,7 @@ defmodule Realtime.Integration.RtChannelTest do
 
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
-      tenant = Tenants.get_tenant_by_external_id(@external_id)
+      tenant = Tenants.get_tenant_by_external_id(tenant.external_id)
       Realtime.Api.update_tenant(tenant, %{jwt_jwks: %{keys: ["potato"]}})
 
       assert_receive %Message{
@@ -1111,8 +1142,8 @@ defmodule Realtime.Integration.RtChannelTest do
                      500
     end
 
-    test "on jwt_secret the socket closes and sends a system message", %{topic: topic} do
-      {socket, _} = get_connection("authenticated")
+    test "on jwt_secret the socket closes and sends a system message", %{tenant: tenant, topic: topic} do
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
@@ -1121,7 +1152,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
 
-      tenant = Tenants.get_tenant_by_external_id(@external_id)
+      tenant = Tenants.get_tenant_by_external_id(tenant.external_id)
       Realtime.Api.update_tenant(tenant, %{jwt_secret: "potato"})
 
       assert_receive %Message{
@@ -1136,8 +1167,8 @@ defmodule Realtime.Integration.RtChannelTest do
                      500
     end
 
-    test "on other param changes the socket won't close and no message is sent", %{topic: topic} do
-      {socket, _} = get_connection("authenticated")
+    test "on other param changes the socket won't close and no message is sent", %{tenant: tenant, topic: topic} do
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{topic}"
 
@@ -1146,7 +1177,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "phx_reply"}, 500
       assert_receive %Message{event: "presence_state"}, 500
 
-      tenant = Tenants.get_tenant_by_external_id(@external_id)
+      tenant = Tenants.get_tenant_by_external_id(tenant.external_id)
       Realtime.Api.update_tenant(tenant, %{max_concurrent_users: 100})
 
       refute_receive %Message{
@@ -1161,8 +1192,10 @@ defmodule Realtime.Integration.RtChannelTest do
                      500
     end
 
-    test "invalid JWT with expired token" do
-      log = capture_log(fn -> get_connection("authenticated", %{:exp => System.system_time(:second) - 1000}) end)
+    test "invalid JWT with expired token", %{tenant: tenant} do
+      log =
+        capture_log(fn -> get_connection(tenant, "authenticated", %{:exp => System.system_time(:second) - 1000}) end)
+
       assert log =~ "InvalidJWTToken: Token has expired"
     end
   end
@@ -1170,11 +1203,11 @@ defmodule Realtime.Integration.RtChannelTest do
   describe "rate limits" do
     setup [:rls_context]
 
-    test "max_concurrent_users limit respected" do
-      %{max_concurrent_users: max_concurrent_users} = Tenants.get_tenant_by_external_id(@external_id)
-      change_tenant_configuration(:max_concurrent_users, 1)
+    test "max_concurrent_users limit respected", %{tenant: tenant} do
+      %{max_concurrent_users: max_concurrent_users} = Tenants.get_tenant_by_external_id(tenant.external_id)
+      change_tenant_configuration(tenant, :max_concurrent_users, 1)
 
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{random_string()}"
       WebsocketClient.join(socket, realtime_topic, %{config: config})
@@ -1191,14 +1224,14 @@ defmodule Realtime.Integration.RtChannelTest do
 
       assert_receive %Message{event: "phx_close"}
 
-      change_tenant_configuration(:max_concurrent_users, max_concurrent_users)
+      change_tenant_configuration(tenant, :max_concurrent_users, max_concurrent_users)
     end
 
-    test "max_events_per_second limit respected" do
-      %{max_events_per_second: max_concurrent_users} = Tenants.get_tenant_by_external_id(@external_id)
-      change_tenant_configuration(:max_events_per_second, 1)
+    test "max_events_per_second limit respected", %{tenant: tenant} do
+      %{max_events_per_second: max_concurrent_users} = Tenants.get_tenant_by_external_id(tenant.external_id)
+      change_tenant_configuration(tenant, :max_events_per_second, 1)
 
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{random_string()}"
 
@@ -1221,14 +1254,14 @@ defmodule Realtime.Integration.RtChannelTest do
 
       assert_receive %Message{event: "phx_close"}
 
-      change_tenant_configuration(:max_events_per_second, max_concurrent_users)
+      change_tenant_configuration(tenant, :max_events_per_second, max_concurrent_users)
     end
 
-    test "max_channels_per_client limit respected" do
-      %{max_events_per_second: max_concurrent_users} = Tenants.get_tenant_by_external_id(@external_id)
-      change_tenant_configuration(:max_channels_per_client, 1)
+    test "max_channels_per_client limit respected", %{tenant: tenant} do
+      %{max_events_per_second: max_concurrent_users} = Tenants.get_tenant_by_external_id(tenant.external_id)
+      change_tenant_configuration(tenant, :max_channels_per_client, 1)
 
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic_1 = "realtime:#{random_string()}"
       realtime_topic_2 = "realtime:#{random_string()}"
@@ -1255,14 +1288,14 @@ defmodule Realtime.Integration.RtChannelTest do
       refute_receive %Message{event: "phx_reply", topic: ^realtime_topic_2}, 500
       refute_receive %Message{event: "presence_state", topic: ^realtime_topic_2}, 500
 
-      change_tenant_configuration(:max_channels_per_client, max_concurrent_users)
+      change_tenant_configuration(tenant, :max_channels_per_client, max_concurrent_users)
     end
 
-    test "max_joins_per_second limit respected" do
-      %{max_joins_per_second: max_joins_per_second} = Tenants.get_tenant_by_external_id(@external_id)
-      change_tenant_configuration(:max_joins_per_second, 1)
+    test "max_joins_per_second limit respected", %{tenant: tenant} do
+      %{max_joins_per_second: max_joins_per_second} = Tenants.get_tenant_by_external_id(tenant.external_id)
+      change_tenant_configuration(tenant, :max_joins_per_second, 1)
 
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{random_string()}"
 
@@ -1280,7 +1313,7 @@ defmodule Realtime.Integration.RtChannelTest do
                      },
                      2000
 
-      change_tenant_configuration(:max_joins_per_second, max_joins_per_second)
+      change_tenant_configuration(tenant, :max_joins_per_second, max_joins_per_second)
     end
   end
 
@@ -1290,8 +1323,8 @@ defmodule Realtime.Integration.RtChannelTest do
     @tag role: "authenticated",
          policies: [:broken_read_presence, :broken_write_presence]
 
-    test "handle failing rls policy" do
-      {socket, _} = get_connection("authenticated")
+    test "handle failing rls policy", %{tenant: tenant} do
+      {socket, _} = get_connection(tenant, "authenticated")
       config = %{broadcast: %{self: true}, private: true}
       topic = random_string()
       realtime_topic = "realtime:#{topic}"
@@ -1319,8 +1352,8 @@ defmodule Realtime.Integration.RtChannelTest do
     end
   end
 
-  test "handle empty topic by closing the socket" do
-    {socket, _} = get_connection("authenticated")
+  test "handle empty topic by closing the socket", %{tenant: tenant} do
+    {socket, _} = get_connection(tenant, "authenticated")
     config = %{broadcast: %{self: true}, private: false}
     realtime_topic = "realtime:"
 
@@ -1352,7 +1385,7 @@ defmodule Realtime.Integration.RtChannelTest do
   end
 
   describe "billable events" do
-    setup do
+    setup %{tenant: tenant} do
       events = [
         [:realtime, :rate_counter, :channel, :joins],
         [:realtime, :rate_counter, :channel, :events],
@@ -1369,8 +1402,8 @@ defmodule Realtime.Integration.RtChannelTest do
 
       {:ok, _} = Agent.start_link(fn -> %{joins: 0, events: 0, db_events: 0, presence_events: 0} end, name: TestCounter)
 
-      RateCounter.stop(@external_id)
-      GenCounter.stop(@external_id)
+      RateCounter.stop(tenant.external_id)
+      GenCounter.stop(tenant.external_id)
       :telemetry.detach(__MODULE__)
       :telemetry.attach_many(__MODULE__, events, &__MODULE__.handle_telemetry/4, [])
 
@@ -1379,11 +1412,11 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag skip: "This tests are skipped because they are flaky due to the fact that it's using the same tenant database"
 
-    test "join events" do
+    test "join events", %{tenant: tenant} do
       # Wait for timer to run GenCounter and RateCounter tickers to clean them
       Process.sleep(5000)
 
-      {socket, _} = get_connection()
+      {socket, _} = get_connection(tenant)
       config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "public"}]}
       topic = "realtime:any"
 
@@ -1410,11 +1443,11 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag skip: "This tests are skipped because they are flaky due to the fact that it's using the same tenant database"
 
-    test "broadcast events" do
+    test "broadcast events", %{tenant: tenant} do
       # Wait for timer to run GenCounter and RateCounter tickers to clean them
       Process.sleep(5000)
 
-      {socket, _} = get_connection()
+      {socket, _} = get_connection(tenant)
       config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "public"}]}
       topic = "realtime:any"
 
@@ -1426,7 +1459,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{topic: ^topic, event: "system"}, 5000
 
       # Add second client so we can test the "multiplication" of billable events
-      {socket, _} = get_connection()
+      {socket, _} = get_connection(tenant)
       WebsocketClient.join(socket, topic, %{config: config})
 
       # Join events
@@ -1458,11 +1491,11 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag skip: "This tests are skipped because they are flaky due to the fact that it's using the same tenant database"
 
-    test "presence events" do
+    test "presence events", %{tenant: tenant} do
       # Wait for timer to run GenCounter and RateCounter tickers to clean them
       Process.sleep(5000)
 
-      {socket, _} = get_connection()
+      {socket, _} = get_connection(tenant)
       config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "public"}]}
       topic = "realtime:any"
 
@@ -1474,7 +1507,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{topic: ^topic, event: "system"}, 5000
 
       # Presence events
-      {socket, _} = get_connection("authenticated")
+      {socket, _} = get_connection(tenant, "authenticated")
       WebsocketClient.join(socket, topic, %{config: config})
 
       assert_receive %Message{event: "phx_reply", topic: ^topic}, 500
@@ -1497,11 +1530,11 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag skip: "This tests are skipped because they are flaky due to the fact that it's using the same tenant database"
 
-    test "postgres changes events" do
+    test "postgres changes events", %{tenant: tenant} do
       # Wait for timer to run GenCounter and RateCounter tickers to clean them
       Process.sleep(5000)
 
-      {socket, _} = get_connection()
+      {socket, _} = get_connection(tenant)
       config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "public"}]}
       topic = "realtime:any"
 
@@ -1513,7 +1546,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{topic: ^topic, event: "system"}, 5000
 
       # Add second user to test the "multiplication" of billable events
-      {socket, _} = get_connection()
+      {socket, _} = get_connection(tenant)
       WebsocketClient.join(socket, topic, %{config: config})
       assert_receive %Message{event: "phx_reply", topic: ^topic}, 500
       assert_receive %Message{topic: ^topic, event: "presence_state"}, 500
@@ -1521,7 +1554,7 @@ defmodule Realtime.Integration.RtChannelTest do
 
       # Postgres Change events
       for _ <- 1..5 do
-        tenant = Tenants.get_tenant_by_external_id(@external_id)
+        tenant = Tenants.get_tenant_by_external_id(tenant.external_id)
         {:ok, conn} = Database.connect(tenant, "realtime_test", :stop)
         Postgrex.query!(conn, "insert into test (details) values ('test')", [])
 
@@ -1549,11 +1582,11 @@ defmodule Realtime.Integration.RtChannelTest do
 
     @tag skip: "This tests are skipped because they are flaky due to the fact that it's using the same tenant database"
 
-    test "postgres changes error events" do
+    test "postgres changes error events", %{tenant: tenant} do
       # Wait for timer to run GenCounter and RateCounter tickers to clean them
       Process.sleep(5000)
 
-      {socket, _} = get_connection()
+      {socket, _} = get_connection(tenant)
       config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "none"}]}
       topic = "realtime:any"
 
@@ -1579,28 +1612,29 @@ defmodule Realtime.Integration.RtChannelTest do
     end
   end
 
-  defp token_valid(role, claims \\ %{}), do: generate_token(Map.put(claims, :role, role))
-  defp token_no_role, do: generate_token()
+  defp token_valid(tenant, role, claims \\ %{}), do: generate_token(tenant, Map.put(claims, :role, role))
+  defp token_no_role(tenant), do: generate_token(tenant)
 
-  defp generate_token(claims \\ %{}) do
+  defp generate_token(tenant, claims \\ %{}) do
     claims =
       Map.merge(
         %{ref: "127.0.0.1", iat: System.system_time(:second), exp: System.system_time(:second) + 604_800},
         claims
       )
 
-    {:ok, generate_jwt_token(@secret, claims)}
+    {:ok, generate_jwt_token(tenant, claims)}
   end
 
   defp get_connection(
+         tenant,
          role \\ "anon",
          claims \\ %{},
          params \\ %{vsn: "1.0.0", log_level: :warning}
        ) do
     params = Enum.reduce(params, "", fn {k, v}, acc -> "#{acc}&#{k}=#{v}" end)
-    uri = "#{@uri}?#{params}"
+    uri = "#{uri(tenant)}?#{params}"
 
-    with {:ok, token} <- token_valid(role, claims),
+    with {:ok, token} <- token_valid(tenant, role, claims),
          {:ok, socket} <- WebsocketClient.connect(self(), uri, @serializer, [{"x-api-key", token}]) do
       {socket, token}
     end
@@ -1619,10 +1653,10 @@ defmodule Realtime.Integration.RtChannelTest do
   end
 
   def setup_trigger(%{tenant: tenant, topic: topic} = context) do
-    Realtime.Tenants.Connect.shutdown(@external_id)
+    Realtime.Tenants.Connect.shutdown(tenant.external_id)
     Process.sleep(500)
 
-    {:ok, db_conn} = Realtime.Tenants.Connect.connect(@external_id)
+    {:ok, db_conn} = Realtime.Tenants.Connect.connect(tenant.external_id)
 
     random_name = String.downcase("test_#{random_string()}")
     query = "CREATE TABLE #{random_name} (id serial primary key, details text)"
@@ -1669,12 +1703,12 @@ defmodule Realtime.Integration.RtChannelTest do
     |> Map.put(:table_name, random_name)
   end
 
-  defp change_tenant_configuration(limit, value) do
-    @external_id
+  defp change_tenant_configuration(%Tenant{external_id: external_id}, limit, value) do
+    external_id
     |> Realtime.Tenants.get_tenant_by_external_id()
     |> Realtime.Api.Tenant.changeset(%{limit => value})
     |> Realtime.Repo.update!()
 
-    Realtime.Tenants.Cache.invalidate_tenant_cache(@external_id)
+    Realtime.Tenants.Cache.invalidate_tenant_cache(external_id)
   end
 end

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -40,8 +40,7 @@ defmodule Realtime.Integration.RtChannelTest do
         connect_info: [:peer_data, :uri, :x_headers],
         fullsweep_after: 20,
         max_frame_size: 8_000_000
-      ],
-      longpoll: true
+      ]
     )
 
     plug(Plug.Session, @session_config)

--- a/test/realtime/api_test.exs
+++ b/test/realtime/api_test.exs
@@ -48,7 +48,11 @@ defmodule Realtime.ApiTest do
 
   describe "create_tenant/1" do
     test "valid data creates a tenant" do
-      port = Enum.random(5500..8000)
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
+
       external_id = random_string()
 
       valid_attrs = %{

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -25,7 +25,10 @@ defmodule Realtime.DatabaseTest do
 
   describe "check_tenant_connection/1" do
     setup context do
-      port = Enum.random(5500..9000)
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
 
       extensions = [
         %{

--- a/test/realtime/messages_test.exs
+++ b/test/realtime/messages_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.MessagesTest do
-  use Realtime.DataCase, async: true
+  use Realtime.DataCase, async: false
 
   alias Realtime.Api.Message
   alias Realtime.Database

--- a/test/realtime/monitoring/prom_ex/plugins/tenants_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenants_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.PromEx.Plugins.TenantsTest do
-  use Realtime.DataCase, async: true
+  use Realtime.DataCase, async: false
 
   alias Realtime.PromEx.Plugins.Tenants
   alias Realtime.Rpc

--- a/test/realtime/repo_test.exs
+++ b/test/realtime/repo_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.RepoTest do
-  use Realtime.DataCase, async: true
+  use Realtime.DataCase, async: false
 
   import Ecto.Query
 

--- a/test/realtime/tenants/cache_supervisor_test.exs
+++ b/test/realtime/tenants/cache_supervisor_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.Tenants.CacheSupervisorTest do
-  use Realtime.DataCase, async: true
+  use Realtime.DataCase, async: false
 
   alias Realtime.Api.Tenant
   alias Realtime.Tenants.Cache

--- a/test/realtime/tenants/cache_test.exs
+++ b/test/realtime/tenants/cache_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.Tenants.CacheTest do
-  use Realtime.DataCase, async: true
+  use Realtime.DataCase, async: false
 
   alias Realtime.Api
   alias Realtime.Tenants.Cache

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -227,8 +227,10 @@ defmodule Realtime.Tenants.ConnectTest do
       refute_receive :too_many_connections
     end
 
-    test "on migrations failure, stop the process", %{tenant: tenant} do
+    test "on migrations failure, stop the process" do
       with_mock Realtime.Tenants.Migrations, [], run_migrations: fn _ -> raise("error") end do
+        tenant = tenant_fixture()
+        tenant = Containers.initialize(tenant, true)
         assert {:ok, pid} = Connect.lookup_or_start_connection(tenant.external_id)
         Process.sleep(1000)
         refute Process.alive?(pid)

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -65,7 +65,10 @@ defmodule Realtime.Tenants.ConnectTest do
     end
 
     test "if tenant exists but unable to connect, returns error" do
-      port = Enum.random(5500..9000)
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
 
       extensions = [
         %{
@@ -194,7 +197,10 @@ defmodule Realtime.Tenants.ConnectTest do
     end
 
     test "properly handles of failing calls by avoid creating too many connections" do
-      port = Enum.random(5500..6000)
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
 
       tenant =
         tenant_fixture(%{
@@ -388,7 +394,10 @@ defmodule Realtime.Tenants.ConnectTest do
     end
 
     test "tenant not able to connect if database has not enough connections" do
-      port = Enum.random(5500..9000)
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
 
       extensions = [
         %{

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -169,12 +169,15 @@ defmodule Realtime.Tenants.ConnectTest do
     end
 
     test "handles tenant suspension only on targetted suspended user" do
-      tenant1 = Containers.checkout_tenant(true)
-      tenant2 = Containers.checkout_tenant(true)
+      tenant1 = tenant_fixture()
+      tenant1 = Containers.initialize(tenant1, true, true)
+
+      tenant2 = tenant_fixture()
+      tenant2 = Containers.initialize(tenant2, true, true)
 
       on_exit(fn ->
-        Containers.checkin_tenant(tenant1)
-        Containers.checkin_tenant(tenant2)
+        Containers.stop_container(tenant1)
+        Containers.stop_container(tenant2)
       end)
 
       assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant1.external_id)

--- a/test/realtime/tenants/janitor_test.exs
+++ b/test/realtime/tenants/janitor_test.exs
@@ -130,7 +130,10 @@ defmodule Realtime.Tenants.JanitorTest do
   end
 
   test "logs error if fails to connect to tenant" do
-    port = Enum.random(5500..8000)
+    port =
+      5500..9000
+      |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+      |> Enum.random()
 
     extensions = [
       %{

--- a/test/realtime/tenants/listen_test.exs
+++ b/test/realtime/tenants/listen_test.exs
@@ -3,7 +3,6 @@ defmodule Realtime.Tenants.ListenTest do
   import ExUnit.CaptureLog
 
   alias Realtime.Tenants.Listen
-  alias Realtime.Tenants.Migrations
   alias Realtime.Database
 
   describe("start/1") do
@@ -17,7 +16,6 @@ defmodule Realtime.Tenants.ListenTest do
 
       {:ok, _} = Listen.start(tenant, self())
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
-      Migrations.run_migrations(tenant)
 
       {:ok, tenant: tenant, db_conn: db_conn}
     end

--- a/test/realtime/tenants/listen_test.exs
+++ b/test/realtime/tenants/listen_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.Tenants.ListenTest do
-  use Realtime.DataCase, async: true
+  use Realtime.DataCase, async: false
   import ExUnit.CaptureLog
 
   alias Realtime.Tenants.Listen

--- a/test/realtime/tenants/migrations_test.exs
+++ b/test/realtime/tenants/migrations_test.exs
@@ -1,6 +1,6 @@
 defmodule Realtime.Tenants.MigrationsTest do
   alias Realtime.Tenants.Cache
-  use Realtime.DataCase, async: true
+  use Realtime.DataCase, async: false
 
   alias Realtime.Tenants.Migrations
 

--- a/test/realtime/tenants/migrations_test.exs
+++ b/test/realtime/tenants/migrations_test.exs
@@ -1,16 +1,14 @@
 defmodule Realtime.Tenants.MigrationsTest do
+  alias Realtime.Tenants.Cache
   use Realtime.DataCase, async: true
 
   alias Realtime.Tenants.Migrations
 
   describe "run_migrations/1" do
-    setup do
+    test "migrations for a given tenant only run once" do
       tenant = Containers.checkout_tenant()
       on_exit(fn -> Containers.checkin_tenant(tenant) end)
-      %{tenant: tenant}
-    end
 
-    test "migrations for a given tenant only run once", %{tenant: tenant} do
       res =
         for _ <- 0..10 do
           Task.async(fn -> Migrations.run_migrations(tenant) end)
@@ -19,6 +17,20 @@ defmodule Realtime.Tenants.MigrationsTest do
         |> Enum.uniq()
 
       assert [:ok] = res
+    end
+
+    test "migrations run if tenant has migrations_ran set to 0" do
+      tenant = Containers.checkout_tenant()
+      on_exit(fn -> Containers.checkin_tenant(tenant) end)
+
+      assert Migrations.run_migrations(tenant) == :ok
+      Process.sleep(100)
+      assert Cache.get_tenant_by_external_id(tenant.external_id).migrations_ran == Enum.count(Migrations.migrations())
+    end
+
+    test "migrations do not run if tenant has migrations_ran at the count of all migrations" do
+      tenant = tenant_fixture(%{migrations_ran: Enum.count(Migrations.migrations())})
+      assert Migrations.run_migrations(tenant) == :noop
     end
   end
 end

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -104,7 +104,7 @@ defmodule Realtime.TenantsTest do
   describe "update_migrations_ran/1" do
     test "updates migrations_ran to the count of all migrations" do
       tenant = tenant_fixture(%{migrations_ran: 0})
-      Tenants.update_migrations_ran(tenant, 1)
+      Tenants.update_migrations_ran(tenant.external_id, 1)
       tenant = Repo.reload!(tenant)
       assert tenant.migrations_ran == 1
     end

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -1,5 +1,6 @@
 defmodule Realtime.TenantsTest do
   # async: false due to cache usage
+  alias Realtime.Tenants.Migrations
   use Realtime.DataCase, async: false
 
   alias Realtime.GenCounter
@@ -82,6 +83,30 @@ defmodule Realtime.TenantsTest do
       tenant = Repo.reload!(tenant)
       assert tenant.suspend == true
       refute_receive :unsuspend_tenant, 500
+    end
+  end
+
+  describe "run_migrations?/1" do
+    test "returns true if migrations_ran is lower than existing migrations" do
+      tenant = tenant_fixture(%{migrations_ran: 0})
+      assert Tenants.run_migrations?(tenant.external_id)
+
+      tenant = tenant_fixture(%{migrations_ran: Enum.count(Migrations.migrations()) - 1})
+      assert Tenants.run_migrations?(tenant.external_id)
+    end
+
+    test "returns false if migrations_ran is count of all migrations" do
+      tenant = tenant_fixture(%{migrations_ran: Enum.count(Migrations.migrations())})
+      refute Tenants.run_migrations?(tenant.external_id)
+    end
+  end
+
+  describe "update_migrations_ran/1" do
+    test "updates migrations_ran to the count of all migrations" do
+      tenant = tenant_fixture(%{migrations_ran: 0})
+      Tenants.update_migrations_ran(tenant, 1)
+      tenant = Repo.reload!(tenant)
+      assert tenant.migrations_ran == 1
     end
   end
 end

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -195,9 +195,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
     RateCounter.new(tenant.external_id)
     GenCounter.new(tenant.external_id)
 
-    on_exit(fn ->
-      Containers.checkin_tenant(tenant)
-    end)
+    on_exit(fn -> Containers.checkin_tenant(tenant) end)
 
     {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
     Process.sleep(500)

--- a/test/realtime_web/channels/realtime_channel/logging_test.exs
+++ b/test/realtime_web/channels/realtime_channel/logging_test.exs
@@ -8,11 +8,13 @@ defmodule RealtimeWeb.RealtimeChannel.LoggingTest do
 
   setup do
     :telemetry.attach(__MODULE__, [:realtime, :channel, :error], &__MODULE__.handle_telemetry/4, pid: self())
-    on_exit(fn -> :telemetry.detach(__MODULE__) end)
-
     level = Logger.level()
-    Logger.configure(level: :debug)
-    on_exit(fn -> Logger.configure(level: level) end)
+    Logger.configure(level: :info)
+
+    on_exit(fn ->
+      :telemetry.detach(__MODULE__)
+      Logger.configure(level: level)
+    end)
   end
 
   describe "maybe_log_handle_info/2" do

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -161,7 +161,10 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     end
 
     test "unsuccessful connection halts join" do
-      port = Enum.random(5500..9000)
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
 
       extensions = [
         %{
@@ -190,7 +193,10 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     end
 
     test "lack of connections halts join" do
-      port = Enum.random(5500..9000)
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
 
       extensions = [
         %{

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -50,7 +50,12 @@ defmodule RealtimeWeb.TenantControllerTest do
   describe "create tenant with post" do
     test "run migrations on creation", %{conn: conn} do
       external_id = random_string()
-      port = Enum.random(5500..9000)
+
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
+
       Containers.initialize_no_tenant(external_id, port)
       on_exit(fn -> Containers.stop_container(external_id) end)
       assert nil == Tenants.get_tenant_by_external_id(external_id)
@@ -71,7 +76,12 @@ defmodule RealtimeWeb.TenantControllerTest do
   describe "create tenant with put" do
     test "run migrations on creation", %{conn: conn} do
       external_id = random_string()
-      port = Enum.random(5500..9000)
+
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
+
       Containers.initialize_no_tenant(external_id, port)
       on_exit(fn -> Containers.stop_container(external_id) end)
       assert nil == Tenants.get_tenant_by_external_id(external_id)

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.TenantControllerTest do
-  use RealtimeWeb.ConnCase, async: true
+  use RealtimeWeb.ConnCase, async: false
 
   alias Realtime.Api.Tenant
   alias Realtime.Crypto

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -1,8 +1,5 @@
 defmodule RealtimeWeb.TenantControllerTest do
-  # async: false due to the usage of mocks
-  use RealtimeWeb.ConnCase, async: false
-
-  import Mock
+  use RealtimeWeb.ConnCase, async: true
 
   alias Realtime.Api.Tenant
   alias Realtime.Crypto
@@ -12,299 +9,214 @@ defmodule RealtimeWeb.TenantControllerTest do
   alias Realtime.Tenants.Cache
   alias Realtime.Tenants.Connect
   alias Realtime.UsersCounter
-  alias RealtimeWeb.ChannelsAuthorization
-  alias RealtimeWeb.JwtVerification
-
-  @update_attrs %{
-    jwt_secret: "some updated jwt_secret",
-    name: "some updated name",
-    max_concurrent_users: 300,
-    max_channels_per_client: 150,
-    max_events_per_second: 250,
-    max_joins_per_second: 50
-  }
-
-  @default_tenant_attrs %{
-    "external_id" => "external_id",
-    "name" => "external_id",
-    "extensions" => [
-      %{
-        "type" => "postgres_cdc_rls",
-        "settings" => %{
-          "db_host" => "127.0.0.1",
-          "db_name" => "postgres",
-          "db_user" => "supabase_admin",
-          "db_password" => "postgres",
-          "db_port" => "6432",
-          "poll_interval" => 100,
-          "poll_max_changes" => 100,
-          "poll_max_record_bytes" => 1_048_576,
-          "region" => "us-east-1"
-        }
-      }
-    ],
-    "postgres_cdc_default" => "postgres_cdc_rls",
-    "jwt_secret" => "new secret"
-  }
 
   @invalid_attrs %{external_id: nil, jwt_secret: nil, extensions: [], name: nil}
 
-  setup %{conn: conn} do
-    Application.put_env(:realtime, :db_enc_key, "1234567890123456")
+  setup context do
+    %{conn: conn} = context
+    key = Application.get_env(:realtime, :api_jwt_secret)
+    jwt = generate_jwt_token(key)
 
-    new_conn =
+    conn =
       conn
       |> put_req_header("accept", "application/json")
-      |> put_req_header(
-        "authorization",
-        "Bearer auth_token"
-      )
+      |> put_req_header("authorization", "Bearer #{jwt}")
 
-    on_exit(fn -> Realtime.Tenants.Connect.shutdown("dev_tenant") end)
+    {:ok, conn: conn}
+  end
 
-    {:ok, conn: new_conn}
+  defp with_tenant(context) do
+    tenant = Containers.checkout_tenant(true)
+    on_exit(fn -> Containers.checkin_tenant(tenant) end)
+    Map.put(context, :tenant, tenant)
   end
 
   describe "show tenant" do
-    test "removes db_password", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        conn = get(conn, Routes.tenant_path(conn, :show, "dev_tenant"))
-        response = json_response(conn, 200)
+    setup [:with_tenant]
 
-        refute get_in(response, ["data", "extensions", Access.at(0), "settings", "db_password"])
-      end
+    test "removes db_password", %{conn: conn, tenant: tenant} do
+      conn = get(conn, ~p"/api/tenants/#{tenant.external_id}")
+      response = json_response(conn, 200)
+      refute get_in(response, ["data", "extensions", Access.at(0), "settings", "db_password"])
     end
 
     test "returns not found on non existing tenant", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        conn = get(conn, Routes.tenant_path(conn, :show, "nope"))
-        response = json_response(conn, 404)
-        assert response == %{"error" => "not found"}
-      end
+      conn = get(conn, ~p"/api/tenants/no")
+      response = json_response(conn, 404)
+      assert response == %{"error" => "not found"}
     end
   end
 
-  describe "create tenant" do
-    test "renders tenant when data is valid with put", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        external_id = random_string()
+  describe "create tenant with post" do
+    test "run migrations on creation", %{conn: conn} do
+      external_id = random_string()
+      port = Enum.random(5500..9000)
+      Containers.initialize_no_tenant(external_id, port)
+      on_exit(fn -> Containers.stop_container(external_id) end)
+      assert nil == Tenants.get_tenant_by_external_id(external_id)
 
-        port =
-          5500..9000
-          |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
-          |> Enum.random()
+      attrs = default_tenant_attrs(port)
+      attrs = Map.put(attrs, "external_id", external_id)
 
-        :ets.insert(:test_ports, {port})
+      conn = post(conn, ~p"/api/tenants", tenant: attrs)
 
-        attrs = default_tenant_attrs(port)
+      assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
 
-        Containers.initialize_no_tenant(external_id, port)
-        on_exit(fn -> Containers.stop_container(external_id) end)
-
-        conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
-        assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
-
-        conn = get(conn, Routes.tenant_path(conn, :show, external_id))
-        assert ^external_id = json_response(conn, 200)["data"]["external_id"]
-        assert 200 = json_response(conn, 200)["data"]["max_concurrent_users"]
-        assert 100 = json_response(conn, 200)["data"]["max_channels_per_client"]
-        assert 100 = json_response(conn, 200)["data"]["max_events_per_second"]
-        assert 100 = json_response(conn, 200)["data"]["max_joins_per_second"]
-      end
-    end
-
-    test "renders tenant when data is valid with post", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        external_id = random_string()
-
-        port =
-          5500..9000
-          |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
-          |> Enum.random()
-
-        attrs = default_tenant_attrs(port)
-        attrs = Map.put(attrs, "external_id", external_id)
-
-        Containers.initialize_no_tenant(external_id, port)
-        on_exit(fn -> Containers.stop_container(external_id) end)
-
-        conn = post(conn, ~p"/api/tenants", tenant: attrs)
-        assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
-
-        conn = get(conn, Routes.tenant_path(conn, :show, external_id))
-        assert ^external_id = json_response(conn, 200)["data"]["external_id"]
-        assert 200 = json_response(conn, 200)["data"]["max_concurrent_users"]
-        assert 100 = json_response(conn, 200)["data"]["max_channels_per_client"]
-        assert 100 = json_response(conn, 200)["data"]["max_events_per_second"]
-        assert 100 = json_response(conn, 200)["data"]["max_joins_per_second"]
-      end
-    end
-
-    test "encrypt creds with put", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        external_id = random_string()
-
-        port =
-          5500..9000
-          |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
-          |> Enum.random()
-
-        Containers.initialize_no_tenant(external_id, port)
-        on_exit(fn -> Containers.stop_container(external_id) end)
-
-        attrs = default_tenant_attrs(port)
-        conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
-
-        [%{"settings" => settings}] = json_response(conn, 201)["data"]["extensions"]
-
-        assert Crypto.encrypt!("127.0.0.1") == settings["db_host"]
-        assert Crypto.encrypt!("postgres") == settings["db_name"]
-        assert Crypto.encrypt!("supabase_admin") == settings["db_user"]
-        refute settings["db_password"]
-
-        %{extensions: [%{settings: settings}]} = Tenants.get_tenant_by_external_id(external_id)
-
-        assert Crypto.encrypt!("postgres") == settings["db_password"]
-      end
-    end
-
-    test "encrypt creds with post", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        external_id = random_string()
-
-        port =
-          5500..9000
-          |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
-          |> Enum.random()
-
-        Containers.initialize_no_tenant(external_id, port)
-        on_exit(fn -> Containers.stop_container(external_id) end)
-
-        attrs = default_tenant_attrs(port)
-        attrs = Map.put(attrs, "external_id", external_id)
-        conn = post(conn, ~p"/api/tenants", tenant: attrs)
-
-        [%{"settings" => settings}] = json_response(conn, 201)["data"]["extensions"]
-
-        assert Crypto.encrypt!("127.0.0.1") == settings["db_host"]
-        assert Crypto.encrypt!("postgres") == settings["db_name"]
-        assert Crypto.encrypt!("supabase_admin") == settings["db_user"]
-        refute settings["db_password"]
-
-        %{extensions: [%{settings: settings}]} = Tenants.get_tenant_by_external_id(external_id)
-
-        assert Crypto.encrypt!("postgres") == settings["db_password"]
-      end
-    end
-
-    test "renders errors when data is invalid with put", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        conn = put(conn, ~p"/api/tenants/#{random_string()}", tenant: @invalid_attrs)
-        assert json_response(conn, 422)["errors"] != %{}
-      end
-    end
-
-    test "renders errors when data is invalid with post", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        conn = post(conn, ~p"/api/tenants", tenant: @invalid_attrs)
-        assert json_response(conn, 422)["errors"] != %{}
-      end
-    end
-
-    test "returns 403 when jwt is invalid with put", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:error, "invalid"} end do
-        conn = put(conn, ~p"/api/tenants/external_id", tenant: @default_tenant_attrs)
-        assert response(conn, 403)
-      end
-    end
-
-    test "returns 403 when jwt is invalid with post", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:error, "invalid"} end do
-        conn = post(conn, ~p"/api/tenants", tenant: @default_tenant_attrs)
-        assert response(conn, 403)
-      end
-    end
-
-    test "run migrations on creation with put", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        external_id = random_string()
-        port = Enum.random(5500..9000)
-        Containers.initialize_no_tenant(external_id, port)
-        on_exit(fn -> Containers.stop_container(external_id) end)
-        assert nil == Tenants.get_tenant_by_external_id(external_id)
-
-        attrs = default_tenant_attrs(port)
-
-        conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
-
-        assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
-
-        tenant = Tenants.get_tenant_by_external_id(external_id)
-        {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
-        assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
-      end
-    end
-
-    test "run migrations on creation with post", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        external_id = random_string()
-        port = Enum.random(5500..9000)
-        Containers.initialize_no_tenant(external_id, port)
-        on_exit(fn -> Containers.stop_container(external_id) end)
-        assert nil == Tenants.get_tenant_by_external_id(external_id)
-
-        attrs = default_tenant_attrs(port)
-        attrs = Map.put(attrs, "external_id", external_id)
-
-        conn = post(conn, ~p"/api/tenants", tenant: attrs)
-
-        assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
-
-        tenant = Tenants.get_tenant_by_external_id(external_id)
-        {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
-        assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
-      end
+      tenant = Tenants.get_tenant_by_external_id(external_id)
+      {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+      assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
     end
   end
 
-  describe "update tenant" do
-    setup do
-      tenant = tenant_fixture()
-      tenant = Containers.initialize(tenant, true, true)
-      {:ok, _} = Realtime.Tenants.Connect.lookup_or_start_connection(tenant.external_id)
-      Process.sleep(1000)
-      on_exit(fn -> Containers.stop_container(tenant) end)
-      %{tenant: tenant}
+  describe "create tenant with put" do
+    test "run migrations on creation", %{conn: conn} do
+      external_id = random_string()
+      port = Enum.random(5500..9000)
+      Containers.initialize_no_tenant(external_id, port)
+      on_exit(fn -> Containers.stop_container(external_id) end)
+      assert nil == Tenants.get_tenant_by_external_id(external_id)
+
+      attrs = default_tenant_attrs(port)
+
+      conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
+
+      assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
+
+      tenant = Tenants.get_tenant_by_external_id(external_id)
+      {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+      assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
+    end
+  end
+
+  describe "upsert with post" do
+    test "renders tenant when data is valid", %{conn: conn} do
+      external_id = random_string()
+
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
+
+      attrs = default_tenant_attrs(port)
+      attrs = Map.put(attrs, "external_id", external_id)
+
+      Containers.initialize_no_tenant(external_id, port)
+      on_exit(fn -> Containers.stop_container(external_id) end)
+
+      conn = post(conn, ~p"/api/tenants", tenant: attrs)
+      assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.tenant_path(conn, :show, external_id))
+      assert ^external_id = json_response(conn, 200)["data"]["external_id"]
+      assert 200 = json_response(conn, 200)["data"]["max_concurrent_users"]
+      assert 100 = json_response(conn, 200)["data"]["max_channels_per_client"]
+      assert 100 = json_response(conn, 200)["data"]["max_events_per_second"]
+      assert 100 = json_response(conn, 200)["data"]["max_joins_per_second"]
     end
 
-    test "renders tenant when data is valid", %{
-      conn: conn,
-      tenant: %Tenant{id: id, external_id: ext_id} = _tenant
-    } do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        conn = put(conn, ~p"/api/tenants/#{ext_id}", tenant: @update_attrs)
-        assert %{"id" => ^id, "external_id" => ^ext_id} = json_response(conn, 200)["data"]
-        conn = get(conn, Routes.tenant_path(conn, :show, ext_id))
-        assert "some updated name" = json_response(conn, 200)["data"]["name"]
-        assert 300 = json_response(conn, 200)["data"]["max_concurrent_users"]
-        assert 150 = json_response(conn, 200)["data"]["max_channels_per_client"]
-        assert 250 = json_response(conn, 200)["data"]["max_events_per_second"]
-        assert 50 = json_response(conn, 200)["data"]["max_joins_per_second"]
-      end
+    test "encrypt creds", %{conn: conn} do
+      external_id = random_string()
+
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
+
+      Containers.initialize_no_tenant(external_id, port)
+      on_exit(fn -> Containers.stop_container(external_id) end)
+
+      attrs = default_tenant_attrs(port)
+      attrs = Map.put(attrs, "external_id", external_id)
+      conn = post(conn, ~p"/api/tenants", tenant: attrs)
+
+      [%{"settings" => settings}] = json_response(conn, 201)["data"]["extensions"]
+
+      assert Crypto.encrypt!("127.0.0.1") == settings["db_host"]
+      assert Crypto.encrypt!("postgres") == settings["db_name"]
+      assert Crypto.encrypt!("supabase_admin") == settings["db_user"]
+      refute settings["db_password"]
+
+      %{extensions: [%{settings: settings}]} = Tenants.get_tenant_by_external_id(external_id)
+
+      assert Crypto.encrypt!("postgres") == settings["db_password"]
     end
 
-    test "renders errors when data is invalid", %{conn: conn, tenant: tenant} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        conn = put(conn, ~p"/api/tenants/#{tenant.external_id}", tenant: @invalid_attrs)
-        assert json_response(conn, 422)["errors"] != %{}
-      end
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, ~p"/api/tenants", tenant: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
     end
 
-    test "returns 404 when jwt is invalid", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:error, "invalid"} end do
-        conn = put(conn, ~p"/api/tenants", tenant: @default_tenant_attrs)
-        assert json_response(conn, 404) == "Not Found"
-      end
+    test "returns 403 when jwt is invalid", %{conn: conn} do
+      conn = put_req_header(conn, "authorization", "Bearer potato")
+      conn = post(conn, ~p"/api/tenants", tenant: default_tenant_attrs(5000))
+      assert response(conn, 403)
+    end
+  end
+
+  describe "upsert with put" do
+    setup [:with_tenant]
+
+    test "renders tenant when data is valid", %{conn: conn} do
+      external_id = random_string()
+
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
+
+      :ets.insert(:test_ports, {port})
+
+      attrs = default_tenant_attrs(port)
+
+      Containers.initialize_no_tenant(external_id, port)
+      on_exit(fn -> Containers.stop_container(external_id) end)
+
+      conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
+      assert %{"id" => _id, "external_id" => ^external_id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.tenant_path(conn, :show, external_id))
+      assert ^external_id = json_response(conn, 200)["data"]["external_id"]
+      assert 200 = json_response(conn, 200)["data"]["max_concurrent_users"]
+      assert 100 = json_response(conn, 200)["data"]["max_channels_per_client"]
+      assert 100 = json_response(conn, 200)["data"]["max_events_per_second"]
+      assert 100 = json_response(conn, 200)["data"]["max_joins_per_second"]
+    end
+
+    test "encrypt creds", %{conn: conn} do
+      external_id = random_string()
+
+      port =
+        5500..9000
+        |> Enum.reject(&(&1 in Enum.map(:ets.tab2list(:test_ports), fn {port} -> port end)))
+        |> Enum.random()
+
+      Containers.initialize_no_tenant(external_id, port)
+      on_exit(fn -> Containers.stop_container(external_id) end)
+
+      attrs = default_tenant_attrs(port)
+      conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
+
+      [%{"settings" => settings}] = json_response(conn, 201)["data"]["extensions"]
+
+      assert Crypto.encrypt!("127.0.0.1") == settings["db_host"]
+      assert Crypto.encrypt!("postgres") == settings["db_name"]
+      assert Crypto.encrypt!("supabase_admin") == settings["db_user"]
+      refute settings["db_password"]
+
+      %{extensions: [%{settings: settings}]} = Tenants.get_tenant_by_external_id(external_id)
+
+      assert Crypto.encrypt!("postgres") == settings["db_password"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = put(conn, ~p"/api/tenants/#{random_string()}", tenant: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "returns 403 when jwt is invalid", %{conn: conn} do
+      conn = put_req_header(conn, "authorization", "Bearer potato")
+      conn = put(conn, ~p"/api/tenants/external_id", tenant: default_tenant_attrs(5000))
+      assert response(conn, 403)
     end
   end
 
@@ -312,74 +224,64 @@ defmodule RealtimeWeb.TenantControllerTest do
     setup do
       tenant = tenant_fixture()
       tenant = Containers.initialize(tenant, true, true)
-      {:ok, _} = Realtime.Tenants.Connect.lookup_or_start_connection(tenant.external_id)
-      Process.sleep(1000)
       on_exit(fn -> Containers.stop_container(tenant) end)
       %{tenant: tenant}
     end
 
     test "deletes chosen tenant", %{conn: conn, tenant: tenant} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        assert Cache.get_tenant_by_external_id(tenant.external_id)
-        {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+      {:ok, _pid} = Realtime.Tenants.Connect.lookup_or_start_connection(tenant.external_id)
+      Process.sleep(500)
+      assert Cache.get_tenant_by_external_id(tenant.external_id)
+      {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
 
-        %{rows: [rows]} =
-          Postgrex.query!(db_conn, "SELECT slot_name FROM pg_replication_slots", [])
+      %{rows: [rows]} =
+        Postgrex.query!(db_conn, "SELECT slot_name FROM pg_replication_slots", [])
 
-        assert rows > 0
-        conn = delete(conn, ~p"/api/tenants/#{tenant.external_id}")
-        assert response(conn, 204)
+      assert rows > 0
+      conn = delete(conn, ~p"/api/tenants/#{tenant.external_id}")
+      assert response(conn, 204)
 
-        refute Cache.get_tenant_by_external_id(tenant.external_id)
-        refute Tenants.get_tenant_by_external_id(tenant.external_id)
+      refute Cache.get_tenant_by_external_id(tenant.external_id)
+      refute Tenants.get_tenant_by_external_id(tenant.external_id)
 
-        assert {:ok, %{rows: []}} =
-                 Postgrex.query(db_conn, "SELECT slot_name FROM pg_replication_slots", [])
-      end
+      assert {:ok, %{rows: []}} =
+               Postgrex.query(db_conn, "SELECT slot_name FROM pg_replication_slots", [])
     end
 
     test "tenant doesn't exist", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        conn = delete(conn, ~p"/api/tenants/nope")
-        assert response(conn, 204)
-      end
+      conn = delete(conn, ~p"/api/tenants/nope")
+      assert response(conn, 204)
     end
 
     test "returns 404 when jwt is invalid", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:error, "invalid"} end do
-        conn = delete(conn, ~p"/api/tenants")
-        assert json_response(conn, 404) == "Not Found"
-      end
+      conn = put_req_header(conn, "authorization", "Bearer potato")
+      conn = delete(conn, ~p"/api/tenants")
+      assert json_response(conn, 404) == "Not Found"
     end
   end
 
   describe "reload tenant" do
-    setup [:create_tenant]
+    setup [:with_tenant]
 
     test "reload when tenant does exist", %{conn: conn, tenant: tenant} do
-      with_mock ChannelsAuthorization, authorize: fn _, _, _ -> {:ok, %{}} end do
-        %{status: status} = post(conn, ~p"/api/tenants/#{tenant.external_id}/reload")
-        assert status == 204
-      end
+      %{status: status} = post(conn, ~p"/api/tenants/#{tenant.external_id}/reload")
+      assert status == 204
     end
 
     test "reload when tenant does not exist", %{conn: conn} do
-      with_mock ChannelsAuthorization, authorize: fn _, _, _ -> {:ok, %{}} end do
-        %{status: status} = post(conn, ~p"/api/tenants/nope/reload")
-        assert status == 404
-      end
+      %{status: status} = post(conn, ~p"/api/tenants/nope/reload")
+      assert status == 404
     end
 
     test "returns 404 when jwt is invalid", %{conn: conn, tenant: tenant} do
-      with_mock ChannelsAuthorization, authorize: fn _, _, _ -> {:error, "invalid"} end do
-        conn = delete(conn, ~p"/api/tenants/#{tenant.external_id}/reload")
-        assert json_response(conn, 404) == "Not Found"
-      end
+      conn = put_req_header(conn, "authorization", "Bearer potato")
+      conn = delete(conn, ~p"/api/tenants/#{tenant.external_id}/reload")
+      assert json_response(conn, 404) == "Not Found"
     end
   end
 
   describe "health check tenant" do
-    setup [:create_tenant]
+    setup [:with_tenant]
 
     setup do
       Application.put_env(:realtime, :region, "us-east-1")
@@ -387,113 +289,96 @@ defmodule RealtimeWeb.TenantControllerTest do
     end
 
     test "health check when tenant does not exist", %{conn: conn} do
-      with_mock ChannelsAuthorization, authorize: fn _, _, _ -> {:ok, %{}} end do
-        %{status: status} = get(conn, ~p"/api/tenants/nope/health")
-        assert status == 404
-      end
+      %{status: status} = get(conn, ~p"/api/tenants/nope/health")
+      assert status == 404
     end
 
     test "healthy tenant with 0 client connections", %{
       conn: conn,
       tenant: %Tenant{external_id: external_id}
     } do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        conn = get(conn, ~p"/api/tenants/#{external_id}/health")
-        data = json_response(conn, 200)["data"]
-        Connect.shutdown(external_id)
+      conn = get(conn, ~p"/api/tenants/#{external_id}/health")
+      data = json_response(conn, 200)["data"]
+      Connect.shutdown(external_id)
 
-        assert %{
-                 "healthy" => true,
-                 "db_connected" => false,
-                 "connected_cluster" => 0,
-                 "region" => "us-east-1",
-                 "node" => "#{node()}"
-               } == data
-      end
+      assert %{
+               "healthy" => true,
+               "db_connected" => false,
+               "connected_cluster" => 0,
+               "region" => "us-east-1",
+               "node" => "#{node()}"
+             } == data
     end
 
     test "unhealthy tenant with 1 client connections", %{
       conn: conn,
       tenant: %Tenant{external_id: ext_id}
     } do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        # Fake adding a connected client here
-        # No connection to the tenant database
-        UsersCounter.add(self(), ext_id)
+      # Fake adding a connected client here
+      # No connection to the tenant database
+      UsersCounter.add(self(), ext_id)
 
-        conn = get(conn, ~p"/api/tenants/#{ext_id}/health")
-        data = json_response(conn, 200)["data"]
+      conn = get(conn, ~p"/api/tenants/#{ext_id}/health")
+      data = json_response(conn, 200)["data"]
 
-        assert %{
-                 "healthy" => false,
-                 "db_connected" => false,
-                 "connected_cluster" => 1,
-                 "region" => "us-east-1",
-                 "node" => "#{node()}"
-               } == data
-      end
+      assert %{
+               "healthy" => false,
+               "db_connected" => false,
+               "connected_cluster" => 1,
+               "region" => "us-east-1",
+               "node" => "#{node()}"
+             } == data
     end
 
     test "healthy tenant with 1 client connection", %{
       conn: conn,
       tenant: %Tenant{external_id: ext_id}
     } do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        {:ok, db_conn} = Connect.lookup_or_start_connection(ext_id)
-        # Fake adding a connected client here
-        UsersCounter.add(self(), ext_id)
+      {:ok, db_conn} = Connect.lookup_or_start_connection(ext_id)
+      # Fake adding a connected client here
+      UsersCounter.add(self(), ext_id)
 
-        # Fake a db connection
-        :syn.register(Realtime.Tenants.Connect, ext_id, self(), %{conn: nil})
+      # Fake a db connection
+      :syn.register(Realtime.Tenants.Connect, ext_id, self(), %{conn: nil})
 
-        :syn.update_registry(Realtime.Tenants.Connect, ext_id, fn _pid, meta ->
-          %{meta | conn: db_conn}
-        end)
+      :syn.update_registry(Realtime.Tenants.Connect, ext_id, fn _pid, meta ->
+        %{meta | conn: db_conn}
+      end)
 
-        conn = get(conn, ~p"/api/tenants/#{ext_id}/health")
-        data = json_response(conn, 200)["data"]
+      conn = get(conn, ~p"/api/tenants/#{ext_id}/health")
+      data = json_response(conn, 200)["data"]
 
-        assert %{
-                 "healthy" => true,
-                 "db_connected" => true,
-                 "connected_cluster" => 1,
-                 "region" => "us-east-1",
-                 "node" => "#{node()}"
-               } == data
-      end
+      assert %{
+               "healthy" => true,
+               "db_connected" => true,
+               "connected_cluster" => 1,
+               "region" => "us-east-1",
+               "node" => "#{node()}"
+             } == data
     end
 
     test "returns 404 when jwt is invalid", %{conn: conn, tenant: tenant} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:error, "invalid"} end do
-        conn = delete(conn, ~p"/api/tenants/#{tenant.external_id}/health")
-        assert json_response(conn, 404) == "Not Found"
-      end
+      conn = put_req_header(conn, "authorization", "Bearer potato")
+      conn = delete(conn, ~p"/api/tenants/#{tenant.external_id}/health")
+      assert json_response(conn, 404) == "Not Found"
     end
 
     test "runs migrations", %{conn: conn} do
-      with_mock JwtVerification, verify: fn _token, _secret, _jwks -> {:ok, %{}} end do
-        tenant = tenant_fixture()
-        tenant = Containers.initialize(tenant, true)
-        on_exit(fn -> Containers.stop_container(tenant) end)
+      tenant = tenant_fixture()
+      tenant = Containers.initialize(tenant, true)
+      on_exit(fn -> Containers.stop_container(tenant) end)
 
-        {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
-        assert {:error, _} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
+      {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+      assert {:error, _} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
 
-        conn = get(conn, ~p"/api/tenants/#{tenant.external_id}/health")
-        data = json_response(conn, 200)["data"]
-        Process.sleep(2000)
+      conn = get(conn, ~p"/api/tenants/#{tenant.external_id}/health")
+      data = json_response(conn, 200)["data"]
+      Process.sleep(2000)
 
-        assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
+      assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
 
-        assert %{"healthy" => true, "db_connected" => false, "connected_cluster" => 0} = data
-      end
+      assert %{"healthy" => true, "db_connected" => false, "connected_cluster" => 0} = data
     end
-  end
-
-  defp create_tenant(_) do
-    tenant = Containers.checkout_tenant(true)
-    on_exit(fn -> Containers.checkin_tenant(tenant) end)
-    %{tenant: tenant}
   end
 
   defp default_tenant_attrs(port) do

--- a/test/realtime_web/views/error_view_test.exs
+++ b/test/realtime_web/views/error_view_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.ErrorViewTest do
-  use RealtimeWeb.ConnCase, async: true
+  use RealtimeWeb.ConnCase, async: false
 
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -128,7 +128,7 @@ defmodule Containers do
   def stop_container(%Tenant{} = tenant) do
     :ets.delete(:containers, tenant.external_id)
     pid = Connect.whereis(tenant.external_id)
-    if pid && Process.alive?(pid), do: Connect.shutdown(tenant.external_id)
+    if is_pid(pid) && Process.alive?(pid), do: Connect.shutdown(tenant.external_id)
     name = "realtime-test-#{tenant.external_id}"
     System.cmd("docker", ["rm", "-f", name])
   end

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -43,7 +43,7 @@ defmodule Containers do
     end)
 
     if run_migrations? do
-      :ok = Migrations.run_migrations(tenant)
+      Migrations.run_migrations(tenant)
       {:ok, pid} = Database.connect(tenant, "realtime_test", :stop)
       :ok = Migrations.create_partitions(pid)
       Process.exit(pid, :normal)
@@ -107,7 +107,7 @@ defmodule Containers do
 
       Postgrex.query!(db_conn, "DROP SCHEMA realtime CASCADE", [])
       Postgrex.query!(db_conn, "CREATE SCHEMA realtime", [])
-
+      Tenants.update_migrations_ran(tenant.external_id, 0)
       :ok
     end)
 

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -138,6 +138,7 @@ defmodule Containers do
     :ets.insert(:containers, {tenant.external_id, %{tenant: tenant, using?: false}})
   end
 
+  @spec stop_container(any()) :: {any(), non_neg_integer()}
   def stop_container(%Tenant{} = tenant) do
     :ets.delete(:containers, tenant.external_id)
     pid = Connect.whereis(tenant.external_id)

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -107,13 +107,17 @@ defmodule Containers do
 
       Postgrex.query!(db_conn, "DROP SCHEMA realtime CASCADE", [])
       Postgrex.query!(db_conn, "CREATE SCHEMA realtime", [])
-      Tenants.update_migrations_ran(tenant.external_id, 0)
+
+      if Tenants.get_tenant_by_external_id(tenant.external_id) do
+        Tenants.update_migrations_ran(tenant.external_id, 0)
+      end
+
       :ok
     end)
 
     if run_migrations? do
-      Migrations.run_migrations(tenant)
       {:ok, pid} = Database.connect(tenant, "realtime_test", :stop)
+      Migrations.run_migrations(tenant)
       Migrations.create_partitions(pid)
     end
 

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -13,9 +13,9 @@ defmodule Containers do
 
   @type t :: %__MODULE__{port: integer(), tenant: Realtime.Api.Tenant.t(), using?: boolean()}
   def initialize(tenant, lock? \\ false, run_migrations? \\ false) do
-    capture_log(fn ->
-      if :ets.whereis(:containers) == :undefined, do: :ets.new(:containers, [:named_table, :set, :public])
+    if :ets.whereis(:containers) == :undefined, do: :ets.new(:containers, [:named_table, :set, :public])
 
+    capture_log(fn ->
       name = "realtime-test-#{tenant.external_id}"
       %{port: port} = Database.from_tenant(tenant, "realtime_test", :stop)
 
@@ -53,6 +53,8 @@ defmodule Containers do
   end
 
   def initialize_no_tenant(external_id, port) do
+    if :ets.whereis(:containers) == :undefined, do: :ets.new(:containers, [:named_table, :set, :public])
+
     name = "realtime-test-#{external_id}"
 
     capture_log(fn ->

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -255,7 +255,10 @@ defmodule Generators do
     """
   end
 
-  def generate_jwt_token(secret, claims \\ %{role: "authenticated", exp: System.system_time(:second) + 100_000})
+  def generate_jwt_token(secret_or_tenant) do
+    claims = %{role: "authenticated", exp: System.system_time(:second) + 100_000}
+    generate_jwt_token(secret_or_tenant, claims)
+  end
 
   def generate_jwt_token(%Tenant{} = tenant, claims) do
     secret = Crypto.decrypt!(tenant.jwt_secret)
@@ -268,4 +271,6 @@ defmodule Generators do
     {:ok, jwt, _} = Joken.encode_and_sign(claims, signer)
     jwt
   end
+
+  def generate_jwt_token(nil, _), do: raise("Missing JWT secret")
 end

--- a/test/support/websocket_client.exs
+++ b/test/support/websocket_client.exs
@@ -112,7 +112,9 @@ defmodule Realtime.Integration.WebsocketClient do
         query -> uri.path <> "?" <> query
       end
 
-    with {:ok, conn} <- Mint.HTTP.connect(http_scheme, uri.host, uri.port),
+    [subdomain, host] = String.split(uri.host, ".")
+
+    with {:ok, conn} <- Mint.HTTP.connect(http_scheme, host, uri.port, hostname: subdomain),
          {:ok, conn, ref} <- Mint.WebSocket.upgrade(ws_scheme, conn, path, headers) do
       state = %{state | conn: conn, request_ref: ref, caller: from}
       {:noreply, state}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,7 +36,7 @@ Database.transaction(conn, fn db_conn ->
   Enum.each(queries, &Postgrex.query!(db_conn, &1, []))
 end)
 
-containers = Application.get_env(:ex_unit, :max_cases, System.schedulers()) * 2
+containers = Application.get_env(:ex_unit, :max_cases, System.schedulers()) * 3
 tenants = for _ <- 0..containers, do: Generators.tenant_fixture()
 if :ets.whereis(:containers) == :undefined, do: :ets.new(:containers, [:named_table, :set, :public])
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,7 +36,7 @@ Database.transaction(conn, fn db_conn ->
   Enum.each(queries, &Postgrex.query!(db_conn, &1, []))
 end)
 
-containers = Application.get_env(:ex_unit, :max_cases, System.schedulers()) * 2
+containers = Application.get_env(:ex_unit, :max_cases, System.schedulers()) * 3
 tenants = for _ <- 0..containers, do: Generators.tenant_fixture()
 
 # Start other containers to be used based on max test cases

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,8 +36,9 @@ Database.transaction(conn, fn db_conn ->
   Enum.each(queries, &Postgrex.query!(db_conn, &1, []))
 end)
 
-containers = Application.get_env(:ex_unit, :max_cases, System.schedulers()) * 3
+containers = Application.get_env(:ex_unit, :max_cases, System.schedulers()) * 2
 tenants = for _ <- 0..containers, do: Generators.tenant_fixture()
+if :ets.whereis(:containers) == :undefined, do: :ets.new(:containers, [:named_table, :set, :public])
 
 # Start other containers to be used based on max test cases
 Task.await_many(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Prevents migrations from running if the tenant no longer requires.

