### PR TITLE
fix: RateCounter refactor to make idle shutdown safer

### DIFF
--- a/lib/realtime/api.ex
+++ b/lib/realtime/api.ex
@@ -208,16 +208,16 @@ defmodule Realtime.Api do
   def preload_counters(nil), do: nil
 
   def preload_counters(%Tenant{} = tenant) do
-    id = Tenants.requests_per_second_key(tenant)
+    rate = Tenants.requests_per_second_rate(tenant)
 
-    preload_counters(tenant, id)
+    preload_counters(tenant, rate)
   end
 
-  def preload_counters(nil, _key), do: nil
+  def preload_counters(nil, _rate), do: nil
 
-  def preload_counters(%Tenant{} = tenant, counters_key) do
-    current = GenCounter.get(counters_key)
-    {:ok, %RateCounter{avg: avg}} = RateCounter.get(counters_key)
+  def preload_counters(%Tenant{} = tenant, counters_rate) do
+    current = GenCounter.get(counters_rate.id)
+    {:ok, %RateCounter{avg: avg}} = RateCounter.get(counters_rate)
 
     tenant
     |> Map.put(:events_per_second_rolling, avg)

--- a/lib/realtime/gen_counter/gen_counter.ex
+++ b/lib/realtime/gen_counter/gen_counter.ex
@@ -27,10 +27,10 @@ defmodule Realtime.GenCounter do
   @doc "Reset counter to 0 and return previous value"
   @spec reset(term) :: integer
   def reset(term) do
-    # We might lose some updates between lookup and the delete
+    # We might lose some updates between lookup and the update
     case :ets.lookup(@table, term) do
       [{^term, previous}] ->
-        :ets.delete(@table, term)
+        :ets.update_element(@table, term, {2, 0}, {term, 0})
         previous
 
       [] ->

--- a/lib/realtime/tenants/connect/start_counters.ex
+++ b/lib/realtime/tenants/connect/start_counters.ex
@@ -20,18 +20,10 @@ defmodule Realtime.Tenants.Connect.StartCounters do
   end
 
   def start_joins_per_second_counter(tenant) do
-    %{max_joins_per_second: max_joins_per_second} = tenant
-    id = Tenants.joins_per_second_key(tenant)
-
     res =
-      RateCounter.new(id,
-        idle_shutdown: :infinity,
-        telemetry: %{
-          event_name: [:channel, :joins],
-          measurements: %{limit: max_joins_per_second},
-          metadata: %{tenant: tenant.external_id}
-        }
-      )
+      tenant
+      |> Tenants.joins_per_second_rate()
+      |> RateCounter.new()
 
     case res do
       {:ok, _} -> :ok
@@ -41,19 +33,10 @@ defmodule Realtime.Tenants.Connect.StartCounters do
   end
 
   def start_max_events_counter(tenant) do
-    %{max_events_per_second: max_events_per_second} = tenant
-
-    key = Tenants.events_per_second_key(tenant)
-
     res =
-      RateCounter.new(key,
-        idle_shutdown: :infinity,
-        telemetry: %{
-          event_name: [:channel, :events],
-          measurements: %{limit: max_events_per_second},
-          metadata: %{tenant: tenant.external_id}
-        }
-      )
+      tenant
+      |> Tenants.events_per_second_rate()
+      |> RateCounter.new()
 
     case res do
       {:ok, _} -> :ok
@@ -63,17 +46,10 @@ defmodule Realtime.Tenants.Connect.StartCounters do
   end
 
   def start_db_events_counter(tenant) do
-    key = Tenants.db_events_per_second_key(tenant)
-
     res =
-      RateCounter.new(key,
-        idle_shutdown: :infinity,
-        telemetry: %{
-          event_name: [:channel, :db_events],
-          measurements: %{},
-          metadata: %{tenant: tenant.external_id}
-        }
-      )
+      tenant
+      |> Tenants.db_events_per_second_rate()
+      |> RateCounter.new()
 
     case res do
       {:ok, _} -> :ok

--- a/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
@@ -11,7 +11,6 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
   alias Phoenix.Socket
   alias Realtime.Api.Tenant
   alias Realtime.GenCounter
-  alias Realtime.RateCounter
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
@@ -102,8 +101,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
 
   defp increment_rate_counter(%{assigns: %{rate_counter: counter}} = socket) do
     GenCounter.add(counter.id)
-    {:ok, rate_counter} = RateCounter.get(counter.id)
-    assign(socket, :rate_counter, rate_counter)
+    socket
   end
 
   defp run_authorization_check(

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -10,7 +10,6 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
   alias Phoenix.Socket
   alias Phoenix.Tracker.Shard
   alias Realtime.GenCounter
-  alias Realtime.RateCounter
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.PresencePolicies
@@ -43,7 +42,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
 
   def sync(%{assigns: %{private?: false}} = socket) do
     %{assigns: %{tenant_topic: topic}} = socket
-    socket = count(socket)
+    count(socket)
     push(socket, "presence_state", presence_dirty_list(topic))
     {:noreply, socket}
   end
@@ -141,12 +140,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
     end
   end
 
-  defp count(%{assigns: %{presence_rate_counter: presence_counter}} = socket) do
-    GenCounter.add(presence_counter.id)
-    {:ok, presence_rate_counter} = RateCounter.get(presence_counter.id)
-
-    assign(socket, :presence_rate_counter, presence_rate_counter)
-  end
+  defp count(%{assigns: %{presence_rate_counter: presence_counter}}), do: GenCounter.add(presence_counter.id)
 
   defp presence_dirty_list(topic) do
     [{:pool_size, size}] = :ets.lookup(Presence, :pool_size)

--- a/lib/realtime_web/plugs/assign_tenant.ex
+++ b/lib/realtime_web/plugs/assign_tenant.ex
@@ -44,7 +44,7 @@ defmodule RealtimeWeb.Plugs.AssignTenant do
   end
 
   defp initialize_counters(tenant) do
-    RateCounter.new(Tenants.requests_per_second_key(tenant), idle_shutdown: :infinity)
-    RateCounter.new(Tenants.events_per_second_key(tenant), idle_shutdown: :infinity)
+    RateCounter.new(Tenants.requests_per_second_rate(tenant))
+    RateCounter.new(Tenants.events_per_second_rate(tenant))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.9",
+      version: "2.41.10",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.8",
+      version: "2.41.9",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/gen_counter/gen_counter_test.exs
+++ b/test/realtime/gen_counter/gen_counter_test.exs
@@ -22,12 +22,12 @@ defmodule Realtime.GenCounterTest do
   end
 
   describe "reset/2" do
-    test "delete a counter the previous value" do
+    test "reset a counter returning the previous value" do
       term = {:domain, :metric, Ecto.UUID.generate()}
       GenCounter.add(term, 10)
       assert 10 == GenCounter.reset(term)
       assert GenCounter.get(term) == 0
-      assert :ets.lookup(:gen_counter, term) == []
+      assert :ets.lookup(:gen_counter, term) == [{term, 0}]
     end
   end
 

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -25,14 +25,8 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
 
                 def fake_db_event(external_id) do
                   external_id
-                  |> Realtime.Tenants.db_events_per_second_key()
-                  |> Realtime.RateCounter.new(
-                    telemetry: %{
-                      event_name: [:channel, :db_events],
-                      measurements: %{},
-                      metadata: %{tenant: external_id}
-                    }
-                  )
+                  |> Realtime.Tenants.db_events_per_second_rate()
+                  |> Realtime.RateCounter.new()
 
                   external_id
                   |> Realtime.Tenants.db_events_per_second_key()
@@ -41,14 +35,8 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
 
                 def fake_event(external_id) do
                   external_id
-                  |> Realtime.Tenants.events_per_second_key()
-                  |> Realtime.RateCounter.new(
-                    telemetry: %{
-                      event_name: [:channel, :events],
-                      measurements: %{},
-                      metadata: %{tenant: external_id}
-                    }
-                  )
+                  |> Realtime.Tenants.events_per_second_rate(123)
+                  |> Realtime.RateCounter.new()
 
                   external_id
                   |> Realtime.Tenants.events_per_second_key()
@@ -57,14 +45,8 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
 
                 def fake_presence_event(external_id) do
                   external_id
-                  |> Realtime.Tenants.presence_events_per_second_key()
-                  |> Realtime.RateCounter.new(
-                    telemetry: %{
-                      event_name: [:channel, :presence_events],
-                      measurements: %{},
-                      metadata: %{tenant: external_id}
-                    }
-                  )
+                  |> Realtime.Tenants.presence_events_per_second_rate(123)
+                  |> Realtime.RateCounter.new()
 
                   external_id
                   |> Realtime.Tenants.presence_events_per_second_key()

--- a/test/realtime/rate_counter/rate_counter_test.exs
+++ b/test/realtime/rate_counter/rate_counter_test.exs
@@ -2,38 +2,115 @@ defmodule Realtime.RateCounterTest do
   use Realtime.DataCase, async: true
 
   alias Realtime.RateCounter
+  alias Realtime.RateCounter.Args
   alias Realtime.GenCounter
 
-  describe "new/1" do
-    test "starts a new rate counter from an Erlang term" do
-      term = {:domain, :metric, Ecto.UUID.generate()}
-      assert {:ok, _} = RateCounter.new(term)
+  describe "new/2" do
+    test "starts a new rate counter without telemetry" do
+      id = {:domain, :metric, Ecto.UUID.generate()}
+      args = %Args{id: id, opts: []}
+      assert {:ok, pid} = RateCounter.new(args)
+
+      assert %Realtime.RateCounter{
+               id: ^id,
+               avg: +0.0,
+               bucket: [],
+               max_bucket_len: 60,
+               tick: 1000,
+               tick_ref: _,
+               idle_shutdown: 900_000,
+               idle_shutdown_ref: _,
+               telemetry: %{emit: false}
+             } = :sys.get_state(pid)
+    end
+
+    test "starts a new rate counter with telemetry" do
+      :telemetry.detach(__MODULE__)
+
+      :telemetry.attach(
+        __MODULE__,
+        [:realtime, :rate_counter, :custom, :new_event],
+        &__MODULE__.handle_telemetry/4,
+        pid: self()
+      )
+
+      id = {:domain, :metric, Ecto.UUID.generate()}
+
+      args = %Args{
+        id: id,
+        opts: [
+          telemetry: %{
+            event_name: [:custom, :new_event],
+            measurements: %{limit: 123},
+            metadata: %{tenant: "abc"}
+          }
+        ]
+      }
+
+      assert {:ok, pid} = RateCounter.new(args)
+
+      assert %Realtime.RateCounter{
+               id: ^id,
+               avg: +0.0,
+               bucket: [],
+               max_bucket_len: 60,
+               tick: 1000,
+               tick_ref: _,
+               idle_shutdown: 900_000,
+               idle_shutdown_ref: _,
+               telemetry: %{
+                 emit: true,
+                 event_name: [:realtime, :rate_counter, :custom, :new_event],
+                 measurements: %{sum: 0, limit: 123},
+                 metadata: %{id: ^id, tenant: "abc"}
+               }
+             } = :sys.get_state(pid)
+
+      GenCounter.add(args.id, 10)
+
+      assert_receive {
+        [:realtime, :rate_counter, :custom, :new_event],
+        %{sum: 10, limit: 123},
+        %{id: ^id, tenant: "abc"}
+      }
     end
 
     test "reset counter if GenCounter already had something" do
-      term = {:domain, :metric, Ecto.UUID.generate()}
-      GenCounter.add(term, 100)
-      assert {:ok, _} = RateCounter.new(term)
-      assert GenCounter.get(term) == 0
+      args = %Args{id: {:domain, :metric, Ecto.UUID.generate()}}
+      GenCounter.add(args.id, 100)
+      assert {:ok, _} = RateCounter.new(args)
+      assert GenCounter.get(args.id) == 0
     end
 
     test "rate counters are unique for an Erlang term" do
-      term = {:domain, :metric, Ecto.UUID.generate()}
-      {:ok, _} = RateCounter.new(term)
-      assert {:error, {:already_started, _pid}} = RateCounter.new(term)
+      args = %Args{id: {:domain, :metric, Ecto.UUID.generate()}}
+      {:ok, pid} = RateCounter.new(args)
+
+      assert {:error, {:already_started, ^pid}} = RateCounter.new(args)
     end
 
     test "rate counters shut themselves down when no activity occurs on the GenCounter" do
-      term = {:domain, :metric, Ecto.UUID.generate()}
-      {:ok, _} = RateCounter.new(term, idle_shutdown: 5)
-      Process.sleep(25)
-      assert {:error, _term} = RateCounter.get(term)
+      args = %Args{id: {:domain, :metric, Ecto.UUID.generate()}}
+      {:ok, pid} = RateCounter.new(args, idle_shutdown: 5)
+
+      Process.monitor(pid)
+      assert_receive {:DOWN, _ref, :process, ^pid, :normal}, 25
+      # Cache has not expired yet
+      assert {:ok, %RateCounter{}} = Cachex.get(RateCounter, args.id)
+      Process.sleep(2000)
+      assert {:ok, nil} = Cachex.get(RateCounter, args.id)
+
+      # Ok new RateCounter automatically started now
+      assert {:ok, %RateCounter{}} = RateCounter.get(args)
+
+      [{new_pid, _}] = Registry.lookup(Realtime.Registry.Unique, {RateCounter, :rate_counter, args.id})
+      assert new_pid != pid
     end
 
     test "rate counters reset GenCounter to zero after one tick and average the bucket" do
-      term = {:domain, :metric, Ecto.UUID.generate()}
-      {:ok, _} = RateCounter.new(term, tick: 5)
-      assert GenCounter.add(term) == 1
+      args = %Args{id: {:domain, :metric, Ecto.UUID.generate()}}
+      {:ok, _pid} = RateCounter.new(args, tick: 5)
+      assert GenCounter.add(args.id) == 1
       Process.sleep(10)
 
       assert {:ok,
@@ -41,23 +118,29 @@ defmodule Realtime.RateCounterTest do
                 avg: 0.5,
                 bucket: [0, 1],
                 id: _id,
-                idle_shutdown: 5000,
+                idle_shutdown: _,
                 idle_shutdown_ref: _ref,
                 max_bucket_len: 60,
                 tick: 5,
                 tick_ref: _ref2
-              }} = RateCounter.get(term)
+              }} = RateCounter.get(args)
 
-      assert GenCounter.get(term) == 0
+      assert GenCounter.get(args.id) == 0
     end
   end
 
   describe "get/1" do
     test "gets the state of a rate counter" do
-      term = {:domain, :metric, Ecto.UUID.generate()}
-      {:ok, _} = RateCounter.new(term)
+      args = %Args{id: {:domain, :metric, Ecto.UUID.generate()}}
+      {:ok, _} = RateCounter.new(args)
 
-      assert {:ok, %RateCounter{}} = RateCounter.get(term)
+      assert {:ok, %RateCounter{}} = RateCounter.get(args)
+    end
+
+    test "creates counter if not started yet" do
+      args = %Args{id: {:domain, :metric, Ecto.UUID.generate()}}
+
+      assert {:ok, %RateCounter{}} = RateCounter.get(args)
     end
   end
 
@@ -68,24 +151,28 @@ defmodule Realtime.RateCounterTest do
       terms = Enum.map(1..10, fn _ -> {:domain, :"metric_#{random_string()}", entity_id} end)
 
       for term <- terms do
-        {:ok, _} = RateCounter.new(term)
-        assert {:ok, %RateCounter{}} = RateCounter.get(term)
+        args = %Args{id: term}
+        {:ok, _} = RateCounter.new(args)
+        assert {:ok, %RateCounter{}} = RateCounter.get(args)
       end
 
       for term <- fake_terms do
-        {:ok, _} = RateCounter.new(term)
-        assert {:ok, %RateCounter{}} = RateCounter.get(term)
+        args = %Args{id: term}
+        {:ok, _} = RateCounter.new(args)
+        assert {:ok, %RateCounter{}} = RateCounter.get(args)
       end
 
       assert :ok = RateCounter.stop(entity_id)
 
       for term <- terms do
-        assert {:error, _} = RateCounter.get(term)
+        assert [] = Registry.lookup(Realtime.Registry.Unique, {RateCounter, :rate_counter, term})
       end
 
       for term <- fake_terms do
-        assert {:ok, %RateCounter{}} = RateCounter.get(term)
+        assert [{_pid, _value}] = Registry.lookup(Realtime.Registry.Unique, {RateCounter, :rate_counter, term})
       end
     end
   end
+
+  def handle_telemetry(event, measures, metadata, pid: pid), do: send(pid, {event, measures, metadata})
 end

--- a/test/realtime/tenants/replication_connection_test.exs
+++ b/test/realtime/tenants/replication_connection_test.exs
@@ -8,7 +8,6 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
 
   alias Realtime.Api.Message
   alias Realtime.Database
-  alias Realtime.RateCounter
   alias Realtime.Tenants
   alias Realtime.Tenants.ReplicationConnection
   alias RealtimeWeb.Endpoint
@@ -24,7 +23,6 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
     name = "supabase_realtime_messages_replication_slot_test"
     Postgrex.query(db_conn, "SELECT pg_drop_replication_slot($1)", [name])
     Process.exit(db_conn, :normal)
-    tenant |> Tenants.limiter_keys() |> Enum.each(&RateCounter.new(&1))
 
     %{tenant: tenant}
   end

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -43,7 +43,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
           assert message == %{"event" => "broadcast", "payload" => %{"a" => "b"}, "ref" => nil, "topic" => topic}
         end
 
-        {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_key(tenant))
+        {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
         assert 100 in buckets
         assert avg > 0
       end
@@ -65,7 +65,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
         refute_received _any
 
-        {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_key(tenant))
+        {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
         assert avg == 0.0
       end
 
@@ -97,7 +97,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
           assert message == %{"event" => "broadcast", "payload" => %{"a" => "b"}, "ref" => nil, "topic" => topic}
         end
 
-        {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_key(tenant))
+        {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
         assert 100 in buckets
         assert avg > 0.0
       end
@@ -119,7 +119,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
         refute_received _any
 
-        {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_key(tenant))
+        {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
         assert avg == 0.0
       end
 
@@ -231,7 +231,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
           assert message == %{"event" => "broadcast", "payload" => %{"a" => "b"}, "ref" => nil, "topic" => topic}
         end
 
-        {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_key(tenant))
+        {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
         assert 100 in buckets
         assert avg > 0.0
       end
@@ -259,7 +259,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
         end
 
         Process.sleep(120)
-        {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_key(tenant))
+        {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
         assert 100 in buckets
         assert avg > 0.0
       end
@@ -278,7 +278,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
         assert log =~ "RlsPolicyError"
 
-        {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_key(tenant))
+        {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
         assert avg == 0.0
       end
     end
@@ -292,8 +292,8 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
     # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues
     Cachex.put!(Realtime.Tenants.Cache, {{:get_tenant_by_external_id, 1}, [tenant.external_id]}, {:cached, tenant})
 
-    key = Tenants.events_per_second_key(tenant)
-    RateCounter.new(key, tick: 100)
+    rate = Tenants.events_per_second_rate(tenant)
+    RateCounter.new(rate, tick: 100)
 
     {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
     assert Connect.ready?(tenant.external_id)
@@ -337,8 +337,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
         role: claims.role
       })
 
-    key = Tenants.events_per_second_key(tenant)
-    {:ok, rate_counter} = RateCounter.get(key)
+    rate_counter = Tenants.events_per_second_rate(tenant)
 
     tenant_topic = "realtime:#{topic}"
     self_broadcast = true

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -6,9 +6,6 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
   import Generators
 
   alias Phoenix.Socket.Broadcast
-  alias Realtime.RateCounter
-  alias Realtime.RateCounter
-  alias Realtime.Tenants
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
@@ -209,8 +206,6 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
     # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues
     Cachex.put!(Realtime.Tenants.Cache, {{:get_tenant_by_external_id, 1}, [tenant.external_id]}, {:cached, tenant})
 
-    RateCounter.stop(tenant.external_id)
-
     {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
     assert Connect.ready?(tenant.external_id)
 
@@ -247,10 +242,6 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
         role: claims.role
       })
 
-    key = Tenants.events_per_second_key(tenant)
-    RateCounter.new(key)
-    {:ok, rate_counter} = RateCounter.get(key)
-
     tenant_topic = "realtime:#{topic}"
     self_broadcast = true
 
@@ -262,7 +253,6 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
         self_broadcast: self_broadcast,
         policies: policies,
         authorization_context: authorization_context,
-        rate_counter: rate_counter,
         private?: private?,
         presence_key: presence_key,
         presence_enabled?: enabled?

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -153,10 +153,10 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
         # Wait for counters to increment. RateCounter tick is 1 second
         Process.sleep(2000)
-        {:ok, rate_counter} = RateCounter.get(Tenants.requests_per_second_key(tenant))
+        {:ok, rate_counter} = RateCounter.get(Tenants.requests_per_second_rate(tenant))
         assert rate_counter.avg != 0.0
 
-        {:ok, rate_counter} = RateCounter.get(Tenants.events_per_second_key(tenant))
+        {:ok, rate_counter} = RateCounter.get(Tenants.events_per_second_rate(tenant))
         assert rate_counter.avg == 0.0
 
         refute_receive {:socket_push, _, _}
@@ -166,14 +166,14 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
   describe "too many requests" do
     test "batch will exceed rate limit", %{conn: conn, tenant: tenant} do
-      requests_key = Tenants.requests_per_second_key(tenant)
-      events_key = Tenants.events_per_second_key(tenant)
+      requests_rate = Tenants.requests_per_second_rate(tenant)
+      events_rate = Tenants.events_per_second_rate(tenant)
 
       RateCounter
-      |> stub(:new, fn _, _ -> {:ok, nil} end)
+      |> stub(:new, fn _ -> {:ok, nil} end)
       |> stub(:get, fn
-        ^requests_key -> {:ok, %RateCounter{avg: 0}}
-        ^events_key -> {:ok, %RateCounter{avg: 10}}
+        ^requests_rate -> {:ok, %RateCounter{avg: 0}}
+        ^events_rate -> {:ok, %RateCounter{avg: 10}}
       end)
 
       conn =
@@ -198,14 +198,14 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     end
 
     test "user has hit the rate limit", %{conn: conn, tenant: tenant} do
-      requests_key = Tenants.requests_per_second_key(tenant)
-      events_key = Tenants.events_per_second_key(tenant)
+      requests_rate = Tenants.requests_per_second_rate(tenant)
+      events_rate = Tenants.events_per_second_rate(tenant)
 
       RateCounter
-      |> stub(:new, fn _, _ -> {:ok, nil} end)
+      |> stub(:new, fn _ -> {:ok, nil} end)
       |> stub(:get, fn
-        ^requests_key -> {:ok, %RateCounter{avg: 0}}
-        ^events_key -> {:ok, %RateCounter{avg: 1000}}
+        ^requests_rate -> {:ok, %RateCounter{avg: 0}}
+        ^events_rate -> {:ok, %RateCounter{avg: 1000}}
       end)
 
       messages = [


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow RateCounter processes to stop when idle for a reasonable amount of time.

## What is the current behavior?

`idle_shutdown: :infinity` 🚀 🧑‍🚀 

## What is the new behavior?

`RateCounter` processes can safely go away now and get automatically restarted when `RateCounter.get/2` is called and if there is no RateCounter process running.

I also reworked the way that we we were handling the idle timer. Instead of refreshing the idle timer on every `tick` we now let the idle timer message arrive (every 15 minutes) and check if the `bucket` contains only zeros. If that's the case we let it stop. This is so that we don't refresh an idle timer on a busy RateCounter that always has something to account for. It would refresh this timer every second. If they are busy enough the `bucket` won't be full of zeros.

Later on we can probably decrease the idle shutdown timer to 10, 5 minutes if we wanted to.

## Additional context

Add any other context or screenshots.
