### PR TITLE
fix: set cowboy active_n=100 as cowboy 2.12.0

### DIFF
--- a/lib/realtime_web/endpoint.ex
+++ b/lib/realtime_web/endpoint.ex
@@ -16,6 +16,12 @@ defmodule RealtimeWeb.Endpoint do
       connect_info: [:peer_data, :uri, :x_headers],
       fullsweep_after: 20,
       max_frame_size: 8_000_000,
+      # https://github.com/ninenines/cowboy/blob/24d32de931a0c985ff7939077463fc8be939f0e9/doc/src/manual/cowboy_websocket.asciidoc#L228
+      # active_n: The number of packets Cowboy will request from the socket at once.
+      # This can be used to tweak the performance of the server. Higher values reduce
+      # the number of times Cowboy need to request more packets from the port driver at
+      # the expense of potentially higher memory being used.
+      active_n: 100,
       serializer: [
         {Phoenix.Socket.V1.JSONSerializer, "~> 1.0.0"},
         {Phoenix.Socket.V2.JSONSerializer, "~> 2.0.0"}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.47.2",
+      version: "2.47.3",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
cowboy 2.13.0 sets the default active_n to `1`
cowboy 2.12.0 had this set to 100 before.

https://github.com/ninenines/cowboy/commit/49be0f57cf5ce66178dc24b9c08c835888d1ce0e#diff-6656c67539ca8fa7792bbd977076d4ae369080fb85d6fe3449fd954116c2e625L56

Tested locally:

```
iex(pink@127.0.0.1)1> :sys.get_state(pid(0, 949, 0))
{{:state, #PID<0.676.0>, RealtimeWeb.Endpoint.HTTP, #Port<0.30>, :ranch_tcp,
  %{
    compress: false,
    max_frame_size: 8000000,
    active_n: 100,
    dynamic_buffer: false,
    idle_timeout: 60000
  }, true, WebSockAdapter.CowboyAdapter, :undefined,
  #Reference<0.558699531.1213726721.229254>, 0,
  {:tcp, :tcp_closed, :tcp_error, :tcp_passive}, false, 0, false, :undefined,
  "", 0, true, %{},
  %{
```

Can see the active_n being configured properly