### PR TITLE
fix: rate limit Connect.lookup_or_start_connection on error only

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -328,18 +328,18 @@ defmodule Realtime.Tenants do
     %RateCounter.Args{id: {:channel, :authorization_errors, external_id}, opts: opts}
   end
 
-  @connect_per_second_default 10
+  @connect_errors_per_second_default 10
   @doc "RateCounter arguments for counting connect per second."
-  @spec connect_per_second_rate(Tenant.t() | String.t()) :: RateCounter.Args.t()
-  def connect_per_second_rate(%Tenant{external_id: external_id}) do
-    connect_per_second_rate(external_id)
+  @spec connect_errors_per_second_rate(Tenant.t() | String.t()) :: RateCounter.Args.t()
+  def connect_errors_per_second_rate(%Tenant{external_id: external_id}) do
+    connect_errors_per_second_rate(external_id)
   end
 
-  def connect_per_second_rate(tenant_id) do
+  def connect_errors_per_second_rate(tenant_id) do
     opts = [
       max_bucket_len: 10,
       limit: [
-        value: @connect_per_second_default,
+        value: @connect_errors_per_second_default,
         measurement: :sum,
         log_fn: fn ->
           Logger.critical(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.51.6",
+      version: "2.51.7",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -272,7 +272,6 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      connect_events_key = Tenants.connect_per_second_rate(tenant).id
       expect(TenantBroadcaster, :pubsub_broadcast, 5, fn _, _, _, _ -> :ok end)
 
       messages_to_send =
@@ -291,10 +290,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       GenCounter
       |> expect(:add, fn ^request_events_key -> :ok end)
-      |> expect(:add, length(messages), fn
-        ^broadcast_events_key -> :ok
-        ^connect_events_key -> :ok
-      end)
+      |> expect(:add, length(messages), fn ^broadcast_events_key -> :ok end)
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
@@ -330,7 +326,6 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      connect_events_key = Tenants.connect_per_second_rate(tenant).id
       expect(TenantBroadcaster, :pubsub_broadcast, 6, fn _, _, _, _ -> :ok end)
 
       channels =
@@ -359,10 +354,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       GenCounter
       |> expect(:add, fn ^request_events_key -> :ok end)
-      |> expect(:add, length(messages), fn
-        ^broadcast_events_key -> :ok
-        ^connect_events_key -> :ok
-      end)
+      |> expect(:add, length(messages), fn ^broadcast_events_key -> :ok end)
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
@@ -416,7 +408,6 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      connect_events_key = Tenants.connect_per_second_rate(tenant).id
       expect(TenantBroadcaster, :pubsub_broadcast, 5, fn _, _, _, _ -> :ok end)
 
       messages_to_send =
@@ -438,7 +429,6 @@ defmodule RealtimeWeb.BroadcastControllerTest do
       GenCounter
       |> expect(:add, fn ^request_events_key -> :ok end)
       # remove the one message that won't be broadcasted for this user
-      |> expect(:add, 1, fn ^connect_events_key -> :ok end)
       |> expect(:add, length(messages) - 1, fn ^broadcast_events_key -> :ok end)
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})


### PR DESCRIPTION
## What kind of change does this PR introduce?

We should only increment when there is an error connecting. 

I've renamed the rate counter to explicitly say that it's just for connection errors.

## Additional context

Add any other context or screenshots.
