### PR TITLE
fix: GenRpc broadcaster to use multicast

### DIFF
--- a/lib/realtime_web/tenant_broadcaster/gen_rpc.ex
+++ b/lib/realtime_web/tenant_broadcaster/gen_rpc.ex
@@ -5,13 +5,13 @@ defmodule RealtimeWeb.TenantBroadcaster.GenRpc do
 
   @impl true
   def broadcast(topic, event, msg) do
-    Realtime.GenRpc.multicall(RealtimeWeb.Endpoint, :local_broadcast, [topic, event, msg])
+    Realtime.GenRpc.multicast(RealtimeWeb.Endpoint, :local_broadcast, [topic, event, msg])
     :ok
   end
 
   @impl true
   def broadcast_from(from, topic, event, msg) do
-    Realtime.GenRpc.multicall(RealtimeWeb.Endpoint, :local_broadcast_from, [from, topic, event, msg])
+    Realtime.GenRpc.multicast(RealtimeWeb.Endpoint, :local_broadcast_from, [from, topic, event, msg])
     :ok
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.57.1",
+      version: "2.57.2",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Change the GenRpc broadcaster to use eval_everywhere so that we don't have to wait for all nodes to ack that they called Phoenix.local_broadcast. This way we have a more equivalent version of the Phoenix broadcaster

## What is the current behavior?

Using `multicall` and waiting for responses

## What is the new behavior?

Fire and forget. We still get errors logged if there is an issue with the gen_rpc tcp connection

## Additional context

Add any other context or screenshots.
