### PR TITLE
feat: presence payload size

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -183,7 +183,7 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
         change <- columns |> Enum.zip(row) |> generate_record() |> List.wrap() do
       topic = "realtime:postgres:" <> tenant_id
 
-      RealtimeWeb.TenantBroadcaster.pubsub_broadcast(tenant_id, topic, change, MessageDispatcher)
+      RealtimeWeb.TenantBroadcaster.pubsub_broadcast(tenant_id, topic, change, MessageDispatcher, :postgres_changes)
     end
 
     {:ok, rows_count}

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -36,7 +36,7 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           event_name: [:realtime, :tenants, :payload, :size],
           measurement: :size,
           description: "Tenant payload size",
-          tags: [:tenant],
+          tags: [:tenant, :message_type],
           unit: :byte,
           reporter_options: [
             buckets: [100, 250, 500, 1000, 2000, 3000, 5000, 10_000, 25_000]
@@ -47,6 +47,7 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           event_name: [:realtime, :tenants, :payload, :size],
           measurement: :size,
           description: "Payload size",
+          tags: [:message_type],
           unit: :byte,
           reporter_options: [
             buckets: [100, 250, 500, 1000, 2000, 3000, 5000, 10_000, 25_000]

--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -129,7 +129,7 @@ defmodule Realtime.Tenants.BatchBroadcast do
     broadcast = %Phoenix.Socket.Broadcast{topic: message.topic, event: @event_type, payload: payload}
 
     GenCounter.add(events_per_second_rate.id)
-    TenantBroadcaster.pubsub_broadcast(tenant.external_id, tenant_topic, broadcast, RealtimeChannel.MessageDispatcher)
+    TenantBroadcaster.pubsub_broadcast(tenant.external_id, tenant_topic, broadcast, RealtimeChannel.MessageDispatcher, :broadcast)
   end
 
   defp permissions_for_message(_, nil, _), do: nil

--- a/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
@@ -76,14 +76,21 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
     broadcast = %Phoenix.Socket.Broadcast{topic: tenant_topic, event: @event_type, payload: payload}
 
     if self_broadcast do
-      TenantBroadcaster.pubsub_broadcast(tenant_id, tenant_topic, broadcast, RealtimeChannel.MessageDispatcher)
+      TenantBroadcaster.pubsub_broadcast(
+        tenant_id,
+        tenant_topic,
+        broadcast,
+        RealtimeChannel.MessageDispatcher,
+        :broadcast
+      )
     else
       TenantBroadcaster.pubsub_broadcast_from(
         tenant_id,
         self(),
         tenant_topic,
         broadcast,
-        RealtimeChannel.MessageDispatcher
+        RealtimeChannel.MessageDispatcher,
+        :broadcast
       )
     end
   end

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -109,6 +109,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
 
     %{assigns: %{presence_key: presence_key, tenant_topic: tenant_topic}} = socket
     payload = Map.get(payload, "payload", %{})
+    RealtimeWeb.TenantBroadcaster.collect_payload_size(socket.assigns.tenant, payload, :presence)
 
     with :ok <- limit_presence_event(socket),
          {:ok, _} <- Presence.track(self(), tenant_topic, presence_key, payload) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.51.15",
+      version: "2.52.0",
       elixir: "~> 1.17.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -262,18 +262,18 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
       external_id = context.tenant.external_id
 
       pattern =
-        ~r/realtime_tenants_payload_size_count{tenant="#{external_id}"}\s(?<number>\d+)/
+        ~r/realtime_tenants_payload_size_count{message_type=\"presence\",tenant="#{external_id}"}\s(?<number>\d+)/
 
       metric_value = metric_value(pattern)
 
       message = %{topic: "a topic", event: "an event", payload: ["a", %{"b" => "c"}, 1, 23]}
-      RealtimeWeb.TenantBroadcaster.pubsub_broadcast(external_id, "a topic", message, Phoenix.PubSub)
+      RealtimeWeb.TenantBroadcaster.pubsub_broadcast(external_id, "a topic", message, Phoenix.PubSub, :presence)
 
       Process.sleep(200)
       assert metric_value(pattern) == metric_value + 1
 
       bucket_pattern =
-        ~r/realtime_tenants_payload_size_bucket{tenant="#{external_id}",le="100"}\s(?<number>\d+)/
+        ~r/realtime_tenants_payload_size_bucket{message_type=\"presence\",tenant="#{external_id}",le="100"}\s(?<number>\d+)/
 
       assert metric_value(bucket_pattern) > 0
     end
@@ -281,17 +281,17 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
     test "global metric payload size", context do
       external_id = context.tenant.external_id
 
-      pattern = ~r/realtime_payload_size_count\s(?<number>\d+)/
+      pattern = ~r/realtime_payload_size_count{message_type=\"broadcast\"}\s(?<number>\d+)/
 
       metric_value = metric_value(pattern)
 
       message = %{topic: "a topic", event: "an event", payload: ["a", %{"b" => "c"}, 1, 23]}
-      RealtimeWeb.TenantBroadcaster.pubsub_broadcast(external_id, "a topic", message, Phoenix.PubSub)
+      RealtimeWeb.TenantBroadcaster.pubsub_broadcast(external_id, "a topic", message, Phoenix.PubSub, :broadcast)
 
       Process.sleep(200)
       assert metric_value(pattern) == metric_value + 1
 
-      bucket_pattern = ~r/realtime_payload_size_bucket{le="100"}\s(?<number>\d+)/
+      bucket_pattern = ~r/realtime_payload_size_bucket{message_type=\"broadcast\",le="100"}\s(?<number>\d+)/
 
       assert metric_value(bucket_pattern) > 0
     end

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -272,7 +272,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      expect(TenantBroadcaster, :pubsub_broadcast, 5, fn _, _, _, _ -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, 5, fn _, _, _, _, _ -> :ok end)
 
       messages_to_send =
         Stream.repeatedly(fn -> generate_message_with_policies(db_conn, tenant) end)
@@ -294,7 +294,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
-      broadcast_calls = calls(&TenantBroadcaster.pubsub_broadcast/4)
+      broadcast_calls = calls(&TenantBroadcaster.pubsub_broadcast/5)
 
       Enum.each(messages_to_send, fn %{topic: topic} ->
         broadcast_topic = Tenants.tenant_topic(tenant, topic, false)
@@ -326,7 +326,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      expect(TenantBroadcaster, :pubsub_broadcast, 6, fn _, _, _, _ -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, 6, fn _, _, _, _, _ -> :ok end)
 
       channels =
         Stream.repeatedly(fn -> generate_message_with_policies(db_conn, tenant) end)
@@ -358,7 +358,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
-      broadcast_calls = calls(&TenantBroadcaster.pubsub_broadcast/4)
+      broadcast_calls = calls(&TenantBroadcaster.pubsub_broadcast/5)
 
       Enum.each(channels, fn %{topic: topic} ->
         broadcast_topic = Tenants.tenant_topic(tenant, topic, false)
@@ -408,7 +408,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     } do
       request_events_key = Tenants.requests_per_second_key(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
-      expect(TenantBroadcaster, :pubsub_broadcast, 5, fn _, _, _, _ -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, 5, fn _, _, _, _, _ -> :ok end)
 
       messages_to_send =
         Stream.repeatedly(fn -> generate_message_with_policies(db_conn, tenant) end)
@@ -433,7 +433,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       conn = post(conn, Routes.broadcast_path(conn, :broadcast), %{"messages" => messages})
 
-      broadcast_calls = calls(&TenantBroadcaster.pubsub_broadcast/4)
+      broadcast_calls = calls(&TenantBroadcaster.pubsub_broadcast/5)
 
       Enum.each(messages_to_send, fn %{topic: topic} ->
         broadcast_topic = Tenants.tenant_topic(tenant, topic, false)
@@ -462,7 +462,7 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     @tag role: "anon"
     test "user without permission won't broadcast", %{conn: conn, db_conn: db_conn, tenant: tenant} do
       request_events_key = Tenants.requests_per_second_key(tenant)
-      reject(&TenantBroadcaster.pubsub_broadcast/4)
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
 
       messages =
         Stream.repeatedly(fn -> generate_message_with_policies(db_conn, tenant) end)

--- a/test/realtime_web/tenant_broadcaster_test.exs
+++ b/test/realtime_web/tenant_broadcaster_test.exs
@@ -60,7 +60,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
 
       test "pubsub_broadcast", %{node: node} do
         message = %Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
-        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub)
+        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -71,13 +71,13 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 114},
-          %{tenant: "realtime-dev"}
+          %{tenant: "realtime-dev", message_type: :broadcast}
         }
       end
 
       test "pubsub_broadcast list payload", %{node: node} do
         message = %Broadcast{topic: @topic, event: "an event", payload: ["a", %{"b" => "c"}, 1, 23]}
-        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub)
+        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -88,13 +88,13 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 130},
-          %{tenant: "realtime-dev"}
+          %{tenant: "realtime-dev", message_type: :broadcast}
         }
       end
 
       test "pubsub_broadcast string payload", %{node: node} do
         message = %Broadcast{topic: @topic, event: "an event", payload: "some text payload"}
-        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub)
+        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -105,7 +105,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 119},
-          %{tenant: "realtime-dev"}
+          %{tenant: "realtime-dev", message_type: :broadcast}
         }
       end
     end
@@ -131,7 +131,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
 
         message = %Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
 
-        TenantBroadcaster.pubsub_broadcast_from("realtime-dev", self(), @topic, message, Phoenix.PubSub)
+        TenantBroadcaster.pubsub_broadcast_from("realtime-dev", self(), @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive {:other_process, ^message}
 
@@ -142,7 +142,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 114},
-          %{tenant: "realtime-dev"}
+          %{tenant: "realtime-dev", message_type: :broadcast}
         }
 
         # This process does not receive the message


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Start tagging the payload size metrics with `message_type`. message_type can be `presence`, `broadcast` or `postgres_changes`
* Collect the presence `track` payload size

## Additional context

Add any other context or screenshots.
