### PR TITLE
fix: flaky tests

### DIFF
--- a/lib/realtime/rate_counter/rate_counter.ex
+++ b/lib/realtime/rate_counter/rate_counter.ex
@@ -75,6 +75,7 @@ defmodule Realtime.RateCounter do
 
     Enum.each(keys, fn {{_, _, key}, {pid, _}} ->
       if Process.alive?(pid), do: GenServer.stop(pid)
+      GenCounter.stop(key)
       Cachex.del!(@cache, key)
     end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.58.1",
+      version: "2.58.3",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -113,8 +113,8 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
         assert conn.status == 422
 
-        # Wait for counters to increment
-        Process.sleep(1000)
+        # Wait for counters to increment. RateCounter tick is 1 second
+        Process.sleep(2000)
         {:ok, rate_counter} = RateCounter.get(Tenants.requests_per_second_key(tenant))
         assert rate_counter.avg != 0.0
 

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -1,7 +1,6 @@
 defmodule Containers do
   alias Containers.Container
   alias Realtime.Database
-  alias Realtime.GenCounter
   alias Realtime.RateCounter
   alias Realtime.Tenants.Migrations
 
@@ -131,7 +130,6 @@ defmodule Containers do
         )
 
         RateCounter.stop(tenant.external_id)
-        GenCounter.stop(tenant.external_id)
 
         Postgrex.query!(db_conn, "DROP SCHEMA realtime CASCADE", [])
         Postgrex.query!(db_conn, "CREATE SCHEMA realtime", [])


### PR DESCRIPTION
Fix a couple of flaky tests

I had to change `RateCounter.stop/1` so I had to bump up the version BUT this is only used on tests so not an actual change that impacts real traffic.