### PR TITLE
fix: change Authorization policy calls to use RPC when db connection is not local

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -40,10 +40,8 @@ config :realtime,
   prom_poll_rate: 5_000,
   request_id_baggage_key: "sb-request-id"
 
-# Print only errors during test
-config :logger,
-  compile_time_purge_matching: [[module: Postgrex], [module: DBConnection]],
-  level: :warning
+# Print nothing during tests unless captured or a test failure happens
+config :logger, backends: []
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/lib/realtime/rpc.ex
+++ b/lib/realtime/rpc.ex
@@ -32,8 +32,7 @@ defmodule Realtime.Rpc do
     tenant_id = Keyword.get(opts, :tenant_id)
 
     try do
-      with {latency, response} <-
-             :timer.tc(fn -> :erpc.call(node, mod, func, args, timeout) end) do
+      with {latency, response} <- :timer.tc(fn -> :erpc.call(node, mod, func, args, timeout) end) do
         case response do
           {:ok, _} ->
             Telemetry.execute(
@@ -44,14 +43,14 @@ defmodule Realtime.Rpc do
 
             response
 
-          {:error, error} ->
+          error ->
             Telemetry.execute(
               [:realtime, :rpc],
               %{latency: latency},
               %{mod: mod, func: func, target_node: node, origin_node: node(), success: false, tenant: tenant_id}
             )
 
-            {:error, error}
+            error
         end
       end
     catch

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -74,7 +74,8 @@ defmodule Realtime.Tenants.Authorization do
            node(db_conn),
            __MODULE__,
            :get_read_authorizations,
-           [policies, db_conn, authorization_context]
+           [policies, db_conn, authorization_context],
+           tenant_id: authorization_context.tenant_id
          ) do
       {:error, :rpc_error, reason} -> {:error, reason}
       response -> response
@@ -103,7 +104,8 @@ defmodule Realtime.Tenants.Authorization do
            node(db_conn),
            __MODULE__,
            :get_write_authorizations,
-           [policies, db_conn, authorization_context]
+           [policies, db_conn, authorization_context],
+           tenant_id: authorization_context.tenant_id
          ) do
       {:error, :rpc_error, reason} -> {:error, reason}
       response -> response
@@ -152,7 +154,7 @@ defmodule Realtime.Tenants.Authorization do
   defp get_read_policies_for_connection(conn, authorization_context, policies) do
     tenant_id = authorization_context.tenant_id
     opts = [telemetry: [:realtime, :tenants, :read_authorization_check], tenant_id: tenant_id]
-    metadata = [project: tenant_id, external_id: tenant_id]
+    metadata = [project: tenant_id, external_id: tenant_id, tenant_id: tenant_id]
 
     Database.transaction(
       conn,

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -12,11 +12,13 @@ defmodule Realtime.Tenants.Authorization do
   require Logger
   import Ecto.Query
 
+  alias DBConnection.ConnectionError
   alias Realtime.Api.Message
   alias Realtime.Database
   alias Realtime.Repo
+  alias Realtime.Rpc
   alias Realtime.Tenants.Authorization.Policies
-  alias DBConnection.ConnectionError
+
   defstruct [:tenant_id, :topic, :headers, :jwt, :claims, :role]
 
   @type t :: %__MODULE__{
@@ -52,10 +54,12 @@ defmodule Realtime.Tenants.Authorization do
 
   @doc """
   Runs validations based on RLS policies to return policies for read policies
+
+  Automatically uses RPC if the database connection is not in the same node
   """
   @spec get_read_authorizations(Policies.t(), pid(), t()) ::
           {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error, any()}
-  def get_read_authorizations(policies, db_conn, authorization_context) do
+  def get_read_authorizations(policies, db_conn, authorization_context) when node() == node(db_conn) do
     case get_read_policies_for_connection(db_conn, authorization_context, policies) do
       {:ok, %Policies{} = policies} -> {:ok, policies}
       {:ok, {:error, %Postgrex.Error{} = error}} -> {:error, :rls_policy_error, error}
@@ -64,17 +68,45 @@ defmodule Realtime.Tenants.Authorization do
     end
   end
 
+  # Remote call
+  def get_read_authorizations(policies, db_conn, authorization_context) do
+    case Rpc.enhanced_call(
+           node(db_conn),
+           __MODULE__,
+           :get_read_authorizations,
+           [policies, db_conn, authorization_context]
+         ) do
+      {:error, :rpc_error, reason} -> {:error, reason}
+      response -> response
+    end
+  end
+
   @doc """
   Runs validations based on RLS policies to return policies for write policies
+
+  Automatically uses RPC if the database connection is not in the same node
   """
   @spec get_write_authorizations(Policies.t(), pid(), __MODULE__.t()) ::
           {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error, any()}
-  def get_write_authorizations(policies, db_conn, authorization_context) when is_pid(db_conn) do
+  def get_write_authorizations(policies, db_conn, authorization_context) when node() == node(db_conn) do
     case get_write_policies_for_connection(db_conn, authorization_context, policies) do
       {:ok, %Policies{} = policies} -> {:ok, policies}
       {:ok, {:error, %Postgrex.Error{} = error}} -> {:error, :rls_policy_error, error}
       {:error, %ConnectionError{reason: :queue_timeout}} -> {:error, :increase_connection_pool}
       {:error, error} -> {:error, error}
+    end
+  end
+
+  # Remote call
+  def get_write_authorizations(policies, db_conn, authorization_context) do
+    case Rpc.enhanced_call(
+           node(db_conn),
+           __MODULE__,
+           :get_write_authorizations,
+           [policies, db_conn, authorization_context]
+         ) do
+      {:error, :rpc_error, reason} -> {:error, reason}
+      response -> response
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.17",
+      version: "2.56.18",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -234,6 +234,13 @@ defmodule Realtime.DatabaseTest do
   Code.eval_quoted(@aux_mod)
 
   describe "transaction/1 in clustered mode" do
+    setup do
+      Connect.shutdown("dev_tenant")
+      # Waiting for :syn to "unregister" if the Connect process was up
+      Process.sleep(100)
+      :ok
+    end
+
     test "success call returns output" do
       {:ok, node} = Clustered.start(@aux_mod)
       {:ok, db_conn} = Rpc.call(node, Connect, :connect, ["dev_tenant"])

--- a/test/realtime/tenants/authorization_remote_test.exs
+++ b/test/realtime/tenants/authorization_remote_test.exs
@@ -1,0 +1,250 @@
+defmodule Realtime.Tenants.AuthorizationRemoteTest do
+  # async: false due to usage of Clustered
+  # Also using dev_tenant due to distributed test
+  use RealtimeWeb.ConnCase, async: false
+  use Mimic
+  setup :set_mimic_global
+
+  require Phoenix.ChannelTest
+
+  alias Realtime.Database
+  alias Realtime.Tenants.Authorization
+  alias Realtime.Tenants.Authorization.Policies
+  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Authorization.Policies.PresencePolicies
+
+  setup [:rls_context]
+
+  describe "get_authorizations" do
+    @tag role: "authenticated",
+         policies: [
+           :authenticated_read_broadcast_and_presence,
+           :authenticated_write_broadcast_and_presence
+         ]
+    test "authenticated user has expected policies", context do
+      {:ok, policies} =
+        Authorization.get_read_authorizations(
+          %Policies{},
+          context.db_conn,
+          context.authorization_context
+        )
+
+      {:ok, policies} =
+        Authorization.get_write_authorizations(
+          policies,
+          context.db_conn,
+          context.authorization_context
+        )
+
+      assert %Policies{
+               broadcast: %BroadcastPolicies{read: true, write: true},
+               presence: %PresencePolicies{read: true, write: true}
+             } == policies
+    end
+
+    @tag role: "anon",
+         policies: [
+           :authenticated_read_broadcast_and_presence,
+           :authenticated_write_broadcast_and_presence
+         ]
+    test "anon user has no policies", context do
+      {:ok, policies} =
+        Authorization.get_read_authorizations(
+          %Policies{},
+          context.db_conn,
+          context.authorization_context
+        )
+
+      {:ok, policies} =
+        Authorization.get_write_authorizations(
+          policies,
+          context.db_conn,
+          context.authorization_context
+        )
+
+      assert %Policies{
+               broadcast: %BroadcastPolicies{read: false, write: false},
+               presence: %PresencePolicies{read: false, write: false}
+             } == policies
+    end
+  end
+
+  describe "get_write_authorizations for DBConnection" do
+    @tag role: "authenticated",
+         policies: [
+           :authenticated_read_broadcast_and_presence,
+           :authenticated_write_broadcast_and_presence
+         ]
+    test "authenticated user has expected policies", context do
+      {:ok, policies} =
+        Authorization.get_write_authorizations(
+          %Policies{},
+          context.db_conn,
+          context.authorization_context
+        )
+
+      assert %Policies{
+               broadcast: %BroadcastPolicies{read: nil, write: true},
+               presence: %PresencePolicies{read: nil, write: true}
+             } == policies
+    end
+
+    @tag role: "anon",
+         policies: [
+           :authenticated_read_broadcast_and_presence,
+           :authenticated_write_broadcast_and_presence
+         ]
+    test "anon user has no policies", context do
+      {:ok, policies} =
+        Authorization.get_write_authorizations(
+          %Policies{},
+          context.db_conn,
+          context.authorization_context
+        )
+
+      assert %Policies{
+               broadcast: %BroadcastPolicies{read: nil, write: false},
+               presence: %PresencePolicies{read: nil, write: false}
+             } = policies
+    end
+  end
+
+  describe "database error" do
+    @tag role: "authenticated",
+         policies: [
+           :authenticated_read_broadcast_and_presence,
+           :authenticated_write_broadcast_and_presence
+         ],
+         timeout: :timer.minutes(2)
+    test "handles small pool size", context do
+      task =
+        Task.async(fn ->
+          :erpc.call(node(context.db_conn), Postgrex, :query!, [
+            context.db_conn,
+            "SELECT pg_sleep(59)",
+            [],
+            [timeout: :timer.minutes(1)]
+          ])
+        end)
+
+      Process.sleep(100)
+
+      assert {:error, :increase_connection_pool} =
+               Authorization.get_read_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      assert {:error, :increase_connection_pool} =
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      assert {:error, :increase_connection_pool} =
+               Authorization.get_read_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      assert {:error, :increase_connection_pool} =
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      assert {:error, :increase_connection_pool} =
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      Task.await(task, :timer.minutes(1))
+    end
+
+    @tag role: "authenticated",
+         policies: [:broken_read_presence, :broken_write_presence]
+    test "broken RLS policy sets policies to false and shows error to user", context do
+      assert {:error, :rls_policy_error, %Postgrex.Error{}} =
+               Authorization.get_read_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      assert {:error, :rls_policy_error, %Postgrex.Error{}} =
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      assert {:error, :rls_policy_error, %Postgrex.Error{}} =
+               Authorization.get_read_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      assert {:error, :rls_policy_error, %Postgrex.Error{}} =
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+
+      assert {:error, :rls_policy_error, %Postgrex.Error{}} =
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context
+               )
+    end
+  end
+
+  defp rls_context(context) do
+    tenant = Realtime.Tenants.get_tenant_by_external_id("dev_tenant")
+
+    {:ok, local_db_conn} = Database.connect(tenant, "realtime_test", :stop)
+    topic = random_string()
+
+    clean_table(local_db_conn, "realtime", "messages")
+
+    claims = %{sub: random_string(), role: context.role, exp: Joken.current_time() + 1_000}
+    signer = Joken.Signer.create("HS256", "secret")
+
+    jwt = Joken.generate_and_sign!(%{}, claims, signer)
+
+    authorization_context =
+      Authorization.build_authorization_params(%{
+        tenant_id: tenant.external_id,
+        topic: topic,
+        jwt: jwt,
+        claims: claims,
+        headers: [{"header-1", "value-1"}],
+        role: claims.role
+      })
+
+    Realtime.Tenants.Migrations.create_partitions(local_db_conn)
+    create_rls_policies(local_db_conn, context.policies, %{topic: topic})
+
+    {:ok, node} = Clustered.start()
+    # Start the database connection on the remote node
+    stub(Realtime.Nodes, :get_node_for_tenant, fn _ -> {:ok, node} end)
+    {:ok, db_conn} = Realtime.Tenants.Connect.lookup_or_start_connection("dev_tenant")
+
+    assert node(db_conn) == node
+
+    %{
+      tenant: tenant,
+      topic: topic,
+      db_conn: db_conn,
+      authorization_context: authorization_context
+    }
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

This way we reduce the amount of information sent between nodes to authorize channels to read and write. 

## What is the current behavior?

To authorize RPC calls that were being made through `Database.transaction`.

## What is the new behavior?

Now we do the RPC call from a higher level not passing an anonymous function and simplifying the arguments (and consequently the amount of bytes) passed. Roughly 30% smaller using `:erlang.term_to_binary` to calculate (based on our test cases).

Notice that it still calls `Database.transaction` but now it will always be handled locally:

https://github.com/supabase/realtime/blob/488af4e0e04ad7a41aadee7536bd40b47b063c07/lib/realtime/database.ex#L160-L161

## Additional context

Add any other context or screenshots.
