### PR TITLE
fix: unassign db_conn from socket to prevent dead connections

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -93,8 +93,7 @@ defmodule RealtimeWeb.RealtimeChannel do
         presence_key: presence_key(params),
         self_broadcast: !!params["config"]["broadcast"]["self"],
         tenant_topic: tenant_topic,
-        channel_name: sub_topic,
-        db_conn: db_conn
+        channel_name: sub_topic
       }
 
       # Start presence and add user
@@ -343,13 +342,13 @@ defmodule RealtimeWeb.RealtimeChannel do
       assigns: %{
         access_token: access_token,
         pg_sub_ref: pg_sub_ref,
-        db_conn: db_conn,
         channel_name: channel_name,
         pg_change_params: pg_change_params
       }
     } = socket
 
     socket = assign(socket, :access_token, refresh_token)
+    {:ok, db_conn} = Connect.lookup_or_start_connection(socket.assigns.tenant)
 
     with {:ok, claims, confirm_token_ref, _, socket} <- confirm_token(socket),
          socket = assign_authorization_context(socket, channel_name, access_token, claims),
@@ -541,13 +540,15 @@ defmodule RealtimeWeb.RealtimeChannel do
   defp confirm_token(%{assigns: assigns} = socket) do
     %{
       jwt_secret: jwt_secret,
-      access_token: access_token
+      access_token: access_token,
+      tenant: tenant_id
     } = assigns
 
     topic = Map.get(assigns, :topic)
-    db_conn = Map.get(assigns, :db_conn)
     socket = Map.put(socket, :policies, nil)
     jwt_jwks = Map.get(assigns, :jwt_jwks)
+
+    db_conn = Connect.lookup_or_start_connection(tenant_id)
 
     with jwt_secret_dec <- Crypto.decrypt!(jwt_secret),
          {:ok, %{"exp" => exp} = claims} when is_integer(exp) <-
@@ -705,11 +706,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     assign(socket, :authorization_context, authorization_context)
   end
 
-  defp maybe_assign_policies(
-         topic,
-         db_conn,
-         %{assigns: %{private?: true}} = socket
-       )
+  defp maybe_assign_policies(topic, db_conn, %{assigns: %{private?: true}} = socket)
        when not is_nil(topic) and not is_nil(db_conn) do
     authorization_context = socket.assigns.authorization_context
 

--- a/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
@@ -9,6 +9,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
   alias Phoenix.Socket
   alias Realtime.GenCounter
   alias Realtime.RateCounter
+  alias Realtime.Tenants.Connect
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
@@ -23,9 +24,11 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
         self_broadcast: self_broadcast,
         tenant_topic: tenant_topic,
         authorization_context: authorization_context,
-        db_conn: db_conn
+        tenant: tenant_id
       }
     } = socket
+
+    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant_id)
 
     case run_authorization_check(socket, db_conn, authorization_context) do
       {:ok,

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -12,6 +12,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
   alias Phoenix.Tracker.Shard
   alias Realtime.GenCounter
   alias Realtime.RateCounter
+  alias Realtime.Tenants.Connect
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.PresencePolicies
@@ -68,7 +69,8 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
          payload,
          %{assigns: %{private?: true, policies: %Policies{presence: %PresencePolicies{write: nil}}}} = socket
        ) do
-    %{assigns: %{db_conn: db_conn, authorization_context: authorization_context}} = socket
+    %{assigns: %{authorization_context: authorization_context, tenant: tenant_id}} = socket
+    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant_id)
 
     case run_authorization_check(socket, db_conn, authorization_context) do
       {:ok, socket} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.0",
+      version: "2.56.1",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -19,8 +19,8 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
   setup [:initiate_tenant]
 
   describe "call/2" do
-    test "with write true policy, user is able to send message", %{topic: topic, tenant: tenant, db_conn: db_conn} do
-      socket = socket_fixture(tenant, topic, db_conn, %Policies{broadcast: %BroadcastPolicies{write: true}})
+    test "with write true policy, user is able to send message", %{topic: topic, tenant: tenant} do
+      socket = socket_fixture(tenant, topic, %Policies{broadcast: %BroadcastPolicies{write: true}})
 
       for _ <- 1..100, reduce: socket do
         socket ->
@@ -39,8 +39,8 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
       assert avg > 0
     end
 
-    test "with write false policy, user is not able to send message", %{topic: topic, tenant: tenant, db_conn: db_conn} do
-      socket = socket_fixture(tenant, topic, db_conn, %Policies{broadcast: %BroadcastPolicies{write: false}})
+    test "with write false policy, user is not able to send message", %{topic: topic, tenant: tenant} do
+      socket = socket_fixture(tenant, topic, %Policies{broadcast: %BroadcastPolicies{write: false}})
 
       for _ <- 1..100, reduce: socket do
         socket ->
@@ -62,10 +62,9 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
     @tag policies: [:authenticated_read_broadcast, :authenticated_write_broadcast]
     test "with nil policy but valid user, is able to send message", %{
       topic: topic,
-      tenant: tenant,
-      db_conn: db_conn
+      tenant: tenant
     } do
-      socket = socket_fixture(tenant, topic, db_conn)
+      socket = socket_fixture(tenant, topic)
 
       for _ <- 1..100, reduce: socket do
         socket ->
@@ -86,10 +85,9 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
     test "with nil policy and invalid user, is not able to send message", %{
       topic: topic,
-      tenant: tenant,
-      db_conn: db_conn
+      tenant: tenant
     } do
-      socket = socket_fixture(tenant, topic, db_conn)
+      socket = socket_fixture(tenant, topic)
 
       for _ <- 1..100, reduce: socket do
         socket ->
@@ -112,10 +110,9 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
     test "validation only runs once on nil and valid policies", %{
       topic: topic,
-      tenant: tenant,
-      db_conn: db_conn
+      tenant: tenant
     } do
-      socket = socket_fixture(tenant, topic, db_conn)
+      socket = socket_fixture(tenant, topic)
 
       with_mock Authorization, [:passthrough], [] do
         for _ <- 1..100, reduce: socket do
@@ -137,10 +134,9 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
     test "validation only runs once on nil and blocking policies", %{
       topic: topic,
-      tenant: tenant,
-      db_conn: db_conn
+      tenant: tenant
     } do
-      socket = socket_fixture(tenant, topic, db_conn)
+      socket = socket_fixture(tenant, topic)
 
       with_mock Authorization, [:passthrough], [] do
         for _ <- 1..100, reduce: socket do
@@ -162,10 +158,9 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
     test "no ack still sends message", %{
       topic: topic,
-      tenant: tenant,
-      db_conn: db_conn
+      tenant: tenant
     } do
-      socket = socket_fixture(tenant, topic, db_conn, %Policies{broadcast: %BroadcastPolicies{write: true}}, false)
+      socket = socket_fixture(tenant, topic, %Policies{broadcast: %BroadcastPolicies{write: true}}, false)
 
       for _ <- 1..100, reduce: socket do
         socket ->
@@ -181,8 +176,8 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
       end
     end
 
-    test "public channels are able to send messages", %{topic: topic, tenant: tenant, db_conn: db_conn} do
-      socket = socket_fixture(tenant, topic, db_conn, nil, false, false)
+    test "public channels are able to send messages", %{topic: topic, tenant: tenant} do
+      socket = socket_fixture(tenant, topic, nil, false, false)
 
       for _ <- 1..100, reduce: socket do
         socket ->
@@ -201,8 +196,8 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
       assert avg > 0.0
     end
 
-    test "public channels are able to send messages and ack", %{topic: topic, tenant: tenant, db_conn: db_conn} do
-      socket = socket_fixture(tenant, topic, db_conn, nil, true, false)
+    test "public channels are able to send messages and ack", %{topic: topic, tenant: tenant} do
+      socket = socket_fixture(tenant, topic, nil, true, false)
 
       for _ <- 1..100, reduce: socket do
         socket ->
@@ -235,13 +230,12 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
     Endpoint.subscribe("realtime:#{topic}")
     if policies = context[:policies], do: create_rls_policies(db_conn, policies, %{topic: topic})
 
-    {:ok, tenant: tenant, db_conn: db_conn, topic: topic}
+    {:ok, tenant: tenant, topic: topic}
   end
 
   defp socket_fixture(
          tenant,
          topic,
-         db_conn,
          policies \\ %Policies{broadcast: %BroadcastPolicies{write: nil, read: true}},
          ack_broadcast \\ true,
          private? \\ true
@@ -275,7 +269,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
         authorization_context: authorization_context,
         rate_counter: rate_counter,
         private?: private?,
-        db_conn: db_conn
+        tenant: tenant.external_id
       }
     }
   end

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -25,13 +25,12 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
   describe "handle/2" do
     test "with true policy and is private, user can track their presence and changes", %{
       tenant: tenant,
-      topic: topic,
-      db_conn: db_conn
+      topic: topic
     } do
       key = random_string()
 
       socket =
-        socket_fixture(tenant, topic, db_conn, key, %Policies{presence: %PresencePolicies{read: true, write: true}})
+        socket_fixture(tenant, topic, key, %Policies{presence: %PresencePolicies{read: true, write: true}})
 
       PresenceHandler.handle(%{"event" => "track"}, socket)
       topic = "realtime:#{topic}"
@@ -41,13 +40,12 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
     test "when tracking already existing user, metadata updated", %{
       tenant: tenant,
-      topic: topic,
-      db_conn: db_conn
+      topic: topic
     } do
       key = random_string()
 
       socket =
-        socket_fixture(tenant, topic, db_conn, key, %Policies{presence: %PresencePolicies{read: true, write: true}})
+        socket_fixture(tenant, topic, key, %Policies{presence: %PresencePolicies{read: true, write: true}})
 
       assert {:reply, :ok, socket} = PresenceHandler.handle(%{"event" => "track"}, socket)
       topic = "realtime:#{topic}"
@@ -64,8 +62,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
     test "with false policy and is public, user can track their presence and changes", %{
       tenant: tenant,
-      topic: topic,
-      db_conn: db_conn
+      topic: topic
     } do
       key = random_string()
 
@@ -73,7 +70,6 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
         socket_fixture(
           tenant,
           topic,
-          db_conn,
           key,
           %Policies{presence: %PresencePolicies{read: false, write: false}},
           false
@@ -85,11 +81,11 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
       assert Map.has_key?(joins, key)
     end
 
-    test "user can untrack when they want", %{tenant: tenant, topic: topic, db_conn: db_conn} do
+    test "user can untrack when they want", %{tenant: tenant, topic: topic} do
       key = random_string()
 
       socket =
-        socket_fixture(tenant, topic, db_conn, key, %Policies{presence: %PresencePolicies{read: true, write: true}})
+        socket_fixture(tenant, topic, key, %Policies{presence: %PresencePolicies{read: true, write: true}})
 
       assert {:reply, :ok, socket} = PresenceHandler.handle(%{"event" => "track"}, socket)
       topic = "realtime:#{topic}"
@@ -102,10 +98,10 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
     end
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
-    test "only checks write policies once on private channels", %{tenant: tenant, topic: topic, db_conn: db_conn} do
+    test "only checks write policies once on private channels", %{tenant: tenant, topic: topic} do
       with_mock Authorization, [:passthrough], [] do
         key = random_string()
-        socket = socket_fixture(tenant, topic, db_conn, key)
+        socket = socket_fixture(tenant, topic, key)
         topic = "realtime:#{topic}"
 
         for _ <- 1..100, reduce: socket do
@@ -124,12 +120,12 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
       end
     end
 
-    test "does not check write policies once on public channels", %{tenant: tenant, topic: topic, db_conn: db_conn} do
+    test "does not check write policies once on public channels", %{tenant: tenant, topic: topic} do
       with_mock Authorization, [:passthrough], [] do
         key = random_string()
 
         socket =
-          socket_fixture(tenant, topic, db_conn, key, %Policies{broadcast: %BroadcastPolicies{read: false}}, false)
+          socket_fixture(tenant, topic, key, %Policies{broadcast: %BroadcastPolicies{read: false}}, false)
 
         topic = "realtime:#{topic}"
 
@@ -182,13 +178,12 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
     Endpoint.subscribe("realtime:#{topic}")
     if policies = context[:policies], do: create_rls_policies(db_conn, policies, %{topic: topic})
 
-    {:ok, tenant: tenant, db_conn: db_conn, topic: topic}
+    {:ok, tenant: tenant, topic: topic}
   end
 
   defp socket_fixture(
          tenant,
          topic,
-         db_conn,
          presence_key,
          policies \\ %Policies{
            broadcast: %BroadcastPolicies{read: true},
@@ -229,8 +224,8 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
         authorization_context: authorization_context,
         rate_counter: rate_counter,
         private?: private?,
-        db_conn: db_conn,
-        presence_key: presence_key
+        presence_key: presence_key,
+        tenant: tenant.external_id
       }
     }
   end


### PR DESCRIPTION
## What kind of change does this PR introduce?

unassign db_conn from socket to prevent dead connections