### PR TITLE
fix: avoid touching the ETS table when counter is 0

### DIFF
--- a/lib/realtime/gen_counter/gen_counter.ex
+++ b/lib/realtime/gen_counter/gen_counter.ex
@@ -29,6 +29,9 @@ defmodule Realtime.GenCounter do
   def reset(term) do
     # We might lose some updates between lookup and the update
     case :ets.lookup(@table, term) do
+      [{^term, 0}] ->
+        0
+
       [{^term, previous}] ->
         :ets.update_element(@table, term, {2, 0}, {term, 0})
         previous

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.14",
+      version: "2.41.15",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/gen_counter/gen_counter_test.exs
+++ b/test/realtime/gen_counter/gen_counter_test.exs
@@ -29,6 +29,22 @@ defmodule Realtime.GenCounterTest do
       assert GenCounter.get(term) == 0
       assert :ets.lookup(:gen_counter, term) == [{term, 0}]
     end
+
+    test "reset a counter returning the previous value when counter doesn't exist" do
+      term = {:domain, :metric, Ecto.UUID.generate()}
+      assert 0 == GenCounter.reset(term)
+      assert GenCounter.get(term) == 0
+      assert :ets.lookup(:gen_counter, term) == []
+    end
+
+    test "reset a counter returning the previous value when counter is 0" do
+      term = {:domain, :metric, Ecto.UUID.generate()}
+      GenCounter.add(term, 0)
+      assert 0 == GenCounter.reset(term)
+      assert 0 == GenCounter.reset(term)
+      assert GenCounter.get(term) == 0
+      assert :ets.lookup(:gen_counter, term) == [{term, 0}]
+    end
   end
 
   describe "delete/1" do


### PR DESCRIPTION
## What kind of change does this PR introduce?

We don't need to touch the ETS table if the counter is already 0

## What is the current behavior?

It updates the ETS row even when the value is already 0

## What is the new behavior?

Avoid the update

## Additional context

Add any other context or screenshots.
