### PR TITLE
fix: use better key for node selection on regional broadcasting

### DIFF
--- a/lib/realtime/gen_rpc/pub_sub.ex
+++ b/lib/realtime/gen_rpc/pub_sub.ex
@@ -56,7 +56,7 @@ defmodule Realtime.GenRpcPubSub do
       GenRpc.abcast(other_nodes, worker, Worker.forward_to_local(topic, message, dispatcher), key: worker)
 
       # send a message to a node in each region to forward to the rest of the region
-      other_region_nodes = nodes_from_other_regions(my_region, worker)
+      other_region_nodes = nodes_from_other_regions(my_region, self())
 
       GenRpc.abcast(other_region_nodes, worker, Worker.forward_to_region(topic, message, dispatcher), key: worker)
     else

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.0",
+      version: "2.56.1",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Using "worker" is not great because we can have a single worker if `broacast_pool_size=1` and only one specific node will be selected.

Using `self()` will ensure that the selected node will vary as self() has a high cardinality
