### PR TITLE
chore: fix couple of flaky tests

### DIFF
--- a/test/realtime/monitoring/distributed_metrics_test.exs
+++ b/test/realtime/monitoring/distributed_metrics_test.exs
@@ -32,28 +32,5 @@ defmodule Realtime.DistributedMetricsTest do
                }
              } = DistributedMetrics.info()
     end
-
-    test "metric matches on both sides", %{node: node} do
-      # We need to generate some data first
-      Realtime.Rpc.call(node, String, :to_integer, ["25"], key: 1)
-      Realtime.Rpc.call(node, String, :to_integer, ["25"], key: 2)
-
-      local_metrics = DistributedMetrics.info()[node][:inet_stats]
-      # Use gen_rpc to not use erl dist and change the result
-      remote_metrics = :gen_rpc.call(node, DistributedMetrics, :info, [])[node()][:inet_stats]
-
-      # It's not going to 100% the same because erl dist sends pings and other things out of our control
-
-      assert local_metrics[:connections] == remote_metrics[:connections]
-
-      assert_in_delta(local_metrics[:send_avg], remote_metrics[:recv_avg], 5)
-      assert_in_delta(local_metrics[:recv_avg], remote_metrics[:send_avg], 5)
-
-      assert_in_delta(local_metrics[:send_oct], remote_metrics[:recv_oct], 5)
-      assert_in_delta(local_metrics[:recv_oct], remote_metrics[:send_oct], 5)
-
-      assert_in_delta(local_metrics[:send_max], remote_metrics[:recv_max], 5)
-      assert_in_delta(local_metrics[:recv_max], remote_metrics[:send_max], 5)
-    end
   end
 end

--- a/test/realtime/rate_counter/rate_counter_test.exs
+++ b/test/realtime/rate_counter/rate_counter_test.exs
@@ -227,11 +227,12 @@ defmodule Realtime.RateCounterTest do
 
       log =
         capture_log(fn ->
-          GenCounter.add(args.id, 50)
+          GenCounter.add(args.id, 100)
           Process.sleep(100)
         end)
 
-      assert {:ok, %RateCounter{sum: 50, limit: %{triggered: true}}} = RateCounter.get(args)
+      assert {:ok, %RateCounter{sum: sum, limit: %{triggered: true}}} = RateCounter.get(args)
+      assert sum > 49
       assert log =~ "project=tenant123 external_id=tenant123 [error] ErrorMessage: Reason"
 
       # Only one log message should be emitted


### PR DESCRIPTION
Decided to remove the DistributedMetrics test because we can't really control how much data goes through that pipe. Erlang sends heartbeats etc making it impossible to assert with some degree of certainty about the data sent through.