### PR TITLE
fix: enable presence on track message

### DIFF
--- a/lib/realtime/api.ex
+++ b/lib/realtime/api.ex
@@ -187,8 +187,9 @@ defmodule Realtime.Api do
   end
 
   defp list_extensions(type) do
-    from(e in Extensions, where: e.type == ^type, select: e)
-    |> Repo.all()
+    query = from(e in Extensions, where: e.type == ^type, select: e)
+
+    Repo.all(query)
   end
 
   def rename_settings_field(from, to) do

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -376,7 +376,7 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   def handle_in("presence", payload, %{assigns: %{private?: false}} = socket) do
-    with {:ok, socket} <- PresenceHandler.handle(payload, socket) do
+    with {:ok, socket} <- PresenceHandler.handle(payload, nil, socket) do
       {:reply, :ok, socket}
     else
       {:error, :rate_limit_exceeded} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.47.1",
+      version: "2.47.2",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

currently the user would need to have enabled from the beginning of the channel. this will enable users to enable presence later in the flow by sending a track message which will enable presence messages for them

