### PR TITLE
fix: revert phoenix promex plugin change

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.6",
+      version: "2.56.7",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
It turned out that the opentelemetry setup didn't need the latest ranch

We don't need this change as it's calculating active connections differently

## What kind of change does this PR introduce?

Reverts the change made [here](https://github.com/supabase/realtime/commit/c9683f3f5f94bd2e37494f02c1f4415551e96e5b#diff-9ecf706a524ec8811da1b7cd3c6d8e775f26c9cf39f0abf3b7ccca9a465c0203)

After looking at ranch's code the essential difference is between `all` and `active`:

https://github.com/ninenines/ranch/blob/a692f44567034dacf5efcaa24a24183788594eb7/src/ranch.erl#L354-L355

```
		{active_connections, ranch_conns_sup:active_connections(ConnsSup)},
		{all_connections, proplists:get_value(active, supervisor:count_children(ConnsSup))},
```

`active` supervisor process is different from what ranch considers an `active` connection.

## What is the current behavior?

Active connections metrics is not the same 

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Once we upgrade cowboy + ranch we need to revisit this and understand the difference.
