### PR TITLE
Extract dev seeds from the main seeds file

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,6 +2,6 @@
   import_deps: [:ecto, :ecto_sql, :phoenix, :open_api_spex],
   subdirectories: ["priv/*/migrations"],
   plugins: [Phoenix.LiveView.HTMLFormatter],
-  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/seeds.exs"],
+  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/*seeds*.exs"],
   line_length: 120
 ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on:
       - main
 
 jobs:
-  format:
+  tests:
     name: Tests
     runs-on: ubuntu-latest
 
@@ -69,6 +69,8 @@ jobs:
           mix dialyzer.build
       - name: Run dialyzer
         run: mix dialyzer
+      - name: Run dev seeds
+        run: DB_ENC_KEY="1234567890123456" mix ecto.setup
       - name: Start epmd
         run: epmd -daemon
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ dev.orange: ## Start another dev server (orange) on port 4001
 	ELIXIR_ERL_OPTIONS="+hmax 1000000000" SLOT_NAME_SUFFIX=some_sha PORT=4001 MIX_ENV=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" CLUSTER_STRATEGIES=$(CLUSTER_STRATEGIES) ERL_AFLAGS="-kernel shell_history enabled" iex --name orange@127.0.0.1 --cookie cookie  -S mix phx.server
 
 seed: ## Seed the database
-	DB_ENC_KEY="1234567890123456" FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 mix run priv/repo/seeds.exs
+	DB_ENC_KEY="1234567890123456" FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 mix run priv/repo/dev_seeds.exs
 
 prod: ## Start a server with a MIX_ENV=prod
 	ELIXIR_ERL_OPTIONS="+hmax 1000000000" SLOT_NAME_SUFFIX=some_sha MIX_ENV=prod FLY_APP_NAME=realtime-local API_KEY=dev SECURE_CHANNELS=true API_JWT_SECRET=dev METRICS_JWT_SECRET=dev FLY_REGION=fra FLY_ALLOC_ID=123e4567-e89b-12d3-a456-426614174000 DB_ENC_KEY="1234567890123456" SECRET_KEY_BASE=M+55t7f6L9VWyhH03R5N7cIhrdRlZaMDfTE6Udz0eZS7gCbnoLQ8PImxwhEyao6D DASHBOARD_USER=realtime_local DASHBOARD_PASSWORD=password ERL_AFLAGS="-kernel shell_history enabled" iex -S mix phx.server

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.35.1",
+      version: "2.34.57",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.34.56",
+      version: "2.35.1",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -96,7 +96,7 @@ defmodule Realtime.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup", "cmd npm install --prefix assets"],
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/dev_seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: [
         "cmd epmd -daemon",

--- a/priv/repo/dev_seeds.exs
+++ b/priv/repo/dev_seeds.exs
@@ -1,0 +1,76 @@
+import Ecto.Adapters.SQL, only: [query!: 3]
+
+alias Realtime.Api.Tenant
+alias Realtime.Database
+alias Realtime.Repo
+alias Realtime.Tenants
+
+tenant_name = "realtime-dev"
+default_db_host = "127.0.0.1"
+
+{:ok, tenant} =
+  Repo.transaction(fn ->
+    case Repo.get_by(Tenant, external_id: tenant_name) do
+      %Tenant{} = tenant -> Repo.delete!(tenant)
+      nil -> {:ok, nil}
+    end
+
+    tenant =
+      %Tenant{}
+      |> Tenant.changeset(%{
+        "name" => tenant_name,
+        "external_id" => tenant_name,
+        "jwt_secret" => System.get_env("API_JWT_SECRET", "super-secret-jwt-token-with-at-least-32-characters-long"),
+        "jwt_jwks" => System.get_env("API_JWT_JWKS") |> then(fn v -> if v, do: Jason.decode!(v) end),
+        "extensions" => [
+          %{
+            "type" => "postgres_cdc_rls",
+            "settings" => %{
+              "db_name" => System.get_env("DB_NAME", "postgres"),
+              "db_host" => System.get_env("DB_HOST", default_db_host),
+              "db_user" => System.get_env("DB_USER", "supabase_admin"),
+              "db_password" => System.get_env("DB_PASSWORD", "postgres"),
+              "db_port" => System.get_env("DB_PORT", "5433"),
+              "region" => "us-east-1",
+              "poll_interval_ms" => 100,
+              "poll_max_record_bytes" => 1_048_576,
+              "ssl_enforced" => false
+            }
+          }
+        ]
+      })
+      |> Repo.insert!()
+
+    publication = "supabase_realtime"
+
+    [
+      "drop publication if exists #{publication}",
+      "drop table if exists public.test_tenant;",
+      "create table public.test_tenant ( id SERIAL PRIMARY KEY, details text );",
+      "grant all on table public.test_tenant to anon;",
+      "grant all on table public.test_tenant to postgres;",
+      "grant all on table public.test_tenant to authenticated;",
+      "create publication #{publication} for table public.test_tenant"
+    ]
+    |> Enum.each(&query!(Repo, &1, []))
+
+    tenant
+  end)
+
+# Reset Tenant DB
+settings = Database.from_tenant(tenant, "realtime_migrations", :stop)
+settings = %{settings | max_restarts: 0, ssl: false}
+{:ok, tenant_conn} = Database.connect_db(settings)
+
+Postgrex.transaction(tenant_conn, fn db_conn ->
+  Postgrex.query!(db_conn, "DROP SCHEMA IF EXISTS realtime CASCADE", [])
+  Postgrex.query!(db_conn, "CREATE SCHEMA IF NOT EXISTS realtime", [])
+end)
+
+case Tenants.Migrations.run_migrations(tenant) do
+  :ok -> :ok
+  :noop -> :ok
+  _ -> raise "Running Migrations failed"
+end
+
+Tenants.Migrations.run_migrations(tenant)

--- a/priv/repo/seeds_before_migration.exs
+++ b/priv/repo/seeds_before_migration.exs
@@ -2,4 +2,5 @@ import Ecto.Adapters.SQL, only: [query: 3]
 
 [
   "create schema if not exists realtime"
-] |> Enum.each(&query(Realtime.Repo, &1, []))
+]
+|> Enum.each(&query(Realtime.Repo, &1, []))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Extract a new `dev_seeds.exs` file to be used just for development. A following PR will sort out the actual seeds.exs used for self-hosting (cli)

## What is the current behavior?

Dev seeds is not working 100% and not rebuilding main and tenant database.

## What is the new behavior?

Recreate tenant + tenant db when `make seed`.

Also test dev seeds on CI

## Additional context

Add any other context or screenshots.
