### PR TITLE
fix: region rebalancing for Postgres Changes

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.0",
+      version: "2.41.1",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Follow-up from https://github.com/supabase/realtime/pull/1455  to also rebalance our Postgres Changes pool of processes to the correct region

## What is the current behavior?

If the Postgres Changes pool of processes start in the wrong region they might have a much higher latency that can impact performance. 

## What is the new behavior?

Every X time it will check if it's running at the correct region. If it's not then it stops. The next time it runs it will start at the right place.

## Additional context

Add any other context or screenshots.
