### PR TITLE
fix: Set correct env var name

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,8 +18,7 @@ migration_partition_slots =
 connect_partition_slots =
   System.get_env("CONNECT_PARTITION_SLOTS", "#{System.schedulers_online() * 2}") |> String.to_integer()
 
-connect_throttle_limit_per_second =
-  System.get_env("CONNECT_THROTTLE_LIMIT_per_second_PER_SECOND", "1") |> String.to_integer()
+connect_throttle_limit_per_second = System.get_env("CONNECT_THROTTLE_LIMIT_PER_SECOND", "1") |> String.to_integer()
 
 if !(db_version in [nil, "ipv6", "ipv4"]),
   do: raise("Invalid IP version, please set either ipv6 or ipv4")

--- a/lib/realtime_web/channels/user_socket.ex
+++ b/lib/realtime_web/channels/user_socket.ex
@@ -30,7 +30,6 @@ defmodule RealtimeWeb.UserSocket do
       %{uri: %{host: host}, x_headers: headers} = opts
 
       {:ok, external_id} = Database.get_external_id(host)
-      external_id = String.upcase(external_id)
       Logger.metadata(external_id: external_id, project: external_id)
       Logger.put_process_level(self(), :error)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.54",
+      version: "2.34.55",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -5,7 +5,6 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
   import Generators
   import Mock
 
-  alias Realtime.GenCounter
   alias Realtime.RateCounter
   alias Realtime.RateCounter
   alias Realtime.Tenants
@@ -190,11 +189,6 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
     start_supervised(CurrentTime.Mock)
 
     tenant = Containers.checkout_tenant(true)
-    RateCounter.stop(tenant.external_id)
-    GenCounter.stop(tenant.external_id)
-    RateCounter.new(tenant.external_id)
-    GenCounter.new(tenant.external_id)
-
     on_exit(fn -> Containers.checkin_tenant(tenant) end)
 
     {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
@@ -217,7 +211,6 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
        ) do
     claims = %{sub: random_string(), role: "authenticated", exp: Joken.current_time() + 1_000}
     signer = Joken.Signer.create("HS256", "secret")
-
     jwt = Joken.generate_and_sign!(%{}, claims, signer)
 
     authorization_context =
@@ -231,8 +224,6 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
       })
 
     key = Tenants.events_per_second_key(tenant)
-    GenCounter.new(key)
-    RateCounter.new(key)
     {:ok, rate_counter} = RateCounter.get(key)
 
     tenant_topic = "realtime:#{topic}"

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -79,7 +79,8 @@ defmodule Containers do
         ])
 
       check_container_ready(name)
-      Process.sleep(1000)
+      # Required as the database might not be available yet for first operations
+      Process.sleep(4000)
     end)
 
     name

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -72,9 +72,7 @@ defmodule Generators do
   end
 
   def random_string(length \\ 20) do
-    length
-    |> :crypto.strong_rand_bytes()
-    |> Base.encode32()
+    length |> :crypto.strong_rand_bytes() |> Base.encode32() |> String.downcase()
   end
 
   def clean_table(db_conn, schema, table) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,57 +1,61 @@
+import ExUnit.CaptureLog
+
 alias Ecto.Adapters.SQL.Sandbox
 alias Realtime.Api
 alias Realtime.Database
-ExUnit.start(exclude: [:failing], max_cases: 1)
+ExUnit.start(exclude: [:failing], max_cases: 1, capture_log: false)
 Containers.stop_containers()
 
-for tenant <- Api.list_tenants() do
-  Api.delete_tenant(tenant)
-end
+capture_log(fn ->
+  for tenant <- Api.list_tenants() do
+    Api.delete_tenant(tenant)
+  end
 
-tenant_name = "dev_tenant"
-publication = "supabase_realtime_test"
-port = Enum.random(5500..9000)
-opts = %{external_id: tenant_name, name: tenant_name, port: port, jwt_secret: "secure_jwt_secret"}
-tenant = Generators.tenant_fixture(opts)
+  tenant_name = "dev_tenant"
+  publication = "supabase_realtime_test"
+  port = Enum.random(5500..9000)
+  opts = %{external_id: tenant_name, name: tenant_name, port: port, jwt_secret: "secure_jwt_secret"}
+  tenant = Generators.tenant_fixture(opts)
 
-# Start dev_realtime container to be used in integration tests
-Containers.initialize(tenant, true, true)
-{:ok, conn} = Database.connect(tenant, "realtime_seed", :stop)
+  # Start dev_realtime container to be used in integration tests
+  Containers.initialize(tenant, true, true)
+  {:ok, conn} = Database.connect(tenant, "realtime_seed", :stop)
 
-Database.transaction(conn, fn db_conn ->
-  queries = [
-    "create sequence if not exists test_id_seq;",
-    """
-    create table "public"."test" (
-    "id" int4 not null default nextval('test_id_seq'::regclass),
-    "details" text,
-    primary key ("id"));
-    """,
-    "grant all on table public.test to anon;",
-    "grant all on table public.test to postgres;",
-    "grant all on table public.test to authenticated;",
-    "create publication #{publication} for all tables"
-  ]
+  Database.transaction(conn, fn db_conn ->
+    queries = [
+      "create sequence if not exists test_id_seq;",
+      """
+      create table "public"."test" (
+      "id" int4 not null default nextval('test_id_seq'::regclass),
+      "details" text,
+      primary key ("id"));
+      """,
+      "grant all on table public.test to anon;",
+      "grant all on table public.test to postgres;",
+      "grant all on table public.test to authenticated;",
+      "create publication #{publication} for all tables"
+    ]
 
-  Enum.each(queries, &Postgrex.query!(db_conn, &1, []))
+    Enum.each(queries, &Postgrex.query!(db_conn, &1, []))
+  end)
+
+  containers = Application.get_env(:ex_unit, :max_cases, System.schedulers()) * 3
+  tenants = for _ <- 0..containers, do: Generators.tenant_fixture()
+  if :ets.whereis(:containers) == :undefined, do: :ets.new(:containers, [:named_table, :set, :public])
+
+  # Start other containers to be used based on max test cases
+  Task.await_many(
+    for tenant <- tenants do
+      Task.async(fn -> Containers.initialize(tenant) end)
+    end,
+    :infinity
+  )
+
+  ExUnit.after_suite(fn _ ->
+    Sandbox.checkout(Realtime.Repo)
+
+    Enum.each(tenants, &Realtime.Api.delete_tenant/1)
+  end)
+
+  Ecto.Adapters.SQL.Sandbox.mode(Realtime.Repo, :auto)
 end)
-
-containers = Application.get_env(:ex_unit, :max_cases, System.schedulers()) * 3
-tenants = for _ <- 0..containers, do: Generators.tenant_fixture()
-if :ets.whereis(:containers) == :undefined, do: :ets.new(:containers, [:named_table, :set, :public])
-
-# Start other containers to be used based on max test cases
-Task.await_many(
-  for tenant <- tenants do
-    Task.async(fn -> Containers.initialize(tenant) end)
-  end,
-  :infinity
-)
-
-ExUnit.after_suite(fn _ ->
-  Sandbox.checkout(Realtime.Repo)
-
-  Enum.each(tenants, &Realtime.Api.delete_tenant/1)
-end)
-
-Ecto.Adapters.SQL.Sandbox.mode(Realtime.Repo, :auto)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Set correct env var name for `CONNECT_THROTTLE_LIMIT_PER_SECOND`