### PR TITLE
chore: update tenant creation on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ You can add your own by making a `POST` request to the server. You must change b
             "db_port": "5432",
             "region": "us-west-1",
             "poll_interval_ms": 100,
-            "poll_max_record_bytes": 1048576
+            "poll_max_record_bytes": 1048576,
+            "ssl_enforced": false  
           }
         }
       ]


### PR DESCRIPTION
Specify `ssl_enforced` as an option as the default is true and locally usually SSL is not used.

Related to #1509 