### PR TITLE
fix: enhance log lack of connections

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.55.1",
+      version: "2.55.2",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -48,11 +48,13 @@ defmodule Realtime.DatabaseTest do
 
     # Connection limit for docker tenant db is 100
     @tag db_pool: 50,
-         subs_pool_size: 50,
-         subcriber_pool_size: 50
+         subs_pool_size: 21,
+         subcriber_pool_size: 33
     test "restricts connection if tenant database cannot receive more connections based on tenant pool",
          %{tenant: tenant} do
-      assert {:error, :tenant_db_too_many_connections} = Database.check_tenant_connection(tenant)
+      assert capture_log(fn ->
+               assert {:error, :tenant_db_too_many_connections} = Database.check_tenant_connection(tenant)
+             end) =~ ~r/Only \d+ available connections\. At least 126 connections are required/
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Log the amount of required connections so it's clear why Realtime refused to connect.


## What is the current behavior?

RealtimeChannel logs the following:

https://github.com/supabase/realtime/blob/1ffc07dd9989e43b69720dbb1b544a9b53662dad/lib/realtime_web/channels/realtime_channel.ex#L135-L137

Maybe the above can be removed given that now we will log at the `Database.check_tenant_connection` level?

## What is the new behavior?

```
[error] DatabaseLackOfConnections: Only 91 available connections. At least 126 connections are required.
```

## Additional context


