### PR TITLE
fix: suspend/unsuspend kills sockets and database connection

### DIFF
--- a/lib/realtime/api.ex
+++ b/lib/realtime/api.ex
@@ -20,13 +20,15 @@ defmodule Realtime.Api do
            when changeset.valid? == true and
                   (is_map_key(changeset.changes, :jwt_secret) or
                      is_map_key(changeset.changes, :jwt_jwks) or
-                     is_map_key(changeset.changes, :private_only))
+                     is_map_key(changeset.changes, :private_only) or
+                     is_map_key(changeset.changes, :suspend))
 
   defguard requires_restarting_db_connection(changeset)
            when changeset.valid? == true and
                   (is_map_key(changeset.changes, :extensions) or
                      is_map_key(changeset.changes, :jwt_secret) or
-                     is_map_key(changeset.changes, :jwt_jwks))
+                     is_map_key(changeset.changes, :jwt_jwks) or
+                     is_map_key(changeset.changes, :suspend))
 
   @doc """
   Returns the list of tenants.
@@ -155,9 +157,7 @@ defmodule Realtime.Api do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_tenant(%Tenant{} = tenant) do
-    Repo.delete(tenant)
-  end
+  def delete_tenant(%Tenant{} = tenant), do: Repo.delete(tenant)
 
   @spec delete_tenant_by_external_id(String.t()) :: boolean()
   def delete_tenant_by_external_id(id) do
@@ -170,19 +170,6 @@ defmodule Realtime.Api do
       _ ->
         false
     end
-  end
-
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking tenant changes.
-
-  ## Examples
-
-      iex> change_tenant(tenant)
-      %Ecto.Changeset{data: %Tenant{}}
-
-  """
-  def change_tenant(%Tenant{} = tenant, attrs \\ %{}) do
-    Tenant.changeset(tenant, attrs)
   end
 
   @spec get_tenant_by_external_id(String.t(), atom()) :: Tenant.t() | nil
@@ -218,9 +205,7 @@ defmodule Realtime.Api do
     end
   end
 
-  def preload_counters(nil) do
-    nil
-  end
+  def preload_counters(nil), do: nil
 
   def preload_counters(%Tenant{} = tenant) do
     id = Tenants.requests_per_second_key(tenant)
@@ -228,9 +213,7 @@ defmodule Realtime.Api do
     preload_counters(tenant, id)
   end
 
-  def preload_counters(nil, _key) do
-    nil
-  end
+  def preload_counters(nil, _key), do: nil
 
   def preload_counters(%Tenant{} = tenant, counters_key) do
     {:ok, current} = GenCounter.get(counters_key)

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -5,6 +5,7 @@ defmodule Realtime.Tenants do
 
   require Logger
 
+  alias Realtime.Api
   alias Realtime.Api.Tenant
   alias Realtime.Database
   alias Realtime.Repo
@@ -295,10 +296,8 @@ defmodule Realtime.Tenants do
   def suspend_tenant_by_external_id(external_id) do
     external_id
     |> Cache.get_tenant_by_external_id()
-    |> Tenant.changeset(%{suspend: true})
-    |> Repo.update!()
+    |> Api.update_tenant(%{suspend: true})
     |> tap(fn _ -> broadcast_operation_event(:suspend_tenant, external_id) end)
-    |> tap(fn _ -> Cache.distributed_invalidate_tenant_cache(external_id) end)
   end
 
   @doc """
@@ -308,10 +307,8 @@ defmodule Realtime.Tenants do
   def unsuspend_tenant_by_external_id(external_id) do
     external_id
     |> Cache.get_tenant_by_external_id()
-    |> Tenant.changeset(%{suspend: false})
-    |> Repo.update!()
+    |> Api.update_tenant(%{suspend: false})
     |> tap(fn _ -> broadcast_operation_event(:unsuspend_tenant, external_id) end)
-    |> tap(fn _ -> Cache.distributed_invalidate_tenant_cache(external_id) end)
   end
 
   @doc """

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -322,11 +322,6 @@ defmodule Realtime.Tenants.Connect do
     {:stop, :shutdown, state}
   end
 
-  def handle_info(:suspend_tenant, state) do
-    Logger.warning("Tenant was suspended, database connection will be terminated")
-    {:stop, :shutdown, state}
-  end
-
   def handle_info(:shutdown_connect, state) do
     Logger.warning("Shutdowning tenant connection")
     {:stop, :shutdown, state}

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -335,13 +335,7 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   def handle_info(:sync_presence, %{assigns: %{presence_enabled?: true}} = socket), do: PresenceHandler.sync(socket)
   def handle_info(:sync_presence, socket), do: {:noreply, socket}
-
-  def handle_info(:unsuspend_tenant, socket), do: {:noreply, socket}
-
-  def handle_info(msg, socket) do
-    log_error("UnhandledSystemMessage", msg)
-    {:noreply, socket}
-  end
+  def handle_info(_message, socket), do: {:noreply, socket}
 
   @impl true
   def handle_in("broadcast", payload, %{assigns: %{private?: true}} = socket) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.40.6",
+      version: "2.40.7",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -204,7 +204,7 @@ defmodule Realtime.Tenants.ConnectTest do
       Realtime.Tenants.suspend_tenant_by_external_id(tenant.external_id)
       assert_process_down(db_conn)
       # Wait for syn to unregister and Cachex to be invalided
-      Process.sleep(100)
+      Process.sleep(500)
 
       assert {:error, :tenant_suspended} = Connect.lookup_or_start_connection(tenant.external_id)
       refute Process.alive?(db_conn)

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -19,24 +19,16 @@ defmodule Realtime.TenantsTest do
 
       limits = Tenants.get_tenant_limits(tenant, keys)
 
-      [all] =
-        Enum.filter(limits, fn e -> e.limiter == Tenants.requests_per_second_key(tenant) end)
-
+      [all] = Enum.filter(limits, fn e -> e.limiter == Tenants.requests_per_second_key(tenant) end)
       assert all.counter == 9
 
-      [user_channels] =
-        Enum.filter(limits, fn e -> e.limiter == Tenants.channels_per_client_key(tenant) end)
-
+      [user_channels] = Enum.filter(limits, fn e -> e.limiter == Tenants.channels_per_client_key(tenant) end)
       assert user_channels.counter == 9
 
-      [channel_joins] =
-        Enum.filter(limits, fn e -> e.limiter == Tenants.joins_per_second_key(tenant) end)
-
+      [channel_joins] = Enum.filter(limits, fn e -> e.limiter == Tenants.joins_per_second_key(tenant) end)
       assert channel_joins.counter == 9
 
-      [tenant_events] =
-        Enum.filter(limits, fn e -> e.limiter == Tenants.events_per_second_key(tenant) end)
-
+      [tenant_events] = Enum.filter(limits, fn e -> e.limiter == Tenants.events_per_second_key(tenant) end)
       assert tenant_events.counter == 9
     end
   end
@@ -44,13 +36,12 @@ defmodule Realtime.TenantsTest do
   describe "suspend_tenant_by_external_id/1" do
     setup do
       tenant = tenant_fixture()
-      topic = "realtime:operations:" <> tenant.external_id
-      Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
-      %{topic: topic, tenant: tenant}
+      :ok = Phoenix.PubSub.subscribe(Realtime.PubSub, "realtime:operations:" <> tenant.external_id)
+      %{tenant: tenant}
     end
 
     test "sets suspend flag to true and publishes message", %{tenant: %{external_id: external_id}} do
-      tenant = Tenants.suspend_tenant_by_external_id(external_id)
+      {:ok, tenant} = Tenants.suspend_tenant_by_external_id(external_id)
       assert tenant.suspend == true
       assert_receive :suspend_tenant, 500
     end
@@ -66,13 +57,12 @@ defmodule Realtime.TenantsTest do
   describe "unsuspend_tenant_by_external_id/1" do
     setup do
       tenant = tenant_fixture(%{suspend: true})
-      topic = "realtime:operations:" <> tenant.external_id
-      Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
-      %{topic: topic, tenant: tenant}
+      :ok = Phoenix.PubSub.subscribe(Realtime.PubSub, "realtime:operations:" <> tenant.external_id)
+      %{tenant: tenant}
     end
 
     test "sets suspend flag to false and publishes message", %{tenant: tenant} do
-      tenant = Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
+      {:ok, tenant} = Tenants.unsuspend_tenant_by_external_id(tenant.external_id)
       assert tenant.suspend == false
       assert_receive :unsuspend_tenant, 500
     end
@@ -112,8 +102,7 @@ defmodule Realtime.TenantsTest do
   describe "broadcast_operation_event/2" do
     setup do
       tenant = tenant_fixture()
-      topic = "realtime:operations:" <> tenant.external_id
-      Phoenix.PubSub.subscribe(Realtime.PubSub, topic)
+      :ok = Phoenix.PubSub.subscribe(Realtime.PubSub, "realtime:operations:" <> tenant.external_id)
       %{tenant: tenant}
     end
 

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -246,11 +246,13 @@ defmodule Generators do
     """
   end
 
+  @spec generate_jwt_token(Tenant.t() | binary()) :: Joken.sign_result()
   def generate_jwt_token(secret_or_tenant) do
     claims = %{role: "authenticated", exp: System.system_time(:second) + 100_000}
     generate_jwt_token(secret_or_tenant, claims)
   end
 
+  @spec generate_jwt_token(Tenant.t() | binary(), map()) :: Joken.sign_result()
   def generate_jwt_token(%Tenant{} = tenant, claims) do
     secret = Crypto.decrypt!(tenant.jwt_secret)
     generate_jwt_token(secret, claims)
@@ -262,6 +264,4 @@ defmodule Generators do
     {:ok, jwt, _} = Joken.encode_and_sign(claims, signer)
     jwt
   end
-
-  def generate_jwt_token(nil, _), do: raise("Missing JWT secret")
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

suspend/unsuspend kills sockets and database connection
