### PR TITLE
fix: set idle_shutdown to all RateCounters to be 1 hour

### DIFF
--- a/lib/realtime/rate_counter/rate_counter.ex
+++ b/lib/realtime/rate_counter/rate_counter.ex
@@ -17,7 +17,7 @@ defmodule Realtime.RateCounter do
   alias Realtime.RateCounter
   alias Realtime.Telemetry
 
-  @idle_shutdown :timer.seconds(5)
+  @idle_shutdown :timer.hours(1)
   @tick :timer.seconds(1)
   @max_bucket_len 60
   @cache __MODULE__

--- a/lib/realtime/tenants/connect/backoff.ex
+++ b/lib/realtime/tenants/connect/backoff.ex
@@ -30,7 +30,7 @@ defmodule Realtime.Tenants.Connect.Backoff do
 
       {:error, _} ->
         GenCounter.new(id)
-        RateCounter.new(id, idle_shutdown: :infinity, tick: 100, idle_shutdown_ms: :timer.minutes(5))
+        RateCounter.new(id, idle_shutdown: :timer.minutes(5), tick: 100)
     end
 
     {:ok, id}

--- a/lib/realtime/tenants/connect/start_counters.ex
+++ b/lib/realtime/tenants/connect/start_counters.ex
@@ -27,7 +27,6 @@ defmodule Realtime.Tenants.Connect.StartCounters do
 
     res =
       RateCounter.new(id,
-        idle_shutdown: :infinity,
         telemetry: %{
           event_name: [:channel, :joins],
           measurements: %{limit: max_joins_per_second},
@@ -51,7 +50,6 @@ defmodule Realtime.Tenants.Connect.StartCounters do
 
     res =
       RateCounter.new(key,
-        idle_shutdown: :infinity,
         telemetry: %{
           event_name: [:channel, :events],
           measurements: %{limit: max_events_per_second},
@@ -72,7 +70,6 @@ defmodule Realtime.Tenants.Connect.StartCounters do
 
     res =
       RateCounter.new(key,
-        idle_shutdown: :infinity,
         telemetry: %{
           event_name: [:channel, :db_events],
           measurements: %{},

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -476,7 +476,6 @@ defmodule RealtimeWeb.RealtimeChannel do
     GenCounter.new(id)
 
     RateCounter.new(id,
-      idle_shutdown: :infinity,
       telemetry: %{
         event_name: [:channel, :joins],
         measurements: %{limit: limits.max_joins_per_second},
@@ -524,7 +523,6 @@ defmodule RealtimeWeb.RealtimeChannel do
     GenCounter.new(key)
 
     RateCounter.new(key,
-      idle_shutdown: :infinity,
       telemetry: %{
         event_name: [:channel, :events],
         measurements: %{limit: limits.max_events_per_second},
@@ -545,7 +543,6 @@ defmodule RealtimeWeb.RealtimeChannel do
     GenCounter.new(key)
 
     RateCounter.new(key,
-      idle_shutdown: :infinity,
       telemetry: %{
         event_name: [:channel, :presence_events],
         measurements: %{limit: limits.max_events_per_second},
@@ -679,7 +676,6 @@ defmodule RealtimeWeb.RealtimeChannel do
     GenCounter.new(key)
 
     RateCounter.new(key,
-      idle_shutdown: :infinity,
       telemetry: %{event_name: [:channel, :db_events], measurements: %{}, metadata: %{tenant: tenant}}
     )
 

--- a/lib/realtime_web/plugs/assign_tenant.ex
+++ b/lib/realtime_web/plugs/assign_tenant.ex
@@ -46,7 +46,7 @@ defmodule RealtimeWeb.Plugs.AssignTenant do
   defp initialize_counters(tenant) do
     GenCounter.new(Tenants.requests_per_second_key(tenant))
     GenCounter.new(Tenants.events_per_second_key(tenant))
-    RateCounter.new(Tenants.requests_per_second_key(tenant), idle_shutdown: :infinity)
-    RateCounter.new(Tenants.events_per_second_key(tenant), idle_shutdown: :infinity)
+    RateCounter.new(Tenants.requests_per_second_key(tenant))
+    RateCounter.new(Tenants.events_per_second_key(tenant))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.58.1",
+      version: "2.58.2",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/distributed_metrics_test.exs
+++ b/test/realtime/monitoring/distributed_metrics_test.exs
@@ -30,7 +30,7 @@ defmodule Realtime.DistributedMetricsTest do
                    send_pend: _
                  ]
                }
-             } = DistributedMetrics.info() |> dbg()
+             } = DistributedMetrics.info()
     end
   end
 end

--- a/test/realtime/rate_counter/rate_counter_test.exs
+++ b/test/realtime/rate_counter/rate_counter_test.exs
@@ -1,5 +1,7 @@
 defmodule Realtime.RateCounterTest do
-  use Realtime.DataCase
+  use Realtime.DataCase, async: true
+
+  import ExUnit.CaptureLog
 
   alias Realtime.RateCounter
   alias Realtime.GenCounter
@@ -18,9 +20,15 @@ defmodule Realtime.RateCounterTest do
 
     test "rate counters shut themselves down when no activity occurs on the GenCounter" do
       term = {:domain, :metric, Ecto.UUID.generate()}
-      {:ok, _} = RateCounter.new(term, idle_shutdown: 5)
-      Process.sleep(25)
-      assert {:error, _term} = RateCounter.get(term)
+
+      log =
+        capture_log(fn ->
+          {:ok, _} = RateCounter.new(term, idle_shutdown: 5)
+          Process.sleep(25)
+          assert {:error, _term} = RateCounter.get(term)
+        end)
+
+      assert log =~ "idle_shutdown reached for: #{inspect(term)}"
     end
 
     test "rate counters reset GenCounter to zero after one tick and average the bucket" do
@@ -34,7 +42,7 @@ defmodule Realtime.RateCounterTest do
                 avg: 0.5,
                 bucket: [0, 1],
                 id: _id,
-                idle_shutdown: 5000,
+                idle_shutdown: 3_600_000,
                 idle_shutdown_ref: _ref,
                 max_bucket_len: 60,
                 tick: 5,


### PR DESCRIPTION
## What kind of change does this PR introduce?

We were leaving them there forever

## What is the current behavior?

RateCounters and respective GenCounters are left as active processes forever never shutting them down regardless of activity

## What is the new behavior?

Shut them down after 1 hour without any increments.

## Additional context

Add any other context or screenshots.
