### PR TITLE
fix: provide error_code metadata on RealtimeChannel.Logging

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -47,7 +47,7 @@ config :logger,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id, :project, :external_id, :application_name, :sub, :iss, :exp]
+  metadata: [:error_code, :request_id, :project, :external_id, :application_name, :sub, :iss, :exp]
 
 config :opentelemetry,
   span_processor: :simple,

--- a/lib/realtime_web/channels/realtime_channel/logging.ex
+++ b/lib/realtime_web/channels/realtime_channel/logging.ex
@@ -21,7 +21,7 @@ defmodule RealtimeWeb.RealtimeChannel.Logging do
   def log_error(socket, code, msg) do
     msg = build_msg(code, msg)
     emit_system_error(:error, code)
-    log(socket, :error, msg)
+    log(socket, :error, code, msg)
     {:error, %{reason: msg}}
   end
 
@@ -32,7 +32,7 @@ defmodule RealtimeWeb.RealtimeChannel.Logging do
           {:error, %{reason: binary}}
   def log_warning(socket, code, msg) do
     msg = build_msg(code, msg)
-    log(socket, :warning, msg)
+    log(socket, :warning, code, msg)
     {:error, %{reason: msg}}
   end
 
@@ -59,16 +59,16 @@ defmodule RealtimeWeb.RealtimeChannel.Logging do
     if code, do: "#{code}: #{msg}", else: msg
   end
 
-  defp log(%{assigns: %{tenant: tenant, access_token: access_token}}, level, msg) do
+  defp log(%{assigns: %{tenant: tenant, access_token: access_token}}, level, code, msg) do
     Logger.metadata(external_id: tenant, project: tenant)
     if level in [:error, :warning], do: update_metadata_with_token_claims(access_token)
-    Logger.log(level, msg)
+    Logger.log(level, msg, error_code: code)
   end
 
   defp maybe_log(%{assigns: %{log_level: log_level}} = socket, level, code, msg) do
     msg = build_msg(code, msg)
     emit_system_error(level, code)
-    if Logger.compare_levels(log_level, level) != :gt, do: log(socket, level, msg)
+    if Logger.compare_levels(log_level, level) != :gt, do: log(socket, level, code, msg)
     if level in [:error, :warning], do: {:error, %{reason: msg}}, else: :ok
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.47.3",
+      version: "2.47.4",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/channels/realtime_channel/logging_test.exs
+++ b/test/realtime_web/channels/realtime_channel/logging_test.exs
@@ -37,6 +37,7 @@ defmodule RealtimeWeb.RealtimeChannel.LoggingTest do
       assert log =~ "sub=#{sub}"
       assert log =~ "exp=#{exp}"
       assert log =~ "iss=#{iss}"
+      assert log =~ "error_code=TestError"
     end
   end
 
@@ -57,6 +58,7 @@ defmodule RealtimeWeb.RealtimeChannel.LoggingTest do
       assert log =~ "sub=#{sub}"
       assert log =~ "exp=#{exp}"
       assert log =~ "iss=#{iss}"
+      assert log =~ "error_code=TestWarning"
     end
   end
 
@@ -67,10 +69,14 @@ defmodule RealtimeWeb.RealtimeChannel.LoggingTest do
       for log_level <- log_levels do
         socket = %{assigns: %{log_level: log_level, tenant: random_string(), access_token: "test_token"}}
 
-        assert capture_log(fn ->
-                 assert Logging.maybe_log_error(socket, "TestCode", "test message") ==
-                          {:error, %{reason: "TestCode: test message"}}
-               end) =~ "TestCode: test message"
+        log =
+          capture_log(fn ->
+            assert Logging.maybe_log_error(socket, "TestCode", "test message") ==
+                     {:error, %{reason: "TestCode: test message"}}
+          end)
+
+        assert log =~ "TestCode: test message"
+        assert log =~ "error_code=TestCode"
 
         assert capture_log(fn ->
                  assert Logging.maybe_log_error(socket, "TestCode", %{a: "b"}) ==
@@ -103,11 +109,14 @@ defmodule RealtimeWeb.RealtimeChannel.LoggingTest do
       for log_level <- log_levels do
         socket = %{assigns: %{log_level: log_level, tenant: random_string(), access_token: "test_token"}}
 
-        assert capture_log(fn ->
-                 assert Logging.maybe_log_warning(socket, "TestCode", "test message") ==
-                          {:error, %{reason: "TestCode: test message"}}
-               end) =~
-                 "TestCode: test message"
+        log =
+          capture_log(fn ->
+            assert Logging.maybe_log_warning(socket, "TestCode", "test message") ==
+                     {:error, %{reason: "TestCode: test message"}}
+          end)
+
+        assert log =~ "TestCode: test message"
+        assert log =~ "error_code=TestCode"
 
         assert capture_log(fn ->
                  assert Logging.maybe_log_warning(socket, "TestCode", %{a: "b"}) ==


### PR DESCRIPTION
We should log the error_code just like we do on `Realtime.Logs.log_error`

https://github.com/supabase/realtime/blob/main/lib/realtime/logs.ex#L23