### PR TITLE
fix: create/drop partitions when health check runs

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -98,9 +98,9 @@ defmodule Realtime.Tenants do
 
       connected_cluster when is_integer(connected_cluster) ->
         tenant = Cache.get_tenant_by_external_id(external_id)
-        {:ok, db_conn} = Database.connect(tenant, "realtime_health_check")
-        Process.alive?(db_conn) && GenServer.stop(db_conn)
         Migrations.run_migrations(tenant)
+
+        Realtime.Tenants.Janitor.MaintenanceTask.run(external_id)
 
         {:ok,
          %{

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.50.0",
+      version: "2.50.1",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ensure that partitions are created/dropped when tenant health check runs.

## What is the current behavior?

We only ensure that migrations ran.

## What is the new behavior?

We also create/drop messages partitions.

## Additional context

Add any other context or screenshots.
