### PR TITLE
fix: shutdown scenarios for Connect, Listen and ReplicationConnect

### DIFF
--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -159,7 +159,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
 
   @impl true
   def handle_result([%Postgrex.Result{num_rows: 1}], %__MODULE__{step: :check_replication_slot}) do
-    {:disconnect, "Temporary Replication slot already exists and in use"}
+    {:disconnect, {:shutdown, "Temporary Replication slot already exists and in use"}}
   end
 
   def handle_result(
@@ -334,8 +334,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
       {:noreply, state}
   end
 
-  def handle_info(:shutdown, _), do: {:disconnect, :normal}
-  def handle_info({:DOWN, _, :process, _, _}, _), do: {:disconnect, :normal}
+  def handle_info({:DOWN, _, :process, _, _}, _), do: {:disconnect, :shutdown}
   def handle_info(_, state), do: {:noreply, state}
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.10",
+      version: "2.56.11",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -276,7 +276,7 @@ defmodule Realtime.Tenants.ConnectTest do
       assert {:ok, _db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Connect.ready?(tenant.external_id)
 
-      listen_pid = ReplicationConnection.whereis(tenant.external_id)
+      listen_pid = Listen.whereis(tenant.external_id)
       assert Process.alive?(listen_pid)
 
       pid = Connect.whereis(tenant.external_id)

--- a/test/realtime/tenants/replication_connection_test.exs
+++ b/test/realtime/tenants/replication_connection_test.exs
@@ -124,7 +124,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
     end
   end
 
-  test "monitored pid crashing brings down ReplicationConnection ", %{tenant: tenant} do
+  test "monitored pid stopping brings down ReplicationConnection ", %{tenant: tenant} do
     monitored_pid =
       spawn(fn ->
         receive do
@@ -145,6 +145,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
 
         ref = Process.monitor(pid)
         assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 100
+        refute Process.alive?(pid)
       end)
 
     assert logs =~ "Disconnecting broadcast changes handler in the step"

--- a/test/realtime/tenants/replication_connection_test.exs
+++ b/test/realtime/tenants/replication_connection_test.exs
@@ -2,6 +2,8 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
   # Async false due to tweaking application env
   use Realtime.DataCase, async: false
 
+  import ExUnit.CaptureLog
+
   alias Realtime.Api.Message
   alias Realtime.Database
   alias Realtime.RateCounter
@@ -122,6 +124,56 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
     end
   end
 
+  test "monitored pid crashing brings down ReplicationConnection ", %{tenant: tenant} do
+    monitored_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    logs =
+      capture_log(fn ->
+        pid =
+          start_supervised!(
+            {ReplicationConnection,
+             %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: monitored_pid}},
+            restart: :transient
+          )
+
+        send(monitored_pid, :stop)
+
+        ref = Process.monitor(pid)
+        assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 100
+      end)
+
+    assert logs =~ "Disconnecting broadcast changes handler in the step"
+  end
+
+  test "message without event logs error", %{tenant: tenant} do
+    logs =
+      capture_log(fn ->
+        start_supervised!(
+          {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
+          restart: :transient
+        )
+
+        topic = random_string()
+        tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
+        assert :ok = Endpoint.subscribe(tenant_topic)
+
+        message_fixture(tenant, %{
+          "topic" => "some_topic",
+          "private" => true,
+          "payload" => %{"value" => "something"}
+        })
+
+        refute_receive %Phoenix.Socket.Broadcast{}, 500
+      end)
+
+    assert logs =~ "UnableToBatchBroadcastChanges"
+  end
+
   test "payload without id", %{tenant: tenant} do
     start_link_supervised!(
       {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
@@ -195,7 +247,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
 
     Postgrex.query!(db_conn, "SELECT pg_create_logical_replication_slot($1, 'test_decoding')", [name])
 
-    assert {:error, "Temporary Replication slot already exists and in use"} =
+    assert {:error, {:shutdown, "Temporary Replication slot already exists and in use"}} =
              ReplicationConnection.start(tenant, self())
 
     Postgrex.query!(db_conn, "SELECT pg_drop_replication_slot($1)", [name])


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Fix ReplicationConnection shutdown reason. Any reason that is not `:normal`, `:shutdown` or `{:shutdown, reason}` is considered abnormal. 
* Add more tests to Listen, Connect and ReplicationConnection.
* Simplify Connect shutdown process. There is no need to stop ReplicationConnection and Listen because they monitor the process that started them (Connect). 

One observation that came to mind is that we might as well `Process.link` them if we have them monitoring each other and stopping once the other stops.
