### PR TITLE
fix: use primary instead of replica on rename_settings_field

### DIFF
--- a/lib/realtime/api.ex
+++ b/lib/realtime/api.ex
@@ -186,12 +186,9 @@ defmodule Realtime.Api do
     |> repo.preload(:extensions)
   end
 
-  def list_extensions(type \\ "postgres_cdc_rls") do
-    from(e in Extensions,
-      where: e.type == ^type,
-      select: e
-    )
-    |> Replica.replica().all()
+  defp list_extensions(type \\ "postgres_cdc_rls") do
+    from(e in Extensions, where: e.type == ^type, select: e)
+    |> Repo.all()
   end
 
   def rename_settings_field(from, to) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.46.3",
+      version: "2.46.4",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/api_test.exs
+++ b/test/realtime/api_test.exs
@@ -236,10 +236,6 @@ defmodule Realtime.ApiTest do
     end
   end
 
-  test "list_extensions/1 ", %{tenants: tenants} do
-    assert length(Api.list_extensions()) == length(tenants)
-  end
-
   describe "preload_counters/1" do
     test "preloads counters for a given tenant ", %{tenants: [tenant | _]} do
       tenant = Repo.reload!(tenant)


### PR DESCRIPTION
`Api.rename_settings_field` was using a replica to list extensions while issuing `Repo.update` with primary. This was troublesome while running migrations from scratch and causing a flaky test:

```
3) test list_extensions/1  (Realtime.ApiTest)
Error:      test/realtime/api_test.exs:239
     ** (Postgrex.Error) ERROR 0A000 (feature_not_supported) cached plan must not change result type
     code: assert length(Api.list_extensions()) == length(tenants)
     stacktrace:
       (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1054: Ecto.Adapters.SQL.raise_sql_call_error/1
       (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:952: Ecto.Adapters.SQL.execute/6
       (ecto 3.11.2) lib/ecto/repo/queryable.ex:232: Ecto.Repo.Queryable.execute/4
       (ecto 3.11.2) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
       test/realtime/api_test.exs:240: (test)
```