### PR TITLE
fix: ErlSysMon initialization

### DIFF
--- a/lib/realtime/monitoring/erl_sys_mon.ex
+++ b/lib/realtime/monitoring/erl_sys_mon.ex
@@ -7,17 +7,20 @@ defmodule Realtime.ErlSysMon do
 
   require Logger
 
-  @defults [
+  @defaults [
     :busy_dist_port,
     :busy_port,
     {:long_gc, 250},
     {:long_schedule, 100},
     {:long_message_queue, {0, 1_000}}
   ]
-  def start_link(args \\ @defults), do: GenServer.start_link(__MODULE__, args)
+
+  def start_link(args), do: GenServer.start_link(__MODULE__, args)
 
   def init(args) do
-    :erlang.system_monitor(self(), args)
+    config = Keyword.get(args, :config, @defaults)
+    :erlang.system_monitor(self(), config)
+
     {:ok, []}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.7",
+      version: "2.56.8",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/erl_sys_mon_test.exs
+++ b/test/realtime/monitoring/erl_sys_mon_test.exs
@@ -1,11 +1,11 @@
-defmodule Realtime.ErlSysMonTest do
+defmodule Realtime.Monitoring.ErlSysMonTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureLog
   alias Realtime.ErlSysMon
 
   describe "system monitoring" do
     test "logs system monitor events" do
-      start_supervised!({ErlSysMon, [{:long_message_queue, {1, 10}}]})
+      start_supervised!({ErlSysMon, config: [{:long_message_queue, {1, 10}}]})
 
       assert capture_log(fn ->
                Task.async(fn -> Enum.map(1..100_000, &send(self(), &1)) end)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix `ErlSysMon` initialization.

Our application supervision tree adds ErlSysMon like this:

```elixir
[
  ErlSysMon,
  ...
]
```

This translates to `{ErlSysMon, []}` so `ErlSysMon.start_link([])` was being called effectively making system_monitor not track anything. 

I also tested locally calling `:erlang.system_monitor()` which just returns the current configuration. Previously it was returning `:undefined` because nothing was set.

## What is the current behavior?

No erlang system monitor messages

## What is the new behavior?

System monitor messages are being logged

## Additional context

<img width="1247" alt="iex_-S_mix" src="https://github.com/user-attachments/assets/192aaa51-2958-47f7-bc11-1c5e8c285be5" />

