### PR TITLE
feat: disable UTF8 validation on websocket frames

### DIFF
--- a/lib/realtime_web/endpoint.ex
+++ b/lib/realtime_web/endpoint.ex
@@ -22,6 +22,9 @@ defmodule RealtimeWeb.Endpoint do
       # the number of times Cowboy need to request more packets from the port driver at
       # the expense of potentially higher memory being used.
       active_n: 100,
+      # Skip validating UTF8 for faster frame processing.
+      # Currently all text frames as handled only with JSON which already requires UTF-8
+      validate_utf8: false,
       serializer: [
         {Phoenix.Socket.V1.JSONSerializer, "~> 1.0.0"},
         {Phoenix.Socket.V2.JSONSerializer, "~> 2.0.0"}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.47.4",
+      version: "2.48.0",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ddisable UTF8 validation on websocket frames.

Currently all text frames as handled only with JSON which already requires UTF-8


## What is the current behavior?

All text frames are validated to be UTF-8 prior to be handled by Phoenix. That's part of the protocol specification.

## What is the new behavior?

Skip such validation.

## Additional context

Add any other context or screenshots.
