### PR TITLE
fix: register locally after syn

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -137,13 +137,6 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
     {:noreply, prepare_replication(state)}
   end
 
-  @impl true
-  def terminate(reason, state) do
-    Logger.error("Terminating ReplicationPoller: #{inspect(reason)}")
-    Registry.unregister(__MODULE__.Registry, state.tenant)
-    {:stop, reason, state}
-  end
-
   def slot_name_suffix do
     case Application.get_env(:realtime, :slot_name_suffix) do
       nil -> ""

--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -45,6 +45,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
       tenant: tenant
     }
 
+    Registry.register(__MODULE__.Registry, tenant, %{})
     {:ok, state, {:continue, {:connect, args}}}
   end
 
@@ -134,6 +135,13 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
   def handle_info(:retry, %{retry_ref: retry_ref} = state) do
     cancel_timer(retry_ref)
     {:noreply, prepare_replication(state)}
+  end
+
+  @impl true
+  def terminate(reason, state) do
+    Logger.error("Terminating ReplicationPoller: #{inspect(reason)}")
+    Registry.unregister(__MODULE__.Registry, state.tenant)
+    {:stop, reason, state}
   end
 
   def slot_name_suffix do

--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -45,7 +45,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
       tenant: tenant
     }
 
-    Registry.register(__MODULE__.Registry, tenant, %{})
+    {:ok, _} = Registry.register(__MODULE__.Registry, tenant, %{})
     {:ok, state, {:continue, {:connect, args}}}
   end
 

--- a/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
+++ b/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
@@ -3,13 +3,9 @@ defmodule Extensions.PostgresCdcRls.WorkerSupervisor do
   use Supervisor
 
   alias Extensions.PostgresCdcRls
-
-  alias PostgresCdcRls.{
-    ReplicationPoller,
-    SubscriptionManager,
-    SubscriptionsChecker
-  }
-
+  alias PostgresCdcRls.ReplicationPoller
+  alias PostgresCdcRls.SubscriptionManager
+  alias PostgresCdcRls.SubscriptionsChecker
   alias Realtime.Api
   alias Realtime.PostgresCdc.Exception
 

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -354,7 +354,6 @@ defmodule Realtime.Tenants.Connect do
   def terminate(reason, %{tenant_id: tenant_id}) do
     Logger.info("Tenant #{tenant_id} has been terminated: #{inspect(reason)}")
     Realtime.MetricsCleaner.delete_metric(tenant_id)
-    Registry.unregister(__MODULE__.Registry, tenant_id)
     :ok
   end
 
@@ -394,11 +393,8 @@ defmodule Realtime.Tenants.Connect do
     %{
       db_conn_pid: db_conn_pid,
       replication_connection_pid: replication_connection_pid,
-      listen_pid: listen_pid,
-      tenant_id: tenant_id
+      listen_pid: listen_pid
     } = state
-
-    Registry.unregister(__MODULE__.Registry, tenant_id)
 
     :ok = GenServer.stop(db_conn_pid, :shutdown, 500)
 

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -354,6 +354,7 @@ defmodule Realtime.Tenants.Connect do
   def terminate(reason, %{tenant_id: tenant_id}) do
     Logger.info("Tenant #{tenant_id} has been terminated: #{inspect(reason)}")
     Realtime.MetricsCleaner.delete_metric(tenant_id)
+    Registry.unregister(__MODULE__.Registry, tenant_id)
     :ok
   end
 
@@ -393,8 +394,11 @@ defmodule Realtime.Tenants.Connect do
     %{
       db_conn_pid: db_conn_pid,
       replication_connection_pid: replication_connection_pid,
-      listen_pid: listen_pid
+      listen_pid: listen_pid,
+      tenant_id: tenant_id
     } = state
+
+    Registry.unregister(__MODULE__.Registry, tenant_id)
 
     :ok = GenServer.stop(db_conn_pid, :shutdown, 500)
 

--- a/lib/realtime/tenants/connect/register_process.ex
+++ b/lib/realtime/tenants/connect/register_process.ex
@@ -2,14 +2,17 @@ defmodule Realtime.Tenants.Connect.RegisterProcess do
   @moduledoc """
   Registers the database process in :syn
   """
+  alias Realtime.Tenants.Connect
   @behaviour Realtime.Tenants.Connect.Piper
 
   @impl true
   def run(acc) do
     %{tenant_id: tenant_id, db_conn_pid: conn} = acc
 
-    case :syn.update_registry(Realtime.Tenants.Connect, tenant_id, fn _pid, meta -> %{meta | conn: conn} end) do
-      {:ok, _} -> {:ok, acc}
+    with {:ok, _} <- :syn.update_registry(Connect, tenant_id, fn _pid, meta -> %{meta | conn: conn} end),
+         {:ok, _} <- Registry.register(Connect.Registry, tenant_id, %{}) do
+      {:ok, acc}
+    else
       {:error, :undefined} -> {:error, :process_not_found}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/realtime/tenants/connect/register_process.ex
+++ b/lib/realtime/tenants/connect/register_process.ex
@@ -14,6 +14,7 @@ defmodule Realtime.Tenants.Connect.RegisterProcess do
       {:ok, acc}
     else
       {:error, :undefined} -> {:error, :process_not_found}
+      {:error, {:already_registered, _}} -> {:error, :already_registered}
       {:error, reason} -> {:error, reason}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.8",
+      version: "2.56.9",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/e2e/tests.ts
+++ b/test/e2e/tests.ts
@@ -19,11 +19,7 @@ const url = env["PROJECT_URL"];
 const token = env["PROJECT_ANON_TOKEN"];
 const jwtSecret = env["PROJECT_JWT_SECRET"];
 
-const realtime = {
-  heartbeatIntervalMs: 500,
-  timeout: 1000,
-  logger: console.log,
-};
+const realtime = { heartbeatIntervalMs: 500, timeout: 1000 };
 const config = { config: { broadcast: { self: true } } };
 
 let supabase: SupabaseClient | null;

--- a/test/realtime/tenants/connect/register_process_test.exs
+++ b/test/realtime/tenants/connect/register_process_test.exs
@@ -1,20 +1,22 @@
 defmodule Realtime.Tenants.Connect.RegisterProcessTest do
   use Realtime.DataCase, async: true
   alias Realtime.Tenants.Connect.RegisterProcess
-  alias Realtime.Tenants.Connect
+  alias Realtime.Database
 
   describe "run/1" do
     setup do
       tenant = Containers.checkout_tenant(run_migrations: true)
       # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues
       Cachex.put!(Realtime.Tenants.Cache, {{:get_tenant_by_external_id, 1}, [tenant.external_id]}, {:cached, tenant})
-
-      conn = start_supervised!({Connect, [tenant_id: tenant.external_id]})
+      {:ok, conn} = Database.connect(tenant, "realtime_test")
       %{tenant_id: tenant.external_id, db_conn_pid: conn}
     end
 
-    test "registers the process in :syn", %{tenant_id: tenant_id, db_conn_pid: conn} do
+    test "registers the process in syn and Registry and updates metadata", %{tenant_id: tenant_id, db_conn_pid: conn} do
+      # Fake the process registration in :syn
+      :syn.register(Realtime.Tenants.Connect, tenant_id, self(), %{conn: nil})
       assert {:ok, _} = RegisterProcess.run(%{tenant_id: tenant_id, db_conn_pid: conn})
+      assert {_, %{conn: ^conn}} = :syn.lookup(Realtime.Tenants.Connect, tenant_id)
     end
 
     test "handles undefined process error" do

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -417,6 +417,21 @@ defmodule Realtime.Tenants.ConnectTest do
     end
   end
 
+  describe "registers into local registry" do
+    test "successfully registers a process", %{tenant: %{external_id: external_id}} do
+      assert {:ok, _db_conn} = Connect.lookup_or_start_connection(external_id)
+      assert Registry.whereis_name({Realtime.Tenants.Connect.Registry, external_id})
+    end
+
+    test "successfully unregisters a process", %{tenant: %{external_id: external_id}} do
+      assert {:ok, _db_conn} = Connect.lookup_or_start_connection(external_id)
+      assert Registry.whereis_name({Realtime.Tenants.Connect.Registry, external_id})
+      Connect.shutdown(external_id)
+      Process.sleep(100)
+      assert :undefined = Registry.whereis_name({Realtime.Tenants.Connect.Registry, external_id})
+    end
+  end
+
   defp check_db_connections_created(test_pid, tenant_id) do
     spawn(fn ->
       receive do


### PR DESCRIPTION
## What kind of change does this PR introduce?

In Connect and PostgresCDC, after syn registration, it also registers into a Registry so we can use it in the Node for easier debugging and support operations

