### PR TITLE
fix: access token handling

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -538,18 +538,14 @@ defmodule RealtimeWeb.RealtimeChannel do
     end
   end
 
-  defp assign_access_token(%{assigns: %{headers: headers}} = socket, params) do
+  defp assign_access_token(%{assigns: %{tenant_token: tenant_token}} = socket, params) do
     access_token = Map.get(params, "access_token") || Map.get(params, "user_token")
-    {_, header} = Enum.find(headers, {nil, nil}, fn {k, _} -> k == "x-api-key" end)
 
     case access_token do
-      nil -> assign(socket, :access_token, header)
-      "sb_" <> _ -> assign(socket, :access_token, header)
+      "sb_" <> _ -> assign(socket, :access_token, tenant_token)
       _ -> handle_access_token(socket, params)
     end
   end
-
-  defp assign_access_token(socket, params), do: handle_access_token(socket, params)
 
   defp handle_access_token(%{assigns: %{tenant_token: _tenant_token}} = socket, %{"user_token" => user_token})
        when is_binary(user_token) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.43.1",
+      version: "2.43.2",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Rely on `tenant_token` instead of `headers`.  `tenant_token` is assigned by UserSocket based on the `apikey` query string OR the header.

https://github.com/supabase/realtime/blob/5190510ecbf895b5459c67bce126449dafb70900/lib/realtime_web/channels/user_socket.ex#L112-L117

Fixes #1509 

## Additional context

Add any other context or screenshots.
