### PR TITLE
fix: ensure message id doesn't raise on non-map payloads

### DIFF
--- a/lib/realtime_web/channels/realtime_channel/message_dispatcher.ex
+++ b/lib/realtime_web/channels/realtime_channel/message_dispatcher.ex
@@ -25,7 +25,7 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
     # This reduce caches the serialization and bypasses the channel process going straight to the
     # transport process
 
-    message_id = msg.payload["meta"]["id"]
+    message_id = message_id(msg.payload)
 
     # Credo doesn't like that we don't use the result aggregation
     _ =
@@ -61,6 +61,9 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
 
     :ok
   end
+
+  defp message_id(%{"meta" => %{"id" => id}}), do: id
+  defp message_id(_), do: nil
 
   defp already_replayed?(nil, _replayed_message_ids), do: false
   defp already_replayed?(message_id, replayed_message_ids), do: MapSet.member?(replayed_message_ids, message_id)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.50.0",
+      version: "2.50.1",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

A more defensive approach to fetch the message id from the RealtimeChannel.MessageDispatcher

## What is the current behavior?

It's technically possible to send payload that is not a map/object/hash and it could raise at the MessageDispatcher level

## What is the new behavior?

It will not raise if the `meta` `id` is not available.

## Additional context

Add any other context or screenshots.
