### PR TITLE
fix: change Connect and ReplicationConnection to use temporary restart strategy

### DIFF
--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -7,7 +7,7 @@ defmodule Realtime.Tenants.Connect do
   * `:check_connect_region_interval` - The interval in milliseconds to check if this process is in the correct region. If the region is not correct it stops the connection.
   * `:erpc_timeout` - The timeout in milliseconds for the `:erpc` calls to the tenant's database.
   """
-  use GenServer, restart: :transient
+  use GenServer, restart: :temporary
 
   use Realtime.Logs
 

--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -97,7 +97,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
     child_spec = %{
       id: __MODULE__,
       start: {Wrapper, :start_link, [opts, init_timeout]},
-      restart: :transient,
+      restart: :temporary,
       type: :worker
     }
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.42.0",
+      version: "2.42.1",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

We don't want them to be transient as a database connection (Postgrex) might have issues and the supervisor will keep trying to connect but if the database is completely inaccessible the supervisor will reach max restarts causing the whole partition supervisor to crash.

`Connect.lookup_or_start_connection/1` ensures that the connection is back up when needed so we don't need to worry about restarting theses processes straightaway through the supervisors.

## What is the current behavior?

A crashing Connect can bring down other Connects because of a supervisor restarting

## What is the new behavior?

Supervisor won't try to restart Connect and ReplicationConnection processes.

## Additional context

Add any other context or screenshots.
