### PR TITLE
fix: collect global metrics without tenant tagging

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -158,6 +158,12 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           tags: [:tenant]
         ),
         sum(
+          [:realtime, :channel, :global, :events],
+          event_name: [:realtime, :rate_counter, :channel, :events],
+          measurement: :sum,
+          description: "Global sum of messages sent on a Realtime Channel."
+        ),
+        sum(
           [:realtime, :channel, :presence_events],
           event_name: [:realtime, :rate_counter, :channel, :presence_events],
           measurement: :sum,
@@ -165,11 +171,23 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           tags: [:tenant]
         ),
         sum(
+          [:realtime, :channel, :global, :presence_events],
+          event_name: [:realtime, :rate_counter, :channel, :presence_events],
+          measurement: :sum,
+          description: "Global sum of presence messages sent on a Realtime Channel."
+        ),
+        sum(
           [:realtime, :channel, :db_events],
           event_name: [:realtime, :rate_counter, :channel, :db_events],
           measurement: :sum,
           description: "Sum of db messages sent on a Realtime Channel.",
           tags: [:tenant]
+        ),
+        sum(
+          [:realtime, :channel, :global, :db_events],
+          event_name: [:realtime, :rate_counter, :channel, :db_events],
+          measurement: :sum,
+          description: "Global sum of db messages sent on a Realtime Channel."
         ),
         sum(
           [:realtime, :channel, :joins],

--- a/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenants.ex
@@ -21,6 +21,15 @@ defmodule Realtime.PromEx.Plugins.Tenants do
         unit: {:microsecond, :millisecond},
         tags: [:success, :tenant, :mechanism],
         reporter_options: [buckets: [10, 250, 5000, 15_000]]
+      ),
+      distribution(
+        [:realtime, :global, :rpc],
+        event_name: [:realtime, :rpc],
+        description: "Global Latency of rpc calls",
+        measurement: :latency,
+        unit: {:microsecond, :millisecond},
+        tags: [:success, :mechanism],
+        reporter_options: [buckets: [10, 250, 5000, 15_000]]
       )
     ])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.51.14",
+      version: "2.51.15",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -129,6 +129,17 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
       assert metric_value(pattern) == metric_value + 1
     end
 
+    test "global event exists after counter added", %{tenant: %{external_id: external_id}} do
+      pattern =
+        ~r/realtime_channel_global_events\s(?<number>\d+)/
+
+      metric_value = metric_value(pattern)
+      FakeUserCounter.fake_event(external_id)
+
+      Process.sleep(200)
+      assert metric_value(pattern) == metric_value + 1
+    end
+
     test "db_event exists after counter added", %{tenant: %{external_id: external_id}} do
       pattern =
         ~r/realtime_channel_db_events{tenant="#{external_id}"}\s(?<number>\d+)/
@@ -139,9 +150,29 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
       assert metric_value(pattern) == metric_value + 1
     end
 
+    test "global db_event exists after counter added", %{tenant: %{external_id: external_id}} do
+      pattern =
+        ~r/realtime_channel_global_db_events\s(?<number>\d+)/
+
+      metric_value = metric_value(pattern)
+      FakeUserCounter.fake_db_event(external_id)
+      Process.sleep(200)
+      assert metric_value(pattern) == metric_value + 1
+    end
+
     test "presence_event exists after counter added", %{tenant: %{external_id: external_id}} do
       pattern =
         ~r/realtime_channel_presence_events{tenant="#{external_id}"}\s(?<number>\d+)/
+
+      metric_value = metric_value(pattern)
+      FakeUserCounter.fake_presence_event(external_id)
+      Process.sleep(200)
+      assert metric_value(pattern) == metric_value + 1
+    end
+
+    test "global presence_event exists after counter added", %{tenant: %{external_id: external_id}} do
+      pattern =
+        ~r/realtime_channel_global_presence_events\s(?<number>\d+)/
 
       metric_value = metric_value(pattern)
       FakeUserCounter.fake_presence_event(external_id)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Collect global metrics without tagging. Easier to aggregate as it's a single metric instead of per tenant

## Additional context

Add any other context or screenshots.
