### PR TITLE
Fix/rate counter presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,6 @@ This is the list of operational codes that can help you understand your deployme
 | SubscriptionDeletionFailed         | Error when trying to delete a subscription for postgres changes                                                                                                                                       |
 | UnableToDeletePhantomSubscriptions | Error when trying to delete subscriptions that are no longer being used                                                                                                                               |
 | UnableToCheckProcessesOnRemoteNode | Error when trying to check the processes on a remote node                                                                                                                                             |
-| UnableToCreateCounter              | Error when trying to create a counter to track rate limits for a tenant                                                                                                                               |
-| UnableToIncrementCounter           | Error when trying to increment a counter to track rate limits for a tenant                                                                                                                            |
-| UnableToDecrementCounter           | Error when trying to decrement a counter to track rate limits for a tenant                                                                                                                            |
-| UnableToUpdateCounter              | Error when trying to update a counter to track rate limits for a tenant                                                                                                                               |
-| UnableToFindCounter                | Error when trying to find a counter to track rate limits for a tenant                                                                                                                                 |
 | UnhandledProcessMessage            | Unhandled message received by a Realtime process                                                                                                                                                      |
 | UnableToTrackPresence              | Error when handling track presence for this socket                                                                                                                                                    |
 | UnknownPresenceEvent               | Presence event type not recognized by service                                                                                                                                                         |
@@ -274,6 +269,7 @@ This is the list of operational codes that can help you understand your deployme
 | UnableToEncodeJson                 | An error were we are not handling correctly the response to be sent to the end user                                                                                                                   |
 | UnknownErrorOnController           | An error we are not handling correctly was triggered on a controller                                                                                                                                  |
 | UnknownErrorOnChannel              | An error we are not handling correctly was triggered on a channel                                                                                                                                     |
+| TooManyPresenceMessages            | Limit of presence events reached                                                                                                                                                                      |
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.11",
+      version: "2.41.12",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -42,15 +42,6 @@ defmodule Realtime.Integration.RtChannelTest do
     secret_key_base: String.duplicate("a", 64)
   )
 
-  setup do
-    tenant = Api.get_tenant_by_external_id("dev_tenant")
-
-    RateCounter.stop(tenant.external_id)
-    :ets.delete_all_objects(Tracker.table_name())
-
-    %{tenant: tenant}
-  end
-
   setup_all do
     capture_log(fn -> start_supervised!(TestEndpoint) end)
     start_supervised!({Phoenix.PubSub, name: __MODULE__})
@@ -1894,14 +1885,20 @@ defmodule Realtime.Integration.RtChannelTest do
     refute_receive %Message{event: "presence_state"}
   end
 
-  def handle_telemetry(event, %{sum: sum}, _, _) do
+  def handle_telemetry(event, %{sum: sum}, metadata, _) do
+    tenant = metadata[:tenant]
     [key] = Enum.take(event, -1)
-    Agent.update(TestCounter, fn state -> Map.update!(state, key, &(&1 + sum)) end)
+
+    Agent.update(TestCounter, fn state ->
+      state = Map.put_new(state, tenant, %{joins: 0, events: 0, db_events: 0, presence_events: 0})
+      update_in(state, [metadata[:tenant], key], fn v -> (v || 0) + sum end)
+    end)
   end
 
-  def get_count(event) do
+  defp get_count(event, tenant) do
     [key] = Enum.take(event, -1)
-    Agent.get(TestCounter, fn state -> Map.get(state, key, 0) end)
+
+    Agent.get(TestCounter, fn state -> get_in(state, [tenant, key]) || 0 end)
   end
 
   describe "billable events" do
@@ -1916,9 +1913,7 @@ defmodule Realtime.Integration.RtChannelTest do
       {:ok, _} =
         start_supervised(%{
           id: 1,
-          start:
-            {Agent, :start_link,
-             [fn -> %{joins: 0, events: 0, db_events: 0, presence_events: 0} end, [name: TestCounter]]}
+          start: {Agent, :start_link, [fn -> %{} end, [name: TestCounter]]}
         })
 
       RateCounter.stop(tenant.external_id)
@@ -1929,6 +1924,7 @@ defmodule Realtime.Integration.RtChannelTest do
     end
 
     test "join events", %{tenant: tenant} do
+      external_id = tenant.external_id
       {socket, _} = get_connection(tenant)
       config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "public"}]}
       topic = "realtime:any"
@@ -1948,15 +1944,16 @@ defmodule Realtime.Integration.RtChannelTest do
       # 1 presence events due to two sockets
       # 0 db events as no postgres changes used
       # 0 events broadcast is not used
-      assert 1 = get_count([:realtime, :rate_counter, :channel, :joins])
-      assert 1 = get_count([:realtime, :rate_counter, :channel, :presence_events])
-      assert 0 = get_count([:realtime, :rate_counter, :channel, :db_events])
-      assert 0 = get_count([:realtime, :rate_counter, :channel, :events])
+      assert 1 = get_count([:realtime, :rate_counter, :channel, :joins], external_id)
+      assert 1 = get_count([:realtime, :rate_counter, :channel, :presence_events], external_id)
+      assert 0 = get_count([:realtime, :rate_counter, :channel, :db_events], external_id)
+      assert 0 = get_count([:realtime, :rate_counter, :channel, :events], external_id)
     end
 
     test "broadcast events", %{tenant: tenant} do
+      external_id = tenant.external_id
       {socket, _} = get_connection(tenant)
-      config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "public"}]}
+      config = %{broadcast: %{self: true}}
       topic = "realtime:any"
 
       WebsocketClient.join(socket, topic, %{config: config})
@@ -1964,7 +1961,6 @@ defmodule Realtime.Integration.RtChannelTest do
       # Join events
       assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 300
       assert_receive %Message{topic: ^topic, event: "presence_state"}
-      assert_receive %Message{topic: ^topic, event: "system"}, 5000
 
       # Add second client so we can test the "multiplication" of billable events
       {socket, _} = get_connection(tenant)
@@ -1973,7 +1969,6 @@ defmodule Realtime.Integration.RtChannelTest do
       # Join events
       assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 300
       assert_receive %Message{topic: ^topic, event: "presence_state"}
-      assert_receive %Message{topic: ^topic, event: "system"}, 5000
 
       # Broadcast event
       payload = %{"event" => "TEST", "payload" => %{"msg" => 1}, "type" => "broadcast"}
@@ -1991,15 +1986,16 @@ defmodule Realtime.Integration.RtChannelTest do
       # 2 presence events due to two sockets
       # 0 db events as no postgres changes used
       # 15 events as 5 events sent, 5 events received on client 1 and 5 events received on client 2
-      assert 2 = get_count([:realtime, :rate_counter, :channel, :joins])
-      assert 2 = get_count([:realtime, :rate_counter, :channel, :presence_events])
-      assert 0 = get_count([:realtime, :rate_counter, :channel, :db_events])
-      assert 15 = get_count([:realtime, :rate_counter, :channel, :events])
+      assert 2 = get_count([:realtime, :rate_counter, :channel, :joins], external_id)
+      assert 2 = get_count([:realtime, :rate_counter, :channel, :presence_events], external_id)
+      assert 0 = get_count([:realtime, :rate_counter, :channel, :db_events], external_id)
+      assert 15 = get_count([:realtime, :rate_counter, :channel, :events], external_id)
     end
 
     test "presence events", %{tenant: tenant} do
+      external_id = tenant.external_id
       {socket, _} = get_connection(tenant)
-      config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "public"}]}
+      config = %{broadcast: %{self: true}, presence: %{enabled: true}}
       topic = "realtime:any"
 
       WebsocketClient.join(socket, topic, %{config: config})
@@ -2007,7 +2003,15 @@ defmodule Realtime.Integration.RtChannelTest do
       # Join events
       assert_receive %Message{event: "phx_reply", topic: ^topic}, 1000
       assert_receive %Message{topic: ^topic, event: "presence_state"}, 1000
-      assert_receive %Message{topic: ^topic, event: "system"}, 5000
+
+      payload = %{
+        type: "presence",
+        event: "TRACK",
+        payload: %{name: "realtime_presence_1", t: 1814.7000000029802}
+      }
+
+      WebsocketClient.send_event(socket, topic, "presence", payload)
+      assert_receive %Message{event: "presence_diff", payload: %{"joins" => _, "leaves" => %{}}, topic: ^topic}
 
       # Presence events
       {socket, _} = get_connection(tenant, "authenticated")
@@ -2015,23 +2019,33 @@ defmodule Realtime.Integration.RtChannelTest do
 
       assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 300
       assert_receive %Message{topic: ^topic, event: "presence_state"}
-      assert_receive %Message{topic: ^topic, event: "system"}, 5000
+
+      payload = %{
+        type: "presence",
+        event: "TRACK",
+        payload: %{name: "realtime_presence_2", t: 1814.7000000029802}
+      }
+
+      WebsocketClient.send_event(socket, topic, "presence", payload)
+      assert_receive %Message{event: "presence_diff", payload: %{"joins" => _, "leaves" => %{}}, topic: ^topic}
+      assert_receive %Message{event: "presence_diff", payload: %{"joins" => _, "leaves" => %{}}, topic: ^topic}
 
       # Wait for RateCounter to run
       Process.sleep(2000)
 
       # Expected billed
       # 2 joins due to two sockets
-      # 2 presence events due to two sockets
+      # 7 presence events
       # 0 db events as no postgres changes used
       # 0 events as no broadcast used
-      assert 2 = get_count([:realtime, :rate_counter, :channel, :joins])
-      assert 2 = get_count([:realtime, :rate_counter, :channel, :presence_events])
-      assert 0 = get_count([:realtime, :rate_counter, :channel, :db_events])
-      assert 0 = get_count([:realtime, :rate_counter, :channel, :events])
+      assert 2 = get_count([:realtime, :rate_counter, :channel, :joins], external_id)
+      assert 7 = get_count([:realtime, :rate_counter, :channel, :presence_events], external_id)
+      assert 0 = get_count([:realtime, :rate_counter, :channel, :db_events], external_id)
+      assert 0 = get_count([:realtime, :rate_counter, :channel, :events], external_id)
     end
 
     test "postgres changes events", %{tenant: tenant} do
+      external_id = tenant.external_id
       {socket, _} = get_connection(tenant)
       config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "public"}]}
       topic = "realtime:any"
@@ -2073,13 +2087,14 @@ defmodule Realtime.Integration.RtChannelTest do
       # 2 presence events due to two sockets
       # 10 db events due to 5 inserts events sent to client 1 and 5 inserts events sent to client 2
       # 0 events as no broadcast used
-      assert 2 = get_count([:realtime, :rate_counter, :channel, :joins])
-      assert 2 = get_count([:realtime, :rate_counter, :channel, :presence_events])
-      assert 10 = get_count([:realtime, :rate_counter, :channel, :db_events])
-      assert 0 = get_count([:realtime, :rate_counter, :channel, :events])
+      assert 2 = get_count([:realtime, :rate_counter, :channel, :joins], external_id)
+      assert 2 = get_count([:realtime, :rate_counter, :channel, :presence_events], external_id)
+      assert 10 = get_count([:realtime, :rate_counter, :channel, :db_events], external_id)
+      assert 0 = get_count([:realtime, :rate_counter, :channel, :events], external_id)
     end
 
     test "postgres changes error events", %{tenant: tenant} do
+      external_id = tenant.external_id
       {socket, _} = get_connection(tenant)
       config = %{broadcast: %{self: true}, postgres_changes: [%{event: "*", schema: "none"}]}
       topic = "realtime:any"
@@ -2099,10 +2114,10 @@ defmodule Realtime.Integration.RtChannelTest do
       # 1 presence events due to one socket
       # 0 db events
       # 0 events as no broadcast used
-      assert 1 = get_count([:realtime, :rate_counter, :channel, :joins])
-      assert 1 = get_count([:realtime, :rate_counter, :channel, :presence_events])
-      assert 0 = get_count([:realtime, :rate_counter, :channel, :db_events])
-      assert 0 = get_count([:realtime, :rate_counter, :channel, :events])
+      assert 1 = get_count([:realtime, :rate_counter, :channel, :joins], external_id)
+      assert 1 = get_count([:realtime, :rate_counter, :channel, :presence_events], external_id)
+      assert 0 = get_count([:realtime, :rate_counter, :channel, :db_events], external_id)
+      assert 0 = get_count([:realtime, :rate_counter, :channel, :events], external_id)
     end
   end
 
@@ -2190,7 +2205,12 @@ defmodule Realtime.Integration.RtChannelTest do
     assert count == 2
   end
 
-  defp mode(%{mode: :distributed, tenant: tenant}) do
+  defp mode(%{mode: :distributed}) do
+    tenant = Api.get_tenant_by_external_id("dev_tenant")
+
+    RateCounter.stop(tenant.external_id)
+    :ets.delete_all_objects(Tracker.table_name())
+
     Connect.shutdown(tenant.external_id)
     # Sleeping so that syn can forget about this Connect process
     Process.sleep(100)
@@ -2208,16 +2228,20 @@ defmodule Realtime.Integration.RtChannelTest do
     assert Connect.ready?(tenant.external_id)
 
     assert node(db_conn) == node
-    %{db_conn: db_conn, node: node}
+    %{db_conn: db_conn, node: node, tenant: tenant}
   end
 
-  defp mode(%{tenant: tenant}) do
+  defp mode(_) do
+    tenant = Containers.checkout_tenant(run_migrations: true)
+    RateCounter.stop(tenant.external_id)
+
+    :ets.delete_all_objects(Tracker.table_name())
     Realtime.Tenants.Connect.shutdown(tenant.external_id)
     # Sleeping so that syn can forget about this Connect process
     Process.sleep(100)
     {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
     assert Connect.ready?(tenant.external_id)
-    %{db_conn: db_conn}
+    %{db_conn: db_conn, tenant: tenant}
   end
 
   defp rls_context(%{tenant: tenant} = context) do

--- a/test/realtime/rate_counter/rate_counter_test.exs
+++ b/test/realtime/rate_counter/rate_counter_test.exs
@@ -52,7 +52,7 @@ defmodule Realtime.RateCounterTest do
       assert %Realtime.RateCounter{
                id: ^id,
                avg: +0.0,
-               bucket: [],
+               bucket: _,
                max_bucket_len: 60,
                tick: 1000,
                tick_ref: _,
@@ -115,8 +115,8 @@ defmodule Realtime.RateCounterTest do
 
       assert {:ok,
               %RateCounter{
-                avg: 0.5,
-                bucket: [0, 1],
+                avg: avg,
+                bucket: bucket,
                 id: _id,
                 idle_shutdown: _,
                 idle_shutdown_ref: _ref,
@@ -124,6 +124,9 @@ defmodule Realtime.RateCounterTest do
                 tick: 5,
                 tick_ref: _ref2
               }} = RateCounter.get(args)
+
+      assert 1 in bucket
+      assert avg > 0.0
 
       assert GenCounter.get(args.id) == 0
     end
@@ -163,6 +166,8 @@ defmodule Realtime.RateCounterTest do
       end
 
       assert :ok = RateCounter.stop(entity_id)
+      # Wait for processes to shut down and Registry to update
+      Process.sleep(100)
 
       for term <- terms do
         assert [] = Registry.lookup(Realtime.Registry.Unique, {RateCounter, :rate_counter, term})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ensures RateCounter for presence events is up when presence events happen

## What is the current behavior?

Not all presence events are tracked

## What is the new behavior?

* `track`, `sync`, `untrack`, `presence_diff` are all tracked now
* RateCounter is kept up and running when `presence_diff` is sent. This ensures that all the nodes with websockets listening for presence events will have the RateCounter running
* Log whenever presence events hit the limit of events. Logging only because more work is needed there.

## Additional context

Add any other context or screenshots.
