### PR TITLE
fix: do not pass "jwt" to Authorization calls

### DIFF
--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -21,12 +21,11 @@ defmodule Realtime.Tenants.Authorization do
   defstruct [:tenant_id, :topic, :headers, :jwt, :claims, :role]
 
   @type t :: %__MODULE__{
-          :tenant_id => binary() | nil,
-          :topic => binary() | nil,
-          :claims => map(),
-          :headers => keyword({binary(), binary()}),
-          :jwt => map(),
-          :role => binary()
+          :tenant_id => binary | nil,
+          :topic => binary | nil,
+          :claims => map,
+          :headers => list({binary, binary}),
+          :role => binary
         }
 
   @doc """
@@ -35,7 +34,6 @@ defmodule Realtime.Tenants.Authorization do
   Requires a map with the following keys:
   * topic: The name of the channel being accessed taken from the request
   * headers: Request headers when the connection was made or WS was updated
-  * jwt: JWT String
   * claims: JWT claims
   * role: JWT role
   """
@@ -45,7 +43,6 @@ defmodule Realtime.Tenants.Authorization do
       tenant_id: Map.get(map, :tenant_id),
       topic: Map.get(map, :topic),
       headers: Map.get(map, :headers),
-      jwt: Map.get(map, :jwt),
       claims: Map.get(map, :claims),
       role: Map.get(map, :role)
     }

--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -38,7 +38,6 @@ defmodule Realtime.Tenants.BatchBroadcast do
     auth_params = %{
       tenant_id: tenant.external_id,
       headers: conn.req_headers,
-      jwt: conn.assigns.jwt,
       claims: conn.assigns.claims,
       role: conn.assigns.role
     }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.42.4",
+      version: "2.42.5",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -237,15 +237,11 @@ defmodule Realtime.Tenants.AuthorizationTest do
     create_rls_policies(db_conn, context.policies, %{topic: topic})
 
     claims = %{sub: random_string(), role: context.role, exp: Joken.current_time() + 1_000}
-    signer = Joken.Signer.create("HS256", "secret")
-
-    jwt = Joken.generate_and_sign!(%{}, claims, signer)
 
     authorization_context =
       Authorization.build_authorization_params(%{
         tenant_id: tenant.external_id,
         topic: topic,
-        jwt: jwt,
         claims: claims,
         headers: [{"header-1", "value-1"}],
         role: claims.role


### PR DESCRIPTION
It's a minor thing but the JWT was being sent as part of the auth params which is called on an RPC call increasing the payload

It turns out we don't use the JWT. We only set the claims from the JWT.

https://github.com/supabase/realtime/blob/51a75335b46cab78e5f9b4bd2926f1f602bba212/lib/realtime/tenants/authorization.ex#L142-L152