### PR TITLE
fix: change CdcRls.WorkerSupervisor to be temporary instead of transient

### DIFF
--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -99,7 +99,7 @@ defmodule Extensions.PostgresCdcRls do
       %{
         id: tenant,
         start: {Rls.WorkerSupervisor, :start_link, [args]},
-        restart: :transient
+        restart: :temporary
       }
     )
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.1",
+      version: "2.56.2",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
RealtimeChannel already reacts to WorkerSupervisor going down to reconnect: https://github.com/supabase/realtime/blob/53c98c61d13db94e517663c355cb6dfbb7325420/lib/realtime_web/channels/realtime_channel.ex#L256-L262

Having it transient can bring down other unrelated WorkerSupervisor in some cases