### PR TITLE
fix: HS256 JWK signature verification

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.2",
+      version: "2.41.3",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -266,15 +266,10 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
         log =
           capture_log(fn ->
-            for _ <- 1..100, reduce: socket do
-              socket ->
-                {:noreply, socket} = BroadcastHandler.handle(%{}, db_conn, socket)
-                socket
-            end
+            {:noreply, _socket} = BroadcastHandler.handle(%{}, db_conn, socket)
 
-            Process.sleep(1200)
-
-            refute_received _
+            # Enough for the RateCounter to calculate the last bucket
+            refute_received _, 1200
           end)
 
         assert log =~ "RlsPolicyError"


### PR DESCRIPTION
## What kind of change does this PR introduce?

`Joken.Signer.create` does not expect a map for `HS256`

## What is the current behavior?

Failing with

```
(Joken.Error) Couldn't recognize the signer algorithm. Possible values are: ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "Ed25519", "Ed25519ph", "Ed448", "Ed448ph"]
```

## What is the new behavior?

Not failing

## Additional context

Add any other context or screenshots.
