### PR TITLE
chore: fix container startup for tests

### DIFF
--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -9,6 +9,18 @@ defmodule Containers do
 
   @image "supabase/postgres:17.0.1.081-orioledb"
 
+  # Pull image if not available
+  def pull do
+    case System.cmd("docker", ["image", "inspect", @image]) do
+      {_, 0} ->
+        :ok
+
+      _ ->
+        IO.puts("Pulling image #{@image}. This might take a while...")
+        {_, 0} = System.cmd("docker", ["pull", @image])
+    end
+  end
+
   def start_container(), do: GenServer.call(__MODULE__, :start_container, 10_000)
   def port(), do: GenServer.call(__MODULE__, :port, 10_000)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,6 +6,8 @@ ExUnit.start(exclude: [:failing], max_cases: 2, capture_log: true)
 
 max_cases = ExUnit.configuration()[:max_cases]
 
+Containers.pull()
+
 if System.get_env("REUSE_CONTAINERS") != "true" do
   Containers.stop_containers()
   Containers.stop_container("dev_tenant")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ensures that the docker image used for tests is available before starting the tests

## What is the current behavior?

It breaks because `docker run` takes more than 10 seconds when downloading an image is included 🐌 . Tests fail waiting etc.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context
Before:
<img width="903" alt="mix_test_test_realtime_tenants_connect_test_exs" src="https://github.com/user-attachments/assets/db202616-db44-482e-9192-c8aad5970f57" />



Now:


<img width="786" alt="__supa_realtime" src="https://github.com/user-attachments/assets/ebc1d64c-68ba-4538-827f-04f335538137" />
