### PR TITLE
feat: add gen_rpc metrics

### DIFF
--- a/lib/realtime/monitoring/gen_rpc_metrics.ex
+++ b/lib/realtime/monitoring/gen_rpc_metrics.ex
@@ -1,0 +1,81 @@
+defmodule Realtime.GenRpcMetrics do
+  @moduledoc """
+  Gather stats for gen_rpc TCP sockets
+  """
+
+  require Record
+  Record.defrecordp(:net_address, Record.extract(:net_address, from_lib: "kernel/include/net_address.hrl"))
+
+  @spec info() :: %{node() => %{inet_stats: %{:inet.stat_option() => integer}, queue_size: non_neg_integer()}}
+  def info do
+    if :net_kernel.get_state()[:started] != :no do
+      {:ok, nodes_info} = :net_kernel.nodes_info()
+      # All TCP client sockets are managed by this supervisor
+      # For each node gen_rpc might have multiple TCP sockets
+      # We collect them based on the address + TCP port combination (peername)
+      port_addresses =
+        Supervisor.which_children(:gen_rpc_client_sup)
+        |> Stream.map(fn {_, pid, _, _} ->
+          # We then grab the only linked port
+          pid
+          |> Process.info(:links)
+          |> elem(1)
+          |> Enum.filter(&is_port/1)
+          |> hd()
+        end)
+        |> Stream.map(&{:inet.peername(&1), &1})
+        |> Stream.filter(fn
+          {{:ok, _peername}, _port} -> true
+          _ -> false
+        end)
+        |> Stream.map(fn {{:ok, address}, port} -> {address, port} end)
+        |> Enum.reduce(%{}, fn {address, port}, acc ->
+          update_in(acc, [address], fn value -> [port | value || []] end)
+        end)
+
+      Map.new(nodes_info, &info(&1, port_addresses))
+    else
+      %{}
+    end
+  end
+
+  defp info({node, info}, port_addresses) do
+    {:tcp, tcp_port} = :gen_rpc_helper.get_client_config_per_node(node)
+
+    case info[:address] do
+      net_address(address: address) when address != :undefined ->
+        {node, info(port_addresses, address, tcp_port)}
+
+      _ ->
+        {node, %{}}
+    end
+  end
+
+  defp info(port_addresses, {address, _}, tcp_port) do
+    if gen_rpc_ports = port_addresses[{address, tcp_port}] do
+      %{
+        inet_stats: inet_stats(gen_rpc_ports),
+        queue_size: queue_size(gen_rpc_ports),
+        connections: length(gen_rpc_ports)
+      }
+    else
+      %{}
+    end
+  end
+
+  defp inet_stats(ports) do
+    Enum.reduce(ports, %{}, fn port, acc ->
+      case :inet.getstat(port) do
+        {:ok, stats} -> Map.merge(acc, Map.new(stats), fn _k, v1, v2 -> v1 + v2 end)
+        _ -> acc
+      end
+    end)
+  end
+
+  defp queue_size(ports) do
+    Enum.reduce(ports, 0, fn port, acc ->
+      {:queue_size, queue_size} = :erlang.port_info(port, :queue_size)
+      acc + queue_size
+    end)
+  end
+end

--- a/lib/realtime/monitoring/prom_ex.ex
+++ b/lib/realtime/monitoring/prom_ex.ex
@@ -2,6 +2,7 @@ defmodule Realtime.PromEx do
   alias Realtime.Nodes
   alias Realtime.PromEx.Plugins.Channels
   alias Realtime.PromEx.Plugins.Distributed
+  alias Realtime.PromEx.Plugins.GenRpc
   alias Realtime.PromEx.Plugins.OsMon
   alias Realtime.PromEx.Plugins.Phoenix
   alias Realtime.PromEx.Plugins.Tenant
@@ -75,7 +76,8 @@ defmodule Realtime.PromEx do
       {Tenants, poll_rate: poll_rate},
       {Tenant, poll_rate: poll_rate},
       {Channels, poll_rate: poll_rate},
-      {Distributed, poll_rate: poll_rate}
+      {Distributed, poll_rate: poll_rate},
+      {GenRpc, poll_rate: poll_rate}
     ]
   end
 

--- a/lib/realtime/monitoring/prom_ex/plugins/gen_rpc.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/gen_rpc.ex
@@ -1,0 +1,105 @@
+defmodule Realtime.PromEx.Plugins.GenRpc do
+  @moduledoc """
+  GenRpc metrics
+  """
+
+  use PromEx.Plugin
+
+  alias Realtime.GenRpcMetrics
+
+  @event_queue_size_bytes [:prom_ex, :plugin, :gen_rpc, :queue_size, :bytes]
+  @event_recv_bytes [:prom_ex, :plugin, :gen_rpc, :recv, :bytes]
+  @event_recv_count [:prom_ex, :plugin, :gen_rpc, :recv, :count]
+  @event_send_bytes [:prom_ex, :plugin, :gen_rpc, :send, :bytes]
+  @event_send_count [:prom_ex, :plugin, :gen_rpc, :send, :count]
+  @event_send_pending_bytes [:prom_ex, :plugin, :gen_rpc, :send, :pending, :bytes]
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate)
+
+    [
+      metrics(poll_rate)
+    ]
+  end
+
+  defp metrics(poll_rate) do
+    Polling.build(
+      :realtime_gen_rpc,
+      poll_rate,
+      {__MODULE__, :execute_metrics, []},
+      [
+        last_value(
+          [:gen_rpc, :queue_size_bytes],
+          event_name: @event_queue_size_bytes,
+          description: "The total number of bytes queued by the port using the ERTS driver queue implementation",
+          measurement: :size,
+          tags: [:origin_node, :target_node]
+        ),
+        last_value(
+          [:gen_rpc, :recv_bytes],
+          event_name: @event_recv_bytes,
+          description: "Number of bytes received by the socket.",
+          measurement: :size,
+          tags: [:origin_node, :target_node]
+        ),
+        last_value(
+          [:gen_rpc, :recv_count],
+          event_name: @event_recv_count,
+          description: "Number of packets received by the socket.",
+          measurement: :size,
+          tags: [:origin_node, :target_node]
+        ),
+        last_value(
+          [:gen_rpc, :send_bytes],
+          event_name: @event_send_bytes,
+          description: "Number of bytes sent by the socket.",
+          measurement: :size,
+          tags: [:origin_node, :target_node]
+        ),
+        last_value(
+          [:gen_rpc, :send_count],
+          event_name: @event_send_count,
+          description: "Number of packets sent by the socket.",
+          measurement: :size,
+          tags: [:origin_node, :target_node]
+        ),
+        last_value(
+          [:gen_rpc, :send_pending_bytes],
+          event_name: @event_send_pending_bytes,
+          description: "Number of bytes waiting to be sent by the socket.",
+          measurement: :size,
+          tags: [:origin_node, :target_node]
+        )
+      ]
+    )
+  end
+
+  def execute_metrics do
+    dist_info = GenRpcMetrics.info()
+
+    Enum.each(dist_info, fn {node, info} ->
+      execute_queue_size(node, info)
+      execute_inet_stats(node, info)
+    end)
+  end
+
+  defp execute_inet_stats(node, info) do
+    if stats = info[:inet_stats] do
+      :telemetry.execute(@event_recv_bytes, %{size: stats[:recv_oct]}, %{origin_node: node(), target_node: node})
+      :telemetry.execute(@event_recv_count, %{size: stats[:recv_cnt]}, %{origin_node: node(), target_node: node})
+
+      :telemetry.execute(@event_send_bytes, %{size: stats[:send_oct]}, %{origin_node: node(), target_node: node})
+      :telemetry.execute(@event_send_count, %{size: stats[:send_cnt]}, %{origin_node: node(), target_node: node})
+
+      :telemetry.execute(@event_send_pending_bytes, %{size: stats[:send_pend]}, %{
+        origin_node: node(),
+        target_node: node
+      })
+    end
+  end
+
+  defp execute_queue_size(node, info) do
+    :telemetry.execute(@event_queue_size_bytes, %{size: info[:queue_size]}, %{origin_node: node(), target_node: node})
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.39.6",
+      version: "2.40.0",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/gen_rpc_metrics_test.exs
+++ b/test/realtime/monitoring/gen_rpc_metrics_test.exs
@@ -1,0 +1,38 @@
+defmodule Realtime.GenRpcMetricsTest do
+  # Async false due to Clustered usage
+  use ExUnit.Case, async: false
+
+  alias Realtime.GenRpcMetrics
+
+  setup_all do
+    {:ok, node} = Clustered.start()
+    %{node: node}
+  end
+
+  describe "info/0 while connected" do
+    test "per node metric", %{node: node} do
+      # We need to generate some load on gen_rpc first
+      Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 1)
+      Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 2)
+
+      assert %{
+               ^node => %{
+                 connections: _,
+                 queue_size: _,
+                 inet_stats: %{
+                   recv_oct: _,
+                   recv_cnt: _,
+                   recv_max: _,
+                   recv_avg: _,
+                   recv_dvi: _,
+                   send_oct: _,
+                   send_cnt: _,
+                   send_max: _,
+                   send_avg: _,
+                   send_pend: _
+                 }
+               }
+             } = GenRpcMetrics.info()
+    end
+  end
+end

--- a/test/realtime/monitoring/prom_ex/plugins/gen_rpc_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/gen_rpc_test.exs
@@ -1,0 +1,77 @@
+defmodule Realtime.PromEx.Plugins.GenRpcTest do
+  # Async false due to Clustered usage
+  use ExUnit.Case, async: false
+  alias Realtime.PromEx.Plugins
+
+  defmodule MetricsTest do
+    use PromEx, otp_app: :metrics_test
+    @impl true
+    def plugins do
+      [{Plugins.GenRpc, poll_rate: 100}]
+    end
+  end
+
+  setup_all do
+    {:ok, node} = Clustered.start()
+    start_supervised!(MetricsTest)
+    # Send some data back and forth
+    25 = :gen_rpc.call(node, String, :to_integer, ["25"])
+    # Wait for MetricsTest to fetch metrics
+    Process.sleep(200)
+    %{node: node}
+  end
+
+  describe "pooling metrics" do
+    setup do
+      metrics =
+        PromEx.get_metrics(MetricsTest)
+        |> String.split("\n", trim: true)
+
+      %{metrics: metrics}
+    end
+
+    test "send_pending_bytes", %{metrics: metrics, node: node} do
+      pattern = ~r/gen_rpc_send_pending_bytes{origin_node=\"#{node()}\",target_node=\"#{node}\"}\s(?<number>\d+)/
+      assert metric_value(metrics, pattern) == 0
+    end
+
+    test "send_count", %{metrics: metrics, node: node} do
+      pattern = ~r/gen_rpc_send_count{origin_node=\"#{node()}\",target_node=\"#{node}\"}\s(?<number>\d+)/
+      assert metric_value(metrics, pattern) > 0
+    end
+
+    test "send_bytes", %{metrics: metrics, node: node} do
+      pattern = ~r/gen_rpc_send_bytes{origin_node=\"#{node()}\",target_node=\"#{node}\"}\s(?<number>\d+)/
+      assert metric_value(metrics, pattern) > 0
+    end
+
+    test "recv_count", %{metrics: metrics, node: node} do
+      pattern = ~r/gen_rpc_recv_count{origin_node=\"#{node()}\",target_node=\"#{node}\"}\s(?<number>\d+)/
+      assert metric_value(metrics, pattern) > 0
+    end
+
+    test "recv_bytes", %{metrics: metrics, node: node} do
+      pattern = ~r/gen_rpc_recv_bytes{origin_node=\"#{node()}\",target_node=\"#{node}\"}\s(?<number>\d+)/
+      assert metric_value(metrics, pattern) > 0
+    end
+
+    test "queue_size", %{metrics: metrics, node: node} do
+      pattern = ~r/gen_rpc_queue_size_bytes{origin_node=\"#{node()}\",target_node=\"#{node}\"}\s(?<number>\d+)/
+      assert metric_value(metrics, pattern) == 0
+    end
+  end
+
+  defp metric_value(metrics, pattern) do
+    metrics
+    |> Enum.find_value(
+      "0",
+      fn item ->
+        case Regex.run(pattern, item, capture: ["number"]) do
+          [number] -> number
+          _ -> false
+        end
+      end
+    )
+    |> String.to_integer()
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Collect metrics on `gen_rpc` TCP connections so that we have a similar set of metrics that erl dist has at the moment.

It uses the `gen_rpc` client supervisor to grab all the erlang ports that are established.

## What is the current behavior?

No `gen_rpc` TCP metrics

## What is the new behavior?

`gen_rpc` TCP metrics will be published

## Additional context

Add any other context or screenshots.
