### PR TITLE
fix: change TenantBroadcaster.GenRpc to use topic as a key

### DIFF
--- a/lib/realtime_web/tenant_broadcaster/gen_rpc.ex
+++ b/lib/realtime_web/tenant_broadcaster/gen_rpc.ex
@@ -5,13 +5,13 @@ defmodule RealtimeWeb.TenantBroadcaster.GenRpc do
 
   @impl true
   def broadcast(topic, event, msg) do
-    Realtime.GenRpc.multicast(RealtimeWeb.Endpoint, :local_broadcast, [topic, event, msg])
+    Realtime.GenRpc.multicast(RealtimeWeb.Endpoint, :local_broadcast, [topic, event, msg], key: topic)
     :ok
   end
 
   @impl true
   def broadcast_from(from, topic, event, msg) do
-    Realtime.GenRpc.multicast(RealtimeWeb.Endpoint, :local_broadcast_from, [from, topic, event, msg])
+    Realtime.GenRpc.multicast(RealtimeWeb.Endpoint, :local_broadcast_from, [from, topic, event, msg], key: topic)
     :ok
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.57.5",
+      version: "2.57.6",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -248,7 +248,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      expect(Endpoint, :broadcast_from, 5, fn _, _, _, _ -> :ok end)
+      expect(Endpoint, :broadcast, 5, fn _, _, _ -> :ok end)
 
       messages_to_send =
         Stream.repeatedly(fn -> generate_message_with_policies(db_conn, tenant) end)
@@ -270,7 +270,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
-      broadcast_calls = calls(&Endpoint.broadcast_from/4)
+      broadcast_calls = calls(&Endpoint.broadcast/3)
 
       Enum.each(messages_to_send, fn %{topic: topic} ->
         payload = %{
@@ -281,7 +281,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
         broadcast_topic = Tenants.tenant_topic(tenant, topic, false)
 
-        assert [self(), broadcast_topic, "broadcast", payload] in broadcast_calls
+        assert [broadcast_topic, "broadcast", payload] in broadcast_calls
       end)
 
       assert conn.status == 202
@@ -295,7 +295,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      expect(Endpoint, :broadcast_from, 6, fn _, _, _, _ -> :ok end)
+      expect(Endpoint, :broadcast, 6, fn _, _, _ -> :ok end)
 
       channels =
         Stream.repeatedly(fn -> generate_message_with_policies(db_conn, tenant) end)
@@ -327,7 +327,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
-      broadcast_calls = calls(&Endpoint.broadcast_from/4)
+      broadcast_calls = calls(&Endpoint.broadcast/3)
 
       Enum.each(channels, fn %{topic: topic} ->
         payload = %{
@@ -338,7 +338,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
         broadcast_topic = Tenants.tenant_topic(tenant, topic, false)
 
-        assert [self(), broadcast_topic, "broadcast", payload] in broadcast_calls
+        assert [broadcast_topic, "broadcast", payload] in broadcast_calls
       end)
 
       # Check open channel
@@ -348,7 +348,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
         "type" => "broadcast"
       }
 
-      assert [self(), Tenants.tenant_topic(tenant, "open_channel", true), "broadcast", payload] in broadcast_calls
+      assert [Tenants.tenant_topic(tenant, "open_channel", true), "broadcast", payload] in broadcast_calls
 
       assert conn.status == 202
     end
@@ -361,7 +361,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      expect(Endpoint, :broadcast_from, 5, fn _, _, _, _ -> :ok end)
+      expect(Endpoint, :broadcast, 5, fn _, _, _ -> :ok end)
 
       messages_to_send =
         Stream.repeatedly(fn -> generate_message_with_policies(db_conn, tenant) end)
@@ -385,7 +385,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
-      broadcast_calls = calls(&Endpoint.broadcast_from/4)
+      broadcast_calls = calls(&Endpoint.broadcast/3)
 
       Enum.each(messages_to_send, fn %{topic: topic} ->
         payload = %{
@@ -396,7 +396,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
         broadcast_topic = Tenants.tenant_topic(tenant, topic, false)
 
-        assert [self(), broadcast_topic, "broadcast", payload] in broadcast_calls
+        assert [broadcast_topic, "broadcast", payload] in broadcast_calls
       end)
 
       assert conn.status == 202
@@ -405,7 +405,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     @tag role: "anon"
     test "user without permission won't broadcast", %{conn: conn, db_conn: db_conn, tenant: tenant} do
       request_events_key = Tenants.requests_per_second_key(tenant)
-      reject(&Endpoint.broadcast_from/4)
+      reject(&Endpoint.broadcast/3)
 
       messages =
         Stream.repeatedly(fn -> generate_message_with_policies(db_conn, tenant) end)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This ensures that two messages sent to the same topic from the same node are sent one after the other instead of in parallel

## What is the current behavior?

GenRpc will pick a random key making it possible that two different messages for the same topic arrive in any order

## What is the new behavior?

Ensure that messages sent to the same topic at the same time keep the original order

## Additional context

Add any other context or screenshots.
