### PR TITLE
fix: RLS authorization metrics

### DIFF
--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -177,7 +177,7 @@ defmodule Realtime.Database do
     if telemetry do
       tenant_id = Keyword.get(opts, :tenant_id, nil)
       {latency, value} = :timer.tc(Postgrex, :transaction, [db_conn, func, opts], :millisecond)
-      Telemetry.execute(telemetry, %{latency: latency}, %{tenant_id: tenant_id})
+      Telemetry.execute(telemetry, %{latency: latency}, %{tenant: tenant_id})
       value
     else
       Postgrex.transaction(db_conn, func, opts)

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -155,19 +155,23 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           description: "Sum of presence messages sent on a Realtime Channel.",
           tags: [:tenant]
         ),
-        last_value(
+        distribution(
           [:realtime, :tenants, :read_authorization_check],
           event_name: [:realtime, :tenants, :read_authorization_check],
-          measurement: :count,
-          description: "Last value of read authorization checks.",
-          tags: [:tenant]
+          measurement: :latency,
+          unit: :millisecond,
+          description: "Latency of read authorization checks.",
+          tags: [:tenant],
+          reporter_options: [buckets: [10, 250, 5000, 15_000]]
         ),
-        last_value(
+        distribution(
           [:realtime, :tenants, :write_authorization_check],
           event_name: [:realtime, :tenants, :write_authorization_check],
-          measurement: :count,
-          description: "Last value of write authorization checks.",
-          tags: [:tenant]
+          measurement: :latency,
+          unit: :millisecond,
+          description: "Latency of write authorization checks.",
+          tags: [:tenant],
+          reporter_options: [buckets: [10, 250, 5000, 15_000]]
         )
       ]
     )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.19",
+      version: "2.56.20",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -199,7 +199,7 @@ defmodule Realtime.DatabaseTest do
       opts = [telemetry: event]
 
       Database.transaction(db_conn, fn conn -> Postgrex.query!(conn, "SELECT pg_sleep(0.1)", []) end, opts)
-      assert_receive {^event, %{latency: latency}, %{tenant_id: nil}}
+      assert_receive {^event, %{latency: latency}, %{tenant: nil}}
       assert latency > 100
     end
 
@@ -210,7 +210,7 @@ defmodule Realtime.DatabaseTest do
 
       Database.transaction(db_conn, fn conn -> Postgrex.query!(conn, "SELECT pg_sleep(0.1)", []) end, opts)
 
-      assert_receive {^event, %{latency: latency}, %{tenant_id: ^tenant_id}}
+      assert_receive {^event, %{latency: latency}, %{tenant: ^tenant_id}}
       assert latency > 100
     end
   end

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -214,10 +214,10 @@ defmodule Realtime.Tenants.AuthorizationTest do
       external_id = context.authorization_context.tenant_id
 
       assert_receive {:telemetry_event, [:realtime, :tenants, :read_authorization_check], %{latency: _},
-                      %{tenant_id: ^external_id}}
+                      %{tenant: ^external_id}}
 
       assert_receive {:telemetry_event, [:realtime, :tenants, :write_authorization_check], %{latency: _},
-                      %{tenant_id: ^external_id}}
+                      %{tenant: ^external_id}}
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix read and write authorization check metric collection

## What is the current behavior?

```
15:49:18.135 [debug] Measurement not found, expected: count. metric_name:=[:realtime, :tenants, :read_authorization_check]
     15:49:18.142 [debug] Measurement not found, expected: count. metric_name:=[:realtime, :tenants, :write_authorization_check]
```

## What is the new behavior?
Metrics are exposed through prometheus metrics

## Additional context

Add any other context or screenshots.
