### PR TITLE
feat: add support for generating certs for securing inter-node comms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ ENV ECTO_IPV6 true
 ENV ERL_AFLAGS "-proto_dist inet6_tcp"
 
 RUN apt-get update -y && \
-    apt-get install -y libstdc++6 openssl libncurses5 locales iptables sudo tini curl && \
+    apt-get install -y libstdc++6 openssl libncurses5 locales iptables sudo tini curl awscli jq && \
     apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.45.0",
+      version: "2.46.0",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/run.sh
+++ b/run.sh
@@ -69,6 +69,21 @@ generate_certs() {
     chmod a+r "$GEN_RPC_CACERTFILE"
     chmod a+r "$GEN_RPC_KEYFILE"
     chmod a+r "$GEN_RPC_CERTFILE"
+    cat > inet_tls.conf <<EOF
+[
+  {server, [
+    {certfile, "${GEN_RPC_CERTFILE}"},
+    {keyfile, "${GEN_RPC_KEYFILE}"},
+    {secure_renegotiate, true}
+  ]},
+  {client, [
+    {cacertfile, "${GEN_RPC_CACERTFILE}"},
+    {verify, verify_none},
+    {secure_renegotiate, true}
+  ]}
+].
+EOF
+    export ERL_AFLAGS="${ERL_AFLAGS} -proto_dist inet_tls -ssl_dist_optfile ${CWD}/inet_tls.conf"
 }
 
 if [ "${ENABLE_ERL_CRASH_DUMP:-false}" = true ]; then


### PR DESCRIPTION
This is anticipated to be a temporary feature that will be deprecated
and removed once we move to a platform that offers easy init container
support.