### PR TITLE
fix: start RateCounter for db events close to where we generate events

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -60,7 +60,6 @@ defmodule RealtimeWeb.RealtimeChannel do
          :ok <- limit_joins(socket.assigns),
          :ok <- limit_channels(socket),
          :ok <- limit_max_users(socket.assigns),
-         :ok <- start_db_rate_counter(tenant_id),
          {:ok, claims, confirm_token_ref, access_token, _} <- confirm_token(socket),
          {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant_id),
          socket = assign_authorization_context(socket, sub_topic, access_token, claims),
@@ -648,14 +647,6 @@ defmodule RealtimeWeb.RealtimeChannel do
       message: inspect(message),
       channel: channel_name
     })
-  end
-
-  defp start_db_rate_counter(tenant) do
-    rate_args = Tenants.db_events_per_second_rate(tenant)
-
-    RateCounter.new(rate_args)
-
-    :ok
   end
 
   defp new_api?(%{"config" => _}), do: true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.10",
+      version: "2.41.11",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -238,7 +238,7 @@ defmodule Containers do
     ]
     |> Realtime.Repo.with_dynamic_repo(fn repo ->
       try do
-        opts = [all: true, prefix: "realtime", dynamic_repo: repo]
+        opts = [all: true, prefix: "realtime", dynamic_repo: repo, log: false]
         migrations = Realtime.Tenants.Migrations.migrations()
         Ecto.Migrator.run(Realtime.Repo, migrations, :up, opts)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Move RateCounter for `db_events` to happen before we produce them.

Previously we were starting them during `Connect` start and whenever a new RealtimeChannel started. 

With the idle_shutdown not being `:infinity` we need to ensure that the RateCounter exists before we count events.

Summary of the other tenant RateCounters:

* `{:plug, :requests, tenant}` is started whenever a new HTTP request starts. ✅ Same place where it increments
* `{:channel, :joins, tenant}` is started whenever a RealtimeChannel starts. ✅ Same place where it increments
* `{:channel, :events, tenant}` is started whenever a RealtimeChannel starts or a new /broadcast request starts. ✅ Increments happens on both . `BroadcastHandler`, `BatchBroadcast` and `RealtimeChannel.MessageDispatcher`
* `{:channel, :presence_events, tenant}` is started whenever a RealtimeChannel starts. ✅ Same place where it increments. `PresenceHandler.sync` for non-private atm only though: https://github.com/supabase/realtime/blob/37dd1dff3b1f2616a572c92841abb827b7df077a/lib/realtime_web/channels/realtime_channel/presence_handler.ex#L45. Although not much is done with it and one could argue that not all presence events are not properly accounted for? 


## Additional context

Add any other context or screenshots.
