### PR TITLE
fix: Fix GenRpc to not try to connect to nodes that are not alive

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.47.0",
+      version: "2.47.1",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/gen_rpc_test.exs
+++ b/test/realtime/gen_rpc_test.exs
@@ -172,6 +172,18 @@ defmodule Realtime.GenRpcTest do
                         mechanism: :gen_rpc
                       }}
     end
+
+    test "bad node" do
+      node = :"unknown@1.1.1.1"
+
+      log =
+        capture_log(fn ->
+          assert GenRpc.call(node, Map, :fetch, [%{a: 1}, :a], tenant_id: 123) == {:error, :rpc_error, :badnode}
+        end)
+
+      assert log =~
+               ~r/project=123 external_id=123 \[error\] ErrorOnRpcCall: %{+error: :badnode, mod: Map, func: :fetch, target: :"#{node}"/
+    end
   end
 
   describe "multicast/4" do


### PR DESCRIPTION
## What kind of change does this PR introduce?

We don't want to try to establish connections to nodes that are not part of `Node.list()`. They most likely went down and will not be communicable. We keep our cluster connected through other means: libcluster.


## Additional context

Add any other context or screenshots.
