### PR TITLE
fix: RealtimeChannel.Logging when a non binary message is logged

### DIFF
--- a/lib/realtime_web/channels/realtime_channel/logging.ex
+++ b/lib/realtime_web/channels/realtime_channel/logging.ex
@@ -19,6 +19,8 @@ defmodule RealtimeWeb.RealtimeChannel.Logging do
   def maybe_log(%{assigns: %{log_level: log_level}}, level, code, msg, metadata \\ []) do
     metadata = if metadata == [], do: Logger.metadata()
 
+    msg = stringify!(msg)
+
     if Logger.compare_levels(log_level, level) != :gt do
       Logger.log(level, "#{code}: #{msg}", metadata)
     end
@@ -86,17 +88,20 @@ defmodule RealtimeWeb.RealtimeChannel.Logging do
         msg
       ) do
     if Logger.compare_levels(log_level, :info) == :eq do
-      msg =
-        case msg do
-          msg when is_binary(msg) -> msg
-          _ -> inspect(msg, pretty: true)
-        end
+      msg = stringify!(msg)
 
       msg = "Received message on " <> channel_name <> " with payload: " <> msg
       Logger.log(log_level, msg)
     end
 
     socket
+  end
+
+  defp stringify!(msg) do
+    case msg do
+      msg when is_binary(msg) -> msg
+      _ -> inspect(msg, pretty: true)
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.40.1",
+      version: "2.40.2",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/channels/realtime_channel/logging_test.exs
+++ b/test/realtime_web/channels/realtime_channel/logging_test.exs
@@ -85,6 +85,18 @@ defmodule RealtimeWeb.RealtimeChannel.LoggingTest do
              end) =~ "TestError: test error"
     end
 
+    test "logs messages when not binary message" do
+      socket = %{assigns: %{log_level: :info}}
+
+      assert capture_log(fn ->
+               Logging.maybe_log(socket, :info, "TestCode", {:error, "Error message"})
+             end) =~ "TestCode: {:error, \"Error message\"}"
+
+      assert capture_log(fn ->
+               Logging.maybe_log(socket, :error, "TestError", "test error")
+             end) =~ "TestError: test error"
+    end
+
     test "does not log messages when log level is higher than the configured level" do
       socket = %{assigns: %{log_level: :error}}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

We might receive non-binary/string messages when logging errors. Let's inspect if not a binary

## What is the current behavior?

Fail to log 

```
UnableToSubscribeToPostgres: %Protocol.UndefinedError{
  protocol: String.Chars,
  value: {:error,...
```
## What is the new behavior?

Call `inspect/1` if not a string

## Additional context

Related to https://github.com/supabase/realtime/pull/1445
