### PR TITLE
fix: Reload endpoint updated to also shutdown Connect module

### DIFF
--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -12,6 +12,7 @@ defmodule RealtimeWeb.TenantController do
   alias Realtime.PostgresCdc
   alias Realtime.Tenants
   alias Realtime.Tenants.Cache
+  alias Realtime.Tenants.Connect
   alias Realtime.Tenants.Migrations
   alias RealtimeWeb.OpenApiSchemas.EmptyResponse
   alias RealtimeWeb.OpenApiSchemas.ErrorResponse
@@ -239,6 +240,7 @@ defmodule RealtimeWeb.TenantController do
 
       tenant ->
         PostgresCdc.stop_all(tenant, @stop_timeout)
+        Connect.shutdown(tenant.external_id)
         send_resp(conn, 204, "")
     end
   end

--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -22,6 +22,7 @@ defmodule RealtimeWeb.TenantController do
   alias RealtimeWeb.OpenApiSchemas.TenantResponse
   alias RealtimeWeb.OpenApiSchemas.TenantResponseList
   alias RealtimeWeb.OpenApiSchemas.UnauthorizedResponse
+  alias RealtimeWeb.SocketDisconnect
 
   @stop_timeout 10_000
 
@@ -241,6 +242,7 @@ defmodule RealtimeWeb.TenantController do
       tenant ->
         PostgresCdc.stop_all(tenant, @stop_timeout)
         Connect.shutdown(tenant.external_id)
+        SocketDisconnect.disconnect(tenant.external_id)
         send_resp(conn, 204, "")
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.57.8",
+      version: "2.57.9",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/api_test.exs
+++ b/test/realtime/api_test.exs
@@ -191,7 +191,7 @@ defmodule Realtime.ApiTest do
 
     test "valid data and change to tenant data will refresh cache", %{tenants: [tenant | _]} do
       assert {:ok, %Tenant{}} = Api.update_tenant(tenant, %{name: "new_name"})
-      Process.sleep(100)
+      Process.sleep(500)
       assert %Tenant{name: "new_name"} = Realtime.Tenants.Cache.get_tenant_by_external_id(tenant.external_id)
     end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reload endpoint updated to also shutdown Connect module