### PR TITLE
fix: handle wal bloat

### DIFF
--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -144,8 +144,8 @@ defmodule Realtime.Tenants.ReplicationConnection do
         port: connection_opts.port,
         socket_options: connection_opts.socket_options,
         ssl: connection_opts.ssl,
-        backoff_type: :stop,
         sync_connect: true,
+        auto_reconnect: true,
         parameters: [application_name: "realtime_replication_connection"]
       ]
 

--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -145,7 +145,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
         socket_options: connection_opts.socket_options,
         ssl: connection_opts.ssl,
         sync_connect: true,
-        auto_reconnect: true,
+        auto_reconnect: false,
         parameters: [application_name: "realtime_replication_connection"]
       ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.48.1",
+      version: "2.48.2",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -2434,7 +2434,7 @@ defmodule Realtime.Integration.RtChannelTest do
             {:ok, bloat_conn} = Database.connect(tenant, "realtime_bloat", :stop)
 
             Postgrex.transaction(bloat_conn, fn conn ->
-              Postgrex.query(conn, "INSERT INTO wal_test SELECT generate_series(1, 100000), repeat('x', 2000)", [])
+              Postgrex.query(conn, "INSERT INTO wal_test SELECT generate_series(1, 1000), repeat('x', 200)", [])
               {:error, "test"}
             end)
 

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -2454,7 +2454,7 @@ defmodule Realtime.Integration.RtChannelTest do
       # Does it recover?
       assert Connect.ready?(tenant.external_id)
       {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-      Process.sleep(200)
+      Process.sleep(1000)
       %{rows: [[new_db_pid]]} = Postgrex.query!(db_conn, active_slot_query, [])
 
       assert new_db_pid != original_db_pid

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -366,7 +366,7 @@ defmodule Realtime.Tenants.ConnectTest do
 
       assert_receive {:DOWN, _, :process, ^replication_connection_pid, _}
 
-      Process.sleep(500)
+      Process.sleep(1500)
       new_replication_connection_pid = ReplicationConnection.whereis(tenant.external_id)
 
       assert replication_connection_pid != new_replication_connection_pid
@@ -385,7 +385,7 @@ defmodule Realtime.Tenants.ConnectTest do
       Process.exit(replication_connection_pid, :kill)
       assert_receive {:DOWN, _, :process, ^replication_connection_pid, _}
 
-      Process.sleep(500)
+      Process.sleep(1500)
       new_replication_connection_pid = ReplicationConnection.whereis(tenant.external_id)
 
       assert replication_connection_pid != new_replication_connection_pid

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -267,7 +267,13 @@ defmodule Containers do
         @image,
         "postgres",
         "-c",
-        "config_file=/etc/postgresql/postgresql.conf"
+        "config_file=/etc/postgresql/postgresql.conf",
+        "-c",
+        "wal_keep_size=32MB",
+        "-c",
+        "max_wal_size=32MB",
+        "-c",
+        "max_slot_wal_keep_size=32MB"
       ])
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Verify that replication connection is able to reconnect when faced with WAL bloat issues

