### PR TITLE
fix: Add metadata to logs by default

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.40.5",
+      version: "2.40.6",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -130,18 +130,14 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
       log =
         capture_log(fn ->
-          for _ <- 1..100, reduce: socket do
-            socket ->
-              assert {:reply, :error, socket} =
-                       PresenceHandler.handle(
-                         %{"event" => "track", "payload" => %{"metadata" => random_string()}},
-                         db_conn,
-                         socket
-                       )
+          assert {:reply, :error, _} =
+                   PresenceHandler.handle(
+                     %{"event" => "track", "payload" => %{"metadata" => random_string()}},
+                     db_conn,
+                     socket
+                   )
 
-              refute_receive %Broadcast{topic: ^topic, event: "presence_diff"}
-              socket
-          end
+          refute_receive %Broadcast{topic: ^topic, event: "presence_diff"}
         end)
 
       assert log =~ "RlsPolicyError"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add metadata to logs by default
