### PR TITLE
Fix seed generation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ on:
 permissions:
   contents: read
 jobs:
-  format:
+  tests:
     name: Tests
     runs-on: ubuntu-latest
 
@@ -70,6 +70,8 @@ jobs:
           mix dialyzer.build
       - name: Run dialyzer
         run: mix dialyzer
+      - name: Run dev seeds
+        run: DB_ENC_KEY="1234567890123456" mix ecto.setup
       - name: Start epmd
         run: epmd -daemon
       - name: Run tests

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -317,9 +317,8 @@ defmodule Realtime.Tenants do
   @doc """
   Checks if migrations for a given tenant need to run.
   """
-  @spec run_migrations?(binary()) :: boolean()
-  def run_migrations?(external_id) do
-    tenant = Cache.get_tenant_by_external_id(external_id)
+  @spec run_migrations?(Tenant.t()) :: boolean()
+  def run_migrations?(%Tenant{} = tenant) do
     tenant.migrations_ran < Enum.count(Migrations.migrations())
   end
 

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -160,7 +160,7 @@ defmodule Realtime.Tenants.Migrations do
 
     spec = {__MODULE__, attrs}
 
-    if Tenants.run_migrations?(tenant.external_id) do
+    if Tenants.run_migrations?(tenant) do
       case DynamicSupervisor.start_child(supervisor, spec) do
         :ignore -> :ok
         error -> error

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.55",
+      version: "2.34.56",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -5,45 +5,59 @@ import Ecto.Adapters.SQL, only: [query: 3]
 alias Realtime.Api.Tenant
 alias Realtime.Repo
 alias Realtime.Tenants
+alias Realtime.Database
 
 tenant_name = System.get_env("SELF_HOST_TENANT_NAME", "realtime-dev")
 env = if :ets.whereis(Mix.State) != :undefined, do: Mix.env(), else: :prod
 default_db_host = if env in [:dev, :test], do: "127.0.0.1", else: "host.docker.internal"
 
-Repo.transaction(fn ->
-  case Repo.get_by(Tenant, external_id: tenant_name) do
-    %Tenant{} = tenant -> Repo.delete!(tenant)
-    nil -> {:ok, nil}
-  end
+{:ok, tenant} =
+  Repo.transaction(fn ->
+    case Repo.get_by(Tenant, external_id: tenant_name) do
+      %Tenant{} = tenant -> Repo.delete!(tenant)
+      nil -> {:ok, nil}
+    end
 
-  %Tenant{}
-  |> Tenant.changeset(%{
-    "name" => tenant_name,
-    "external_id" => tenant_name,
-    "jwt_secret" => System.get_env("API_JWT_SECRET", "super-secret-jwt-token-with-at-least-32-characters-long"),
-    "jwt_jwks" => System.get_env("API_JWT_JWKS") |> then(fn v -> if v, do: Jason.decode!(v) end),
-    "extensions" => [
-      %{
-        "type" => "postgres_cdc_rls",
-        "settings" => %{
-          "db_name" => System.get_env("DB_NAME", "postgres"),
-          "db_host" => System.get_env("DB_HOST", default_db_host),
-          "db_user" => System.get_env("DB_USER", "supabase_admin"),
-          "db_password" => System.get_env("DB_PASSWORD", "postgres"),
-          "db_port" => System.get_env("DB_PORT", "5433"),
-          "region" => "us-east-1",
-          "poll_interval_ms" => 100,
-          "poll_max_record_bytes" => 1_048_576,
-          "ssl_enforced" => false
+    %Tenant{}
+    |> Tenant.changeset(%{
+      "name" => tenant_name,
+      "external_id" => tenant_name,
+      "jwt_secret" => System.get_env("API_JWT_SECRET", "super-secret-jwt-token-with-at-least-32-characters-long"),
+      "jwt_jwks" => System.get_env("API_JWT_JWKS") |> then(fn v -> if v, do: Jason.decode!(v) end),
+      "extensions" => [
+        %{
+          "type" => "postgres_cdc_rls",
+          "settings" => %{
+            "db_name" => System.get_env("DB_NAME", "postgres"),
+            "db_host" => System.get_env("DB_HOST", default_db_host),
+            "db_user" => System.get_env("DB_USER", "supabase_admin"),
+            "db_password" => System.get_env("DB_PASSWORD", "postgres"),
+            "db_port" => System.get_env("DB_PORT", "5433"),
+            "region" => "us-east-1",
+            "poll_interval_ms" => 100,
+            "poll_max_record_bytes" => 1_048_576,
+            "ssl_enforced" => false
+          }
         }
-      }
-    ]
-  })
-  |> Repo.insert!()
+      ]
+    })
+    |> Repo.insert!()
+  end)
 
-  tenant = Tenants.get_tenant_by_external_id(tenant_name)
-  Tenants.Migrations.run_migrations(tenant)
+settings = Database.from_tenant(tenant, "realtime_migrations", :stop)
+settings = %{settings | max_restarts: 0, ssl: false}
+{:ok, tenant_conn} = Database.connect_db(settings)
+
+Postgrex.transaction(tenant_conn, fn db_conn ->
+  Postgrex.query!(db_conn, "DROP SCHEMA IF EXISTS realtime CASCADE", [])
+  Postgrex.query!(db_conn, "CREATE SCHEMA IF NOT EXISTS realtime", [])
 end)
+
+case Tenants.Migrations.run_migrations(tenant) do
+  :ok -> :ok
+  :noop -> :ok
+  _ -> raise "Running Migrations failed"
+end
 
 if env in [:dev, :test] do
   publication = "supabase_realtime"

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -89,15 +89,15 @@ defmodule Realtime.TenantsTest do
   describe "run_migrations?/1" do
     test "returns true if migrations_ran is lower than existing migrations" do
       tenant = tenant_fixture(%{migrations_ran: 0})
-      assert Tenants.run_migrations?(tenant.external_id)
+      assert Tenants.run_migrations?(tenant)
 
       tenant = tenant_fixture(%{migrations_ran: Enum.count(Migrations.migrations()) - 1})
-      assert Tenants.run_migrations?(tenant.external_id)
+      assert Tenants.run_migrations?(tenant)
     end
 
     test "returns false if migrations_ran is count of all migrations" do
       tenant = tenant_fixture(%{migrations_ran: Enum.count(Migrations.migrations())})
-      refute Tenants.run_migrations?(tenant.external_id)
+      refute Tenants.run_migrations?(tenant)
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Fix dev seeds by avoiding usage of the Cache module.
* Run ecto.setup (which includes dev seeds) on CI so we know if it breaks as it's not something someone would run all the time

## What is the current behavior?

`make seed` returns this:

```
** (KeyError) key :migrations_ran not found in: nil

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
    (realtime 2.34.53) lib/realtime/tenants.ex:304: Realtime.Tenants.run_migrations?/1
    (realtime 2.34.53) lib/realtime/tenants/migrations.ex:163: Realtime.Tenants.Migrations.run_migrations/1
    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1358: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
    (db_connection 2.7.0) lib/db_connection.ex:1756: DBConnection.run_transaction/4
    priv/repo/seeds.exs:13: (file)
```


## What is the new behavior?

seeds work

## Additional context


I was trying to reset my local db with seeds and I ran into this issue where `Tenants.run_migrations?("realtime-dev")` was failing because it couldn't find the tenant. 

Tracing it out I the problem is that `run_migrations?` was using `Cache.get_tenant_by_external_id` and this was inside a transaction where the tenant was just created inside seeds.exs: https://github.com/supabase/realtime/blob/e2275cd3f3cc938b2d14be5dcaf4100f2282c242/priv/repo/seeds.exs#L13-L46


`tenant = Tenants.get_tenant_by_external_id(tenant_name)` would work fine but `Tenants.Migrations.run_migrations(tenant)` would fail and this error would show up:

```
** (KeyError) key :migrations_ran not found in: nil

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
    (realtime 2.34.53) lib/realtime/tenants.ex:304: Realtime.Tenants.run_migrations?/1
    (realtime 2.34.53) lib/realtime/tenants/migrations.ex:163: Realtime.Tenants.Migrations.run_migrations/1
    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1358: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
    (db_connection 2.7.0) lib/db_connection.ex:1756: DBConnection.run_transaction/4
    priv/repo/seeds.exs:13: (file)
```

The issue was that running `Cache.get_tenant_by_external_id` will be called by Cachex https://github.com/supabase/realtime/blob/e2275cd3f3cc938b2d14be5dcaf4100f2282c242/lib/realtime/context_cache.ex#L12

And Cachex uses a separate process outside of the process where the `Repo.transaction` is happening so the Tenant is not found because it ends up using a different Postgres connection.

In the end I noticed that we only have one place using `Tenant.run_migrations?/1` and already has the Tenant in memory so I just updated it to use it instead of fetching from Cache. 

I found this discussion on elixir forums https://elixirforum.com/t/ecto-timeout-errors-when-wrapping-into-cachex-calls-in-tests/19078 which is sort of similar