### PR TITLE
fix: use tenant broadcaster everywhere

### DIFF
--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -14,7 +14,7 @@ defmodule Realtime.Tenants.BatchBroadcast do
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
   alias Realtime.Tenants.Connect
 
-  alias RealtimeWeb.Endpoint
+  alias RealtimeWeb.TenantBroadcaster
 
   embedded_schema do
     embeds_many :messages, Message do
@@ -110,7 +110,7 @@ defmodule Realtime.Tenants.BatchBroadcast do
     payload = %{"payload" => payload, "event" => event, "type" => "broadcast"}
 
     GenCounter.add(events_per_second_key)
-    Endpoint.broadcast_from(self(), tenant_topic, "broadcast", payload)
+    TenantBroadcaster.broadcast(tenant, tenant_topic, "broadcast", payload)
   end
 
   defp permissions_for_message(_, nil, _), do: nil

--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -70,10 +70,8 @@ defmodule Realtime.Tenants.ReplicationConnection do
     """
     use GenServer
 
-    @init_timeout 30_000
-
-    def start_link(args) do
-      GenServer.start_link(__MODULE__, args, timeout: @init_timeout)
+    def start_link(args, init_timeout) do
+      GenServer.start_link(__MODULE__, args, timeout: init_timeout)
     end
 
     @impl true
@@ -85,18 +83,20 @@ defmodule Realtime.Tenants.ReplicationConnection do
     end
   end
 
+  @default_init_timeout 30_000
+
   @doc """
   Starts the replication connection for a tenant and monitors a given pid to stop the ReplicationConnection.
   """
   @spec start(Realtime.Api.Tenant.t(), pid()) :: {:ok, pid()} | {:error, any()}
-  def start(tenant, monitored_pid) do
+  def start(tenant, monitored_pid, init_timeout \\ @default_init_timeout) do
     Logger.info("Starting replication for Broadcast Changes")
     opts = %__MODULE__{tenant_id: tenant.external_id, monitored_pid: monitored_pid}
     supervisor_spec = supervisor_spec(tenant)
 
     child_spec = %{
       id: __MODULE__,
-      start: {Wrapper, :start_link, [opts]},
+      start: {Wrapper, :start_link, [opts, init_timeout]},
       restart: :transient,
       type: :worker
     }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.57.4",
+      version: "2.57.5",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/replication_connection_test.exs
+++ b/test/realtime/tenants/replication_connection_test.exs
@@ -32,131 +32,162 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
     %{tenant: tenant}
   end
 
-  test "fails if tenant connection is invalid" do
-    tenant =
-      tenant_fixture(%{
-        "extensions" => [
-          %{
-            "type" => "postgres_cdc_rls",
-            "settings" => %{
-              "db_host" => "127.0.0.1",
-              "db_name" => "postgres",
-              "db_user" => "supabase_admin",
-              "db_password" => "postgres",
-              "db_port" => "9001",
-              "poll_interval" => 100,
-              "poll_max_changes" => 100,
-              "poll_max_record_bytes" => 1_048_576,
-              "region" => "us-east-1",
-              "ssl_enforced" => true
-            }
-          }
-        ]
-      })
+  for adapter <- [:phoenix, :gen_rpc] do
+    describe "replication with #{adapter}" do
+      @describetag adapter: adapter
 
-    assert {:error, _} = ReplicationConnection.start(tenant, self())
-  end
-
-  test "starts a handler for the tenant and broadcasts", %{tenant: tenant} do
-    start_link_supervised!(
-      {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
-      restart: :transient
-    )
-
-    topic = random_string()
-    tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
-    Endpoint.subscribe(tenant_topic)
-
-    total_messages = 5
-    # Works with one insert per transaction
-    for _ <- 1..total_messages do
-      value = random_string()
-
-      message_fixture(tenant, %{
-        "topic" => topic,
-        "private" => true,
-        "event" => "INSERT",
-        "payload" => %{"value" => value}
-      })
-
-      assert_receive %Phoenix.Socket.Broadcast{
-                       event: "broadcast",
-                       payload: %{
-                         "event" => "INSERT",
-                         "payload" => %{
-                           "value" => ^value
-                         },
-                         "type" => "broadcast"
-                       },
-                       topic: ^tenant_topic
-                     },
-                     500
-    end
-
-    Process.sleep(500)
-    # Works with batch inserts
-    messages =
-      for _ <- 1..total_messages do
-        Message.changeset(%Message{}, %{
-          "topic" => topic,
-          "private" => true,
-          "event" => "INSERT",
-          "extension" => "broadcast",
-          "payload" => %{"value" => random_string()}
-        })
+      setup %{tenant: tenant, adapter: broadcast_adapter} do
+        {:ok, tenant} = Realtime.Api.update_tenant(tenant, %{broadcast_adapter: broadcast_adapter})
+        %{tenant: tenant}
       end
 
-    {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+      test "fails if tenant connection is invalid" do
+        tenant =
+          tenant_fixture(%{
+            "extensions" => [
+              %{
+                "type" => "postgres_cdc_rls",
+                "settings" => %{
+                  "db_host" => "127.0.0.1",
+                  "db_name" => "postgres",
+                  "db_user" => "supabase_admin",
+                  "db_password" => "postgres",
+                  "db_port" => "9001",
+                  "poll_interval" => 100,
+                  "poll_max_changes" => 100,
+                  "poll_max_record_bytes" => 1_048_576,
+                  "region" => "us-east-1",
+                  "ssl_enforced" => true
+                }
+              }
+            ]
+          })
 
-    {:ok, _} = Realtime.Repo.insert_all_entries(db_conn, messages, Message)
+        assert {:error, _} = ReplicationConnection.start(tenant, self())
+      end
 
-    for message <- messages do
-      value = message |> Map.from_struct() |> get_in([:changes, :payload, "value"])
+      test "starts a handler for the tenant and broadcasts", %{tenant: tenant} do
+        start_link_supervised!(
+          {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
+          restart: :transient
+        )
 
-      assert_receive %Phoenix.Socket.Broadcast{
-                       event: "broadcast",
-                       payload: %{
-                         "event" => "INSERT",
-                         "payload" => %{"value" => ^value},
-                         "type" => "broadcast"
-                       },
-                       topic: ^tenant_topic
-                     },
-                     500
-    end
-  end
+        topic = random_string()
+        tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
+        Endpoint.subscribe(tenant_topic)
 
-  test "monitored pid stopping brings down ReplicationConnection ", %{tenant: tenant} do
-    monitored_pid =
-      spawn(fn ->
-        receive do
-          :stop -> :ok
+        total_messages = 5
+        # Works with one insert per transaction
+        for _ <- 1..total_messages do
+          value = random_string()
+
+          message_fixture(tenant, %{
+            "topic" => topic,
+            "private" => true,
+            "event" => "INSERT",
+            "payload" => %{"value" => value}
+          })
+
+          assert_receive %Phoenix.Socket.Broadcast{
+                           event: "broadcast",
+                           payload: %{
+                             "event" => "INSERT",
+                             "payload" => %{
+                               "value" => ^value
+                             },
+                             "type" => "broadcast"
+                           },
+                           topic: ^tenant_topic
+                         },
+                         500
         end
-      end)
 
-    logs =
-      capture_log(fn ->
-        pid =
-          start_supervised!(
-            {ReplicationConnection,
-             %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: monitored_pid}},
-            restart: :transient
-          )
+        Process.sleep(500)
+        # Works with batch inserts
+        messages =
+          for _ <- 1..total_messages do
+            Message.changeset(%Message{}, %{
+              "topic" => topic,
+              "private" => true,
+              "event" => "INSERT",
+              "extension" => "broadcast",
+              "payload" => %{"value" => random_string()}
+            })
+          end
 
-        send(monitored_pid, :stop)
+        {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
 
-        ref = Process.monitor(pid)
-        assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 100
-        refute Process.alive?(pid)
-      end)
+        {:ok, _} = Realtime.Repo.insert_all_entries(db_conn, messages, Message)
 
-    assert logs =~ "Disconnecting broadcast changes handler in the step"
-  end
+        for message <- messages do
+          value = message |> Map.from_struct() |> get_in([:changes, :payload, "value"])
 
-  test "message without event logs error", %{tenant: tenant} do
-    logs =
-      capture_log(fn ->
-        start_supervised!(
+          assert_receive %Phoenix.Socket.Broadcast{
+                           event: "broadcast",
+                           payload: %{
+                             "event" => "INSERT",
+                             "payload" => %{"value" => ^value},
+                             "type" => "broadcast"
+                           },
+                           topic: ^tenant_topic
+                         },
+                         500
+        end
+      end
+
+      test "monitored pid stopping brings down ReplicationConnection ", %{tenant: tenant} do
+        monitored_pid =
+          spawn(fn ->
+            receive do
+              :stop -> :ok
+            end
+          end)
+
+        logs =
+          capture_log(fn ->
+            pid =
+              start_supervised!(
+                {ReplicationConnection,
+                 %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: monitored_pid}},
+                restart: :transient
+              )
+
+            send(monitored_pid, :stop)
+
+            ref = Process.monitor(pid)
+            assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 100
+            refute Process.alive?(pid)
+          end)
+
+        assert logs =~ "Disconnecting broadcast changes handler in the step"
+      end
+
+      test "message without event logs error", %{tenant: tenant} do
+        logs =
+          capture_log(fn ->
+            start_supervised!(
+              {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
+              restart: :transient
+            )
+
+            topic = random_string()
+            tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
+            assert :ok = Endpoint.subscribe(tenant_topic)
+
+            message_fixture(tenant, %{
+              "topic" => "some_topic",
+              "private" => true,
+              "payload" => %{"value" => "something"}
+            })
+
+            refute_receive %Phoenix.Socket.Broadcast{}, 500
+          end)
+
+        assert logs =~ "UnableToBatchBroadcastChanges"
+      end
+
+      test "payload without id", %{tenant: tenant} do
+        start_link_supervised!(
           {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
           restart: :transient
         )
@@ -165,104 +196,127 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
         tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
         assert :ok = Endpoint.subscribe(tenant_topic)
 
+        message =
+          message_fixture(tenant, %{
+            "topic" => topic,
+            "private" => true,
+            "event" => "INSERT",
+            "payload" => %{"value" => "something"}
+          })
+
+        assert_receive %Phoenix.Socket.Broadcast{
+                         event: "broadcast",
+                         payload: %{
+                           "event" => "INSERT",
+                           "payload" => payload,
+                           "type" => "broadcast"
+                         },
+                         topic: ^tenant_topic
+                       },
+                       500
+
+        id = message.id
+
+        assert payload == %{
+                 "value" => "something",
+                 "id" => id
+               }
+      end
+
+      test "payload including id", %{tenant: tenant} do
+        start_link_supervised!(
+          {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
+          restart: :transient
+        )
+
+        topic = random_string()
+        tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
+        assert :ok = Endpoint.subscribe(tenant_topic)
+        payload = %{"value" => "something", "id" => "123456"}
+
         message_fixture(tenant, %{
-          "topic" => "some_topic",
+          "topic" => topic,
           "private" => true,
-          "payload" => %{"value" => "something"}
+          "event" => "INSERT",
+          "payload" => payload
         })
 
-        refute_receive %Phoenix.Socket.Broadcast{}, 500
-      end)
+        assert_receive %Phoenix.Socket.Broadcast{
+                         event: "broadcast",
+                         payload: %{
+                           "event" => "INSERT",
+                           "payload" => ^payload,
+                           "type" => "broadcast"
+                         },
+                         topic: ^tenant_topic
+                       },
+                       500
+      end
 
-    assert logs =~ "UnableToBatchBroadcastChanges"
+      test "fails on existing replication slot", %{tenant: tenant} do
+        {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+        name = "supabase_realtime_messages_replication_slot_test"
+
+        Postgrex.query!(db_conn, "SELECT pg_create_logical_replication_slot($1, 'test_decoding')", [name])
+
+        assert {:error, {:shutdown, "Temporary Replication slot already exists and in use"}} =
+                 ReplicationConnection.start(tenant, self())
+
+        Postgrex.query!(db_conn, "SELECT pg_drop_replication_slot($1)", [name])
+      end
+
+      test "times out when init takes too long", %{tenant: tenant} do
+        expect(ReplicationConnection, :init, 1, fn arg ->
+          :timer.sleep(1000)
+          call_original(ReplicationConnection, :init, [arg])
+        end)
+
+        {:error, :timeout} = ReplicationConnection.start(tenant, self(), 100)
+      end
+
+      test "handle standby connections exceeds max_wal_senders", %{tenant: tenant} do
+        opts = Database.from_tenant(tenant, "realtime_test", :stop) |> Database.opts()
+
+        # This creates a loop of errors that occupies all WAL senders and lets us test the error handling
+        pids =
+          for i <- 0..4 do
+            replication_slot_opts =
+              %PostgresReplication{
+                connection_opts: opts,
+                table: :all,
+                output_plugin: "pgoutput",
+                output_plugin_options: [],
+                handler_module: TestHandler,
+                publication_name: "test_#{i}_publication",
+                replication_slot_name: "test_#{i}_slot"
+              }
+
+            {:ok, pid} = PostgresReplication.start_link(replication_slot_opts)
+            pid
+          end
+
+        on_exit(fn ->
+          Enum.each(pids, &Process.exit(&1, :kill))
+          Process.sleep(2000)
+        end)
+
+        assert {:error, :max_wal_senders_reached} = ReplicationConnection.start(tenant, self())
+      end
+    end
   end
 
-  test "payload without id", %{tenant: tenant} do
-    start_link_supervised!(
-      {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
-      restart: :transient
-    )
+  describe "whereis/1" do
+    @tag skip:
+           "We are using a GenServer wrapper so the pid returned is not the same as the ReplicationConnection for now"
+    test "returns pid if exists", %{tenant: tenant} do
+      {:ok, pid} = ReplicationConnection.start(tenant, self())
+      assert ReplicationConnection.whereis(tenant.external_id) == pid
+      Process.exit(pid, :shutdown)
+    end
 
-    topic = random_string()
-    tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
-    assert :ok = Endpoint.subscribe(tenant_topic)
-
-    message =
-      message_fixture(tenant, %{
-        "topic" => topic,
-        "private" => true,
-        "event" => "INSERT",
-        "payload" => %{"value" => "something"}
-      })
-
-    assert_receive %Phoenix.Socket.Broadcast{
-                     event: "broadcast",
-                     payload: %{
-                       "event" => "INSERT",
-                       "payload" => payload,
-                       "type" => "broadcast"
-                     },
-                     topic: ^tenant_topic
-                   },
-                   500
-
-    id = message.id
-
-    assert payload == %{
-             "value" => "something",
-             "id" => id
-           }
-  end
-
-  test "payload including id", %{tenant: tenant} do
-    start_link_supervised!(
-      {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
-      restart: :transient
-    )
-
-    topic = random_string()
-    tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
-    assert :ok = Endpoint.subscribe(tenant_topic)
-    payload = %{"value" => "something", "id" => "123456"}
-
-    message_fixture(tenant, %{
-      "topic" => topic,
-      "private" => true,
-      "event" => "INSERT",
-      "payload" => payload
-    })
-
-    assert_receive %Phoenix.Socket.Broadcast{
-                     event: "broadcast",
-                     payload: %{
-                       "event" => "INSERT",
-                       "payload" => ^payload,
-                       "type" => "broadcast"
-                     },
-                     topic: ^tenant_topic
-                   },
-                   500
-  end
-
-  test "fails on existing replication slot", %{tenant: tenant} do
-    {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
-    name = "supabase_realtime_messages_replication_slot_test"
-
-    Postgrex.query!(db_conn, "SELECT pg_create_logical_replication_slot($1, 'test_decoding')", [name])
-
-    assert {:error, {:shutdown, "Temporary Replication slot already exists and in use"}} =
-             ReplicationConnection.start(tenant, self())
-
-    Postgrex.query!(db_conn, "SELECT pg_drop_replication_slot($1)", [name])
-  end
-
-  test "times out when init takes too long", %{tenant: tenant} do
-    expect(ReplicationConnection, :init, 1, fn arg ->
-      :timer.sleep(31_000)
-      call_original(ReplicationConnection, :init, [arg])
-    end)
-
-    {:error, :timeout} = ReplicationConnection.start(tenant, self())
+    test "returns nil if not exists" do
+      assert ReplicationConnection.whereis(random_string()) == nil
+    end
   end
 
   defmodule TestHandler do
@@ -290,48 +344,5 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
     end
 
     def call(_, _), do: :noreply
-  end
-
-  test "handle standby connections exceeds max_wal_senders", %{tenant: tenant} do
-    opts = Database.from_tenant(tenant, "realtime_test", :stop) |> Database.opts()
-
-    # This creates a loop of errors that occupies all WAL senders and lets us test the error handling
-    pids =
-      for i <- 0..4 do
-        replication_slot_opts =
-          %PostgresReplication{
-            connection_opts: opts,
-            table: :all,
-            output_plugin: "pgoutput",
-            output_plugin_options: [],
-            handler_module: TestHandler,
-            publication_name: "test_#{i}_publication",
-            replication_slot_name: "test_#{i}_slot"
-          }
-
-        {:ok, pid} = PostgresReplication.start_link(replication_slot_opts)
-        pid
-      end
-
-    on_exit(fn ->
-      Enum.each(pids, &Process.exit(&1, :kill))
-      Process.sleep(2000)
-    end)
-
-    assert {:error, :max_wal_senders_reached} = ReplicationConnection.start(tenant, self())
-  end
-
-  describe "whereis/1" do
-    @tag skip:
-           "We are using a GenServer wrapper so the pid returned is not the same as the ReplicationConnection for now"
-    test "returns pid if exists", %{tenant: tenant} do
-      {:ok, pid} = ReplicationConnection.start(tenant, self())
-      assert ReplicationConnection.whereis(tenant.external_id) == pid
-      Process.exit(pid, :shutdown)
-    end
-
-    test "returns nil if not exists" do
-      assert ReplicationConnection.whereis(random_string()) == nil
-    end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Change `BatchBroadcast` to use `TenantBroadcaster` and allow `gen_rpc` to be used for broadcast API and `realtime.messages` broadcast.

Also updated the `init_timeout` for `ReplicationConnection` so we don't need to wait 30 seconds during tests 🐌 

## What is the current behavior?

It's only using for broadcast coming from RealtimeChannel

## What is the new behavior?

Broadcast API and `realtime.messages` broadcast can use `gen_rpc` depending on the `tenant.broadcast_adapter`

## Additional context

Follow-up from https://github.com/supabase/realtime/pull/1425 & https://github.com/supabase/realtime/pull/1419
