### PR TITLE
chore: add coverage and license badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
 
 ## Status
 
+![GitHub License](https://img.shields.io/github/license/supabase/realtime)
+[![Coverage Status](https://coveralls.io/repos/github/supabase/realtime/badge.svg?branch=main)](https://coveralls.io/github/supabase/realtime?branch=main)
+
 | Features         | v1  | v2  | Status |
 | ---------------- | --- | --- | ------ |
 | Postgres Changes | ✔   | ✔   | GA     |


### PR DESCRIPTION
Add coverage and license badges

<img width="1066" height="777" alt="realtime_README_md_at_chore_add-coverage-badge_·_supabase_realtime" src="https://github.com/user-attachments/assets/accc095e-2e22-448f-b7f7-a45262518f6a" />
