### PR TITLE
Revert "fix: set idle_shutdown to all RateCounters to be 1 hour (#1443)"

### DIFF
--- a/lib/realtime/rate_counter/rate_counter.ex
+++ b/lib/realtime/rate_counter/rate_counter.ex
@@ -17,7 +17,7 @@ defmodule Realtime.RateCounter do
   alias Realtime.RateCounter
   alias Realtime.Telemetry
 
-  @idle_shutdown :timer.hours(1)
+  @idle_shutdown :timer.seconds(5)
   @tick :timer.seconds(1)
   @max_bucket_len 60
   @cache __MODULE__

--- a/lib/realtime/tenants/connect/start_counters.ex
+++ b/lib/realtime/tenants/connect/start_counters.ex
@@ -27,6 +27,7 @@ defmodule Realtime.Tenants.Connect.StartCounters do
 
     res =
       RateCounter.new(id,
+        idle_shutdown: :infinity,
         telemetry: %{
           event_name: [:channel, :joins],
           measurements: %{limit: max_joins_per_second},
@@ -50,6 +51,7 @@ defmodule Realtime.Tenants.Connect.StartCounters do
 
     res =
       RateCounter.new(key,
+        idle_shutdown: :infinity,
         telemetry: %{
           event_name: [:channel, :events],
           measurements: %{limit: max_events_per_second},
@@ -70,6 +72,7 @@ defmodule Realtime.Tenants.Connect.StartCounters do
 
     res =
       RateCounter.new(key,
+        idle_shutdown: :infinity,
         telemetry: %{
           event_name: [:channel, :db_events],
           measurements: %{},

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -483,6 +483,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     GenCounter.new(id)
 
     RateCounter.new(id,
+      idle_shutdown: :infinity,
       telemetry: %{
         event_name: [:channel, :joins],
         measurements: %{limit: limits.max_joins_per_second},
@@ -530,6 +531,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     GenCounter.new(key)
 
     RateCounter.new(key,
+      idle_shutdown: :infinity,
       telemetry: %{
         event_name: [:channel, :events],
         measurements: %{limit: limits.max_events_per_second},
@@ -550,6 +552,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     GenCounter.new(key)
 
     RateCounter.new(key,
+      idle_shutdown: :infinity,
       telemetry: %{
         event_name: [:channel, :presence_events],
         measurements: %{limit: limits.max_events_per_second},
@@ -683,6 +686,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     GenCounter.new(key)
 
     RateCounter.new(key,
+      idle_shutdown: :infinity,
       telemetry: %{event_name: [:channel, :db_events], measurements: %{}, metadata: %{tenant: tenant}}
     )
 

--- a/lib/realtime_web/plugs/assign_tenant.ex
+++ b/lib/realtime_web/plugs/assign_tenant.ex
@@ -46,7 +46,7 @@ defmodule RealtimeWeb.Plugs.AssignTenant do
   defp initialize_counters(tenant) do
     GenCounter.new(Tenants.requests_per_second_key(tenant))
     GenCounter.new(Tenants.events_per_second_key(tenant))
-    RateCounter.new(Tenants.requests_per_second_key(tenant))
-    RateCounter.new(Tenants.events_per_second_key(tenant))
+    RateCounter.new(Tenants.requests_per_second_key(tenant), idle_shutdown: :infinity)
+    RateCounter.new(Tenants.events_per_second_key(tenant), idle_shutdown: :infinity)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.40.0",
+      version: "2.40.1",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/rate_counter/rate_counter_test.exs
+++ b/test/realtime/rate_counter/rate_counter_test.exs
@@ -1,7 +1,5 @@
 defmodule Realtime.RateCounterTest do
-  use Realtime.DataCase, async: true
-
-  import ExUnit.CaptureLog
+  use Realtime.DataCase
 
   alias Realtime.RateCounter
   alias Realtime.GenCounter
@@ -20,15 +18,9 @@ defmodule Realtime.RateCounterTest do
 
     test "rate counters shut themselves down when no activity occurs on the GenCounter" do
       term = {:domain, :metric, Ecto.UUID.generate()}
-
-      log =
-        capture_log(fn ->
-          {:ok, _} = RateCounter.new(term, idle_shutdown: 5)
-          Process.sleep(25)
-          assert {:error, _term} = RateCounter.get(term)
-        end)
-
-      assert log =~ "idle_shutdown reached for: #{inspect(term)}"
+      {:ok, _} = RateCounter.new(term, idle_shutdown: 5)
+      Process.sleep(25)
+      assert {:error, _term} = RateCounter.get(term)
     end
 
     test "rate counters reset GenCounter to zero after one tick and average the bucket" do
@@ -42,7 +34,7 @@ defmodule Realtime.RateCounterTest do
                 avg: 0.5,
                 bucket: [0, 1],
                 id: _id,
-                idle_shutdown: 3_600_000,
+                idle_shutdown: 5000,
                 idle_shutdown_ref: _ref,
                 max_bucket_len: 60,
                 tick: 5,


### PR DESCRIPTION
This reverts commit 8951cd0d02b55aae6dcfe22c63bd113c9d921eb0.

## What kind of change does this PR introduce?

Revert  #1443 while we understand a bit better the implications


## Additional context

Add any other context or screenshots.
