### PR TITLE
chore: improve test speed

### DIFF
--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -40,6 +40,17 @@ defmodule Realtime.Tenants.Connect do
             check_connected_user_interval: nil,
             connected_users_bucket: [1]
 
+  @doc "Check if Connect has finished setting up connections"
+  def ready?(tenant_id) do
+    case whereis(tenant_id) do
+      pid when is_pid(pid) ->
+        GenServer.call(pid, :ready?)
+
+      _ ->
+        false
+    end
+  end
+
   @doc """
   Returns the database connection for a tenant. If the tenant is not connected, it will attempt to connect to the tenant's database.
   """
@@ -332,6 +343,13 @@ defmodule Realtime.Tenants.Connect do
   # Ignore messages to avoid handle_info unmatched functions
   def handle_info(_, state) do
     {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:ready?, _from, state) do
+    # We just want to know if the process is ready to reply to the client
+    # Essentially checking if all handle_continue's were completed
+    {:reply, true, state}
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.55.3",
+      version: "2.55.4",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/adapters/postgres/protocol_test.exs
+++ b/test/realtime/adapters/postgres/protocol_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.Adapters.Postgres.ProtocolTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Realtime.Adapters.Postgres.Protocol
 
   test "defguard is_write/1" do

--- a/test/realtime/cluster_strategy/postgres_test.exs
+++ b/test/realtime/cluster_strategy/postgres_test.exs
@@ -1,13 +1,9 @@
 defmodule Realtime.Cluster.Strategy.PostgresTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Cluster.Strategy.State
   alias Postgrex.Notifications, as: PN
   alias Realtime.Cluster.Strategy.Postgres
-
-  setup do
-    Ecto.Adapters.SQL.Sandbox.mode(Realtime.Repo, :auto)
-  end
 
   test "handle_event/4, :internal, :connect is successful" do
     assert {:noreply, state} = Postgres.handle_continue(:connect, libcluster_state())

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -196,8 +196,9 @@ defmodule Realtime.DatabaseTest do
       event = [:realtime, :database, :transaction]
       opts = [telemetry: event]
 
-      Database.transaction(db_conn, fn conn -> Postgrex.query!(conn, "SELECT pg_sleep(6)", []) end, opts)
-      assert_receive {^event, %{latency: _}, %{tenant_id: nil}}
+      Database.transaction(db_conn, fn conn -> Postgrex.query!(conn, "SELECT pg_sleep(0.1)", []) end, opts)
+      assert_receive {^event, %{latency: latency}, %{tenant_id: nil}}
+      assert latency > 100
     end
 
     test "with telemetry event defined, emits telemetry event with tenant_id", %{db_conn: db_conn} do
@@ -205,9 +206,10 @@ defmodule Realtime.DatabaseTest do
       tenant_id = random_string()
       opts = [telemetry: event, tenant_id: tenant_id]
 
-      Database.transaction(db_conn, fn conn -> Postgrex.query!(conn, "SELECT pg_sleep(6)", []) end, opts)
+      Database.transaction(db_conn, fn conn -> Postgrex.query!(conn, "SELECT pg_sleep(0.1)", []) end, opts)
 
-      assert_receive {^event, %{latency: _}, %{tenant_id: ^tenant_id}}
+      assert_receive {^event, %{latency: latency}, %{tenant_id: ^tenant_id}}
+      assert latency > 100
     end
   end
 

--- a/test/realtime/extensions/cdc_rls/subscriptions_checker_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_checker_test.exs
@@ -1,5 +1,5 @@
 defmodule SubscriptionsCheckerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Extensions.PostgresCdcRls.SubscriptionsChecker, as: Checker
 
   test "subscribers_by_node/1" do

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -1,6 +1,5 @@
 defmodule Realtime.Extensionsubscriptions.CdcRlsSubscriptionsTest do
-  # async: false due to the fact that it uses the database
-  use RealtimeWeb.ChannelCase, async: false
+  use RealtimeWeb.ChannelCase, async: true
   doctest Extensions.PostgresCdcRls.Subscriptions
 
   alias Extensions.PostgresCdcRls.Subscriptions

--- a/test/realtime/gen_counter/gen_counter_test.exs
+++ b/test/realtime/gen_counter/gen_counter_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.GenCounterTest do
-  use Realtime.DataCase
+  use Realtime.DataCase, async: true
 
   alias Realtime.GenCounter
 

--- a/test/realtime/messages_test.exs
+++ b/test/realtime/messages_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.MessagesTest do
-  use Realtime.DataCase, async: false
+  use Realtime.DataCase, async: true
 
   alias Realtime.Api.Message
   alias Realtime.Database

--- a/test/realtime/monitoring/erl_sys_mon_test.exs
+++ b/test/realtime/monitoring/erl_sys_mon_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.ErlSysMonTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import ExUnit.CaptureLog
   alias Realtime.ErlSysMon
 

--- a/test/realtime/oid_test.exs
+++ b/test/realtime/oid_test.exs
@@ -1,5 +1,5 @@
-defmodule OidTest do
-  use ExUnit.Case
+defmodule Realtime.OidTest do
+  use ExUnit.Case, async: true
   import Realtime.Adapters.Postgres.OidDatabase
   doctest Realtime.Adapters.Postgres.OidDatabase
 end

--- a/test/realtime/postgres_decoder_test.exs
+++ b/test/realtime/postgres_decoder_test.exs
@@ -1,5 +1,5 @@
-defmodule PostgresDecoderTest do
-  use ExUnit.Case
+defmodule Realtime.PostgresDecoderTest do
+  use ExUnit.Case, async: true
   alias Realtime.Adapters.Postgres.Decoder
 
   alias Decoder.Messages.{

--- a/test/realtime/tenants/connect/piper_test.exs
+++ b/test/realtime/tenants/connect/piper_test.exs
@@ -1,6 +1,5 @@
 defmodule Realtime.Tenants.Connect.PiperTest do
-  # async: false due to the change of the error log level
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   import ExUnit.CaptureLog
 

--- a/test/realtime/tenants/connect/register_process_test.exs
+++ b/test/realtime/tenants/connect/register_process_test.exs
@@ -1,12 +1,14 @@
 defmodule Realtime.Tenants.Connect.RegisterProcessTest do
-  # Can't use async: true because Cachex does not work well with Ecto Sandbox
-  use Realtime.DataCase, async: false
+  use Realtime.DataCase, async: true
   alias Realtime.Tenants.Connect.RegisterProcess
   alias Realtime.Tenants.Connect
 
   describe "run/1" do
     setup do
       tenant = Containers.checkout_tenant(run_migrations: true)
+      # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues
+      Cachex.put!(Realtime.Tenants.Cache, {{:get_tenant_by_external_id, 1}, [tenant.external_id]}, {:cached, tenant})
+
       conn = start_supervised!({Connect, [tenant_id: tenant.external_id]})
       %{tenant_id: tenant.external_id, db_conn_pid: conn}
     end

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -176,7 +176,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
     GenCounter.new(tenant.external_id)
 
     {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-    Process.sleep(500)
+    assert Connect.ready?(tenant.external_id)
 
     topic = random_string()
     Endpoint.subscribe("realtime:#{topic}")

--- a/test/realtime_web/plugs/auth_tenant_test.exs
+++ b/test/realtime_web/plugs/auth_tenant_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.AuthTenantTest do
-  use RealtimeWeb.ConnCase
+  use RealtimeWeb.ConnCase, async: true
 
   import Plug.Conn
 

--- a/test/realtime_web/views/error_view_test.exs
+++ b/test/realtime_web/views/error_view_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.ErrorViewTest do
-  use RealtimeWeb.ConnCase, async: false
+  use RealtimeWeb.ConnCase, async: true
 
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -25,7 +25,7 @@ defmodule Containers do
   def handle_continue({:pool, max_cases}, state) do
     {:ok, _pid} =
       :poolboy.start_link(
-        [name: {:local, Containers.Pool}, size: max_cases + 1, max_overflow: 0, worker_module: Containers.Container],
+        [name: {:local, Containers.Pool}, size: max_cases + 2, max_overflow: 0, worker_module: Containers.Container],
         []
       )
 
@@ -44,12 +44,18 @@ defmodule Containers do
 
       [] ->
         [port | ports] = state.ports
-        name = "realtime-test-#{System.unique_integer([:positive])}"
+        name = "realtime-test-#{random_string(12)}"
 
         docker_run!(name, port)
 
         {:reply, {:ok, name, port}, %{state | ports: ports}}
     end
+  end
+
+  defp random_string(length) do
+    :crypto.strong_rand_bytes(length)
+    |> Base.url_encode64()
+    |> binary_part(0, length)
   end
 
   def initialize(external_id) do

--- a/test/support/containers/container.ex
+++ b/test/support/containers/container.ex
@@ -5,7 +5,7 @@ defmodule Containers.Container do
     GenServer.start_link(__MODULE__, args, opts)
   end
 
-  def port(pid), do: GenServer.call(pid, :port)
+  def port(pid), do: GenServer.call(pid, :port, 15_000)
 
   @impl true
   def handle_call(:port, _from, state) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,7 @@ start_time = :os.system_time(:millisecond)
 
 alias Realtime.Api
 alias Realtime.Database
-ExUnit.start(exclude: [:failing], max_cases: 1, capture_log: true)
+ExUnit.start(exclude: [:failing], max_cases: 2, capture_log: true)
 
 max_cases = ExUnit.configuration()[:max_cases]
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Run more tests in async mode
* Use less Process.sleep whenever possible

## What is the current behavior?

Some time waiting for tests. ~ 300 seconds before my changes

## What is the new behavior?

Less time waiting for tests. `Finished in 230.6 seconds (11.5s async, 219.0s sync)` after my changes

Only change I made on lib/* was to help with tests assertion so not really any feature changes

## Additional context

Might have one or two flaky tests but I'm sure I can solve them
