### PR TITLE
fix: set realtime_subscription_{manager,checker} to 1

### DIFF
--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -246,9 +246,9 @@ defmodule Realtime.Database do
   @spec pool_size_by_application_name(binary(), map() | nil) :: non_neg_integer()
   def pool_size_by_application_name(application_name, settings) do
     case application_name do
-      "realtime_subscription_manager" -> settings["subcriber_pool_size"] || 1
+      "realtime_subscription_manager" -> 1
       "realtime_subscription_manager_pub" -> settings["subs_pool_size"] || 1
-      "realtime_subscription_checker" -> settings["subs_pool_size"] || 1
+      "realtime_subscription_checker" -> 1
       "realtime_connect" -> settings["db_pool"] || 1
       "realtime_health_check" -> 1
       "realtime_janitor" -> 1

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.56.3",
+      version: "2.56.4",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -45,8 +45,7 @@ defmodule Realtime.DatabaseTest do
 
     # Connection limit for docker tenant db is 100
     @tag db_pool: 50,
-         subs_pool_size: 21,
-         subcriber_pool_size: 33
+         subs_pool_size: 73
     test "restricts connection if tenant database cannot receive more connections based on tenant pool",
          %{tenant: tenant} do
       assert capture_log(fn ->


### PR DESCRIPTION
They essentially send queries/transactions to the db reacting to a GenServer message so it can't do more than 1 thing at at time
