### PR TITLE
fix: move rate limit message to happen inside the RateCounter

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -151,7 +151,16 @@ defmodule Realtime.Tenants do
         event_name: [:channel, :joins],
         measurements: %{limit: max_joins_per_second},
         metadata: %{tenant: tenant_id}
-      }
+      },
+      limit: [
+        value: max_joins_per_second,
+        log_fn: fn ->
+          Logger.error("ClientJoinRateLimitReached: Too many joins per second",
+            external_id: tenant_id,
+            project: tenant_id
+          )
+        end
+      ]
     ]
 
     %RateCounter.Args{id: joins_per_second_key(tenant_id), opts: opts}

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -155,7 +155,7 @@ defmodule Realtime.Tenants do
       limit: [
         value: max_joins_per_second,
         log_fn: fn ->
-          Logger.error("ClientJoinRateLimitReached: Too many joins per second",
+          Logger.critical("ClientJoinRateLimitReached: Too many joins per second",
             external_id: tenant_id,
             project: tenant_id
           )

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -137,7 +137,7 @@ defmodule RealtimeWeb.RealtimeChannel do
 
       {:error, :too_many_joins} ->
         msg = "Too many joins per second"
-        Logging.log_error_message(:error, "ClientJoinRateLimitReached", msg)
+        {:error, %{reason: msg}}
 
       {:error, :increase_connection_pool} ->
         msg = "Please increase your connection pool size"
@@ -504,10 +504,10 @@ defmodule RealtimeWeb.RealtimeChannel do
     rate_args = Tenants.joins_per_second_rate(tenant, limits.max_joins_per_second)
 
     RateCounter.new(rate_args)
-    GenCounter.add(rate_args.id)
 
     case RateCounter.get(rate_args) do
       {:ok, %{avg: avg}} when avg < limits.max_joins_per_second ->
+        GenCounter.add(rate_args.id)
         :ok
 
       {:ok, %{avg: _}} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.41.17",
+      version: "2.41.18",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -1832,7 +1832,7 @@ defmodule Realtime.Integration.RtChannelTest do
         end)
 
       assert log =~
-               "project=#{tenant.external_id} external_id=#{tenant.external_id} [error] ClientJoinRateLimitReached: Too many joins per second"
+               "project=#{tenant.external_id} external_id=#{tenant.external_id} [critical] ClientJoinRateLimitReached: Too many joins per second"
 
       # Only one log message should be emitted
       # Splitting by the error message returns the error message and the rest of the log only

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -1812,21 +1812,31 @@ defmodule Realtime.Integration.RtChannelTest do
       config = %{broadcast: %{self: true}, private: false}
       realtime_topic = "realtime:#{random_string()}"
 
-      for _ <- 1..1000 do
-        WebsocketClient.join(socket, realtime_topic, %{config: config})
-        1..5 |> Enum.random() |> Process.sleep()
-      end
+      log =
+        capture_log(fn ->
+          for _ <- 1..1000 do
+            WebsocketClient.join(socket, realtime_topic, %{config: config})
+            1..5 |> Enum.random() |> Process.sleep()
+          end
 
-      assert_receive %Message{
-                       event: "phx_reply",
-                       payload: %{
-                         "response" => %{"reason" => "Too many joins per second"},
-                         "status" => "error"
-                       }
-                     },
-                     2000
+          assert_receive %Message{
+                           event: "phx_reply",
+                           payload: %{
+                             "response" => %{"reason" => "Too many joins per second"},
+                             "status" => "error"
+                           }
+                         },
+                         2000
 
-      change_tenant_configuration(tenant, :max_joins_per_second, max_joins_per_second)
+          change_tenant_configuration(tenant, :max_joins_per_second, max_joins_per_second)
+        end)
+
+      assert log =~
+               "project=#{tenant.external_id} external_id=#{tenant.external_id} [error] ClientJoinRateLimitReached: Too many joins per second"
+
+      # Only one log message should be emitted
+      # Splitting by the error message returns the error message and the rest of the log only
+      assert length(String.split(log, "ClientJoinRateLimitReached")) == 2
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes so that RateCounter can detect that a limit has been crossed so that we log once instead of whenever an event (in this case a RealtimeChannel join) happens.

I've also changed to only increment a join when it's not being rate limited. 

We can apply the same solution to other limits we currently have like limit of events, presence events, etc

## What is the current behavior?

We log every time a `RealtimeChannel` join has failed due to the rate limit of joins been reached

## What is the new behavior?

We log once when the limit it crossed and we won't log again until the average has decreased enough to be below the limit.

## Additional context

Add any other context or screenshots.
