### PR TITLE
Fix missing log and telemetry metadata

### DIFF
--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -164,7 +164,7 @@ defmodule Realtime.Database do
     metadata = Keyword.put(metadata, :target, node(db_conn))
     args = [db_conn, func, opts, metadata]
 
-    case Rpc.enhanced_call(node(db_conn), __MODULE__, :transaction, args) do
+    case Rpc.enhanced_call(node(db_conn), __MODULE__, :transaction, args, metadata) do
       {:ok, value} -> {:ok, value}
       {:error, :rpc_error, error} -> {:error, error}
       {:error, error} -> {:error, error}
@@ -205,7 +205,6 @@ defmodule Realtime.Database do
       ssl: ssl
     } = settings
 
-    Logger.metadata(application_name: application_name)
     metadata = Logger.metadata()
 
     [

--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -220,7 +220,10 @@ defmodule Realtime.Database do
       backoff_type: backoff_type,
       ssl: ssl,
       configure: fn args ->
-        Logger.metadata(metadata)
+        metadata
+        |> Keyword.put(:application_name, application_name)
+        |> Logger.metadata()
+
         args
       end
     ]

--- a/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
@@ -19,7 +19,7 @@ defmodule Realtime.PromEx.Plugins.Tenants do
         description: "Latency of rpc calls triggered by a tenant action",
         measurement: :latency,
         unit: {:microsecond, :millisecond},
-        tags: [:success],
+        tags: [:success, :tenant],
         reporter_options: [buckets: [10, 250, 5000, 15_000]]
       )
     ])

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -159,7 +159,9 @@ defmodule Realtime.Tenants.Authorization do
   end
 
   defp get_read_policies_for_connection(conn, authorization_context, policies) do
-    opts = [telemetry: [:realtime, :tenants, :read_authorization_check], tenant_id: authorization_context.tenant_id]
+    tenant_id = authorization_context.tenant_id
+    opts = [telemetry: [:realtime, :tenants, :read_authorization_check], tenant_id: tenant_id]
+    metadata = [project: tenant_id, external_id: tenant_id]
 
     Database.transaction(
       conn,
@@ -194,12 +196,15 @@ defmodule Realtime.Tenants.Authorization do
         Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
         policies
       end,
-      opts
+      opts,
+      metadata
     )
   end
 
   defp get_write_policies_for_connection(conn, authorization_context, policies) do
-    opts = [telemetry: [:realtime, :tenants, :write_authorization_check], tenant_id: authorization_context.tenant_id]
+    tenant_id = authorization_context.tenant_id
+    opts = [telemetry: [:realtime, :tenants, :write_authorization_check], tenant_id: tenant_id]
+    metadata = [project: tenant_id, external_id: tenant_id]
 
     Database.transaction(
       conn,
@@ -217,7 +222,8 @@ defmodule Realtime.Tenants.Authorization do
 
         policies
       end,
-      opts
+      opts,
+      metadata
     )
   end
 

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -110,6 +110,7 @@ defmodule Realtime.Tenants.Connect do
       {:via, PartitionSupervisor, {Realtime.Tenants.Connect.DynamicSupervisor, tenant_id}}
 
     spec = {__MODULE__, [tenant_id: tenant_id] ++ opts}
+    metadata = [external_id: tenant_id, project: tenant_id]
 
     case DynamicSupervisor.start_child(supervisor, spec) do
       {:ok, _} ->
@@ -125,15 +126,15 @@ defmodule Realtime.Tenants.Connect do
         {:error, :tenant_not_found}
 
       {:error, {:shutdown, :tenant_create_backoff}} ->
-        log_warning("TooManyConnectAttempts", "Too many connect attempts to tenant database")
+        log_warning("TooManyConnectAttempts", "Too many connect attempts to tenant database", metadata)
         {:error, :tenant_create_backoff}
 
       {:error, :shutdown} ->
-        log_error("UnableToConnectToTenantDatabase", "Unable to connect to tenant database")
+        log_error("UnableToConnectToTenantDatabase", "Unable to connect to tenant database", metadata)
         {:error, :tenant_database_unavailable}
 
       {:error, error} ->
-        log_error("UnableToConnectToTenantDatabase", error)
+        log_error("UnableToConnectToTenantDatabase", error, metadata)
         {:error, :tenant_database_unavailable}
     end
   end

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -365,7 +365,7 @@ defmodule Realtime.Tenants.Connect do
     with tenant <- Tenants.Cache.get_tenant_by_external_id(tenant_id),
          :ok <- tenant_suspended?(tenant),
          {:ok, node} <- Realtime.Nodes.get_node_for_tenant(tenant) do
-      Rpc.enhanced_call(node, __MODULE__, :connect, [tenant_id, opts], timeout: rpc_timeout, tenant: tenant_id)
+      Rpc.enhanced_call(node, __MODULE__, :connect, [tenant_id, opts], timeout: rpc_timeout, tenant_id: tenant_id)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.14",
+      version: "2.56.15",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/prom_ex/plugins/tenants_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenants_test.exs
@@ -2,6 +2,7 @@ defmodule Realtime.PromEx.Plugins.TenantsTest do
   use Realtime.DataCase, async: false
 
   alias Realtime.PromEx.Plugins.Tenants
+  alias Realtime.Rpc
   alias Realtime.Tenants.Connect
 
   defmodule MetricsTest do
@@ -12,30 +13,58 @@ defmodule Realtime.PromEx.Plugins.TenantsTest do
     end
   end
 
-  describe "pooling metrics" do
-    setup do
-      local_tenant = Containers.checkout_tenant(run_migrations: true)
-      start_supervised!(MetricsTest)
-      {:ok, %{tenant: local_tenant}}
-    end
+  defmodule Test do
+    def success, do: {:ok, "success"}
+    def failure, do: {:error, "failure"}
+  end
 
-    test "conneted based on Connect module information for local node only", %{tenant: tenant} do
+  setup do
+    local_tenant = Containers.checkout_tenant(run_migrations: true)
+    start_supervised!(MetricsTest)
+    {:ok, %{tenant: local_tenant}}
+  end
+
+  describe "event_metrics" do
+    test "success RPC" do
+      pattern = ~r/realtime_rpc_count{success="true",tenant="123"}\s(?<number>\d+)/
       # Enough time for the poll rate to be triggered at least once
       Process.sleep(200)
-      previous_value = metric_value()
-      {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
+      previous_value = metric_value(pattern)
+      assert {:ok, "success"} = Rpc.enhanced_call(node(), Test, :success, [], tenant_id: "123")
       Process.sleep(200)
-      assert metric_value() == previous_value + 1
+      assert metric_value(pattern) == previous_value + 1
+    end
+
+    test "failure RPC" do
+      pattern = ~r/realtime_rpc_count{success="false",tenant="123"}\s(?<number>\d+)/
+      # Enough time for the poll rate to be triggered at least once
+      Process.sleep(200)
+      previous_value = metric_value(pattern)
+      assert {:error, "failure"} = Rpc.enhanced_call(node(), Test, :failure, [], tenant_id: "123")
+      Process.sleep(200)
+      assert metric_value(pattern) == previous_value + 1
     end
   end
 
-  defp metric_value() do
+  describe "pooling metrics" do
+    test "conneted based on Connect module information for local node only", %{tenant: tenant} do
+      pattern = ~r/realtime_tenants_connected\s(?<number>\d+)/
+      # Enough time for the poll rate to be triggered at least once
+      Process.sleep(200)
+      previous_value = metric_value(pattern)
+      {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
+      Process.sleep(200)
+      assert metric_value(pattern) == previous_value + 1
+    end
+  end
+
+  defp metric_value(pattern) do
     PromEx.get_metrics(MetricsTest)
     |> String.split("\n", trim: true)
     |> Enum.find_value(
       "0",
       fn item ->
-        case Regex.run(~r/realtime_tenants_connected\s(?<number>\d+)/, item, capture: ["number"]) do
+        case Regex.run(pattern, item, capture: ["number"]) do
           [number] -> number
           _ -> false
         end

--- a/test/realtime/rpc_test.exs
+++ b/test/realtime/rpc_test.exs
@@ -72,7 +72,7 @@ defmodule Realtime.RpcTest do
 
   describe "enhanced_call/5" do
     test "successful RPC call returns exactly what the original function returns", %{node: node} do
-      assert {:ok, "success"} = Rpc.enhanced_call(node, TestRpc, :test_success)
+      assert {:ok, "success"} = Rpc.enhanced_call(node, TestRpc, :test_success, [], tenant_id: "123")
       origin_node = node()
 
       assert_receive {[:realtime, :rpc], %{latency: _},
@@ -81,15 +81,16 @@ defmodule Realtime.RpcTest do
                         func: :test_success,
                         origin_node: ^origin_node,
                         target_node: ^node,
-                        success: true
+                        success: true,
+                        tenant: "123"
                       }}
     end
 
     test "raised exceptions are properly caught and logged", %{node: node} do
       assert capture_log(fn ->
                assert {:error, :rpc_error, %RuntimeError{message: "test"}} =
-                        Rpc.enhanced_call(node, TestRpc, :test_raise)
-             end) =~ "ErrorOnRpcCall"
+                        Rpc.enhanced_call(node, TestRpc, :test_raise, [], tenant_id: "123")
+             end) =~ "project=123 external_id=123 [error] ErrorOnRpcCall"
 
       origin_node = node()
 
@@ -99,7 +100,8 @@ defmodule Realtime.RpcTest do
                         func: :test_raise,
                         origin_node: ^origin_node,
                         target_node: ^node,
-                        success: false
+                        success: false,
+                        tenant: "123"
                       }}
     end
 

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -335,7 +335,9 @@ defmodule Realtime.Tenants.ConnectTest do
 
     test "handle rpc errors gracefully" do
       expect(Realtime.Nodes, :get_node_for_tenant, fn _ -> {:ok, :potato@nohost} end)
-      assert {:error, :rpc_error, _} = Connect.lookup_or_start_connection("tenant")
+
+      assert capture_log(fn -> assert {:error, :rpc_error, _} = Connect.lookup_or_start_connection("tenant") end) =~
+               "project=tenant external_id=tenant [error] ErrorOnRpcCall"
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix a few places where tenant/external_id/project information was missing on logs and telemetry.

## What is the current behavior?

Missing metadata

## What is the new behavior?

Metadata is set (when available) on:
* `Rpc.enhanced_call` error log statements
*  `Rpc.enhanced_call` telemetry
* Authorization -> Database.transaction error logs
* Connect error log statements

## Additional context

Add any other context or screenshots.
