### PR TITLE
fix: provide socket_options to Postgres libcluster strategy

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -278,6 +278,7 @@ cluster_topologies =
               parameters: [
                 application_name: "cluster_node_#{node()}"
               ],
+              socket_options: socket_options,
               heartbeat_interval: 5_000,
               node_timeout: 15_000,
               channel_name: System.get_env("POSTGRES_CLUSTER_CHANNEL_NAME", "realtime_cluster_#{version}")

--- a/lib/realtime/cluster_strategy/postgres.ex
+++ b/lib/realtime/cluster_strategy/postgres.ex
@@ -29,6 +29,7 @@ defmodule Realtime.Cluster.Strategy.Postgres do
       database: Keyword.fetch!(state.config, :database),
       port: Keyword.fetch!(state.config, :port),
       parameters: Keyword.fetch!(state.config, :parameters),
+      socket_options: Keyword.fetch!(state.config, :socket_options),
       channel_name: Keyword.fetch!(state.config, :channel_name)
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.3",
+      version: "2.41.4",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/cluster_strategy/postgres_test.exs
+++ b/test/realtime/cluster_strategy/postgres_test.exs
@@ -49,6 +49,7 @@ defmodule Realtime.Cluster.Strategy.PostgresTest do
       parameters: [
         application_name: "#{node()}"
       ],
+      socket_options: [:inet],
       heartbeat_interval: 5_000,
       node_timeout: 15_000,
       channel_name: "test_channel_name"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Pass the same `socket_options` provided to `Realtime.Repo` to the libcluster Postgres strategy

## What is the current behavior?

`socket_options` are not sent not allowing IPv6 databases to be used for the libcluster setup

## What is the new behavior?

IPv6 databases will work for the cluster strategy as well

## Additional context

Add any other context or screenshots.
