### PR TITLE
fix: invalidate cache on any Tenant update

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.57.5",
+      version: "2.57.6",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/api_test.exs
+++ b/test/realtime/api_test.exs
@@ -214,7 +214,7 @@ defmodule Realtime.ApiTest do
     end
 
     test "valid data and no changes to tenant will not refresh cache", %{tenant: tenant} do
-      reject(&Realtime.Tenants.Cache.get_tenant_by_external_id/1)
+      reject(&Realtime.Tenants.Cache.distributed_invalidate_tenant_cache/1)
       assert {:ok, %Tenant{}} = Api.update_tenant(tenant, %{name: tenant.name})
     end
   end

--- a/test/realtime/tenants/cache_test.exs
+++ b/test/realtime/tenants/cache_test.exs
@@ -1,11 +1,11 @@
 defmodule Realtime.Tenants.CacheTest do
-  alias Realtime.Rpc
   # async: false due to the usage of dev_realtime tenant
   use Realtime.DataCase, async: false
 
   alias Realtime.Api
-  alias Realtime.Tenants.Cache
+  alias Realtime.Rpc
   alias Realtime.Tenants
+  alias Realtime.Tenants.Cache
 
   setup do
     {:ok, tenant: tenant_fixture()}
@@ -15,7 +15,9 @@ defmodule Realtime.Tenants.CacheTest do
     test "tenants cache returns a cached result", %{tenant: tenant} do
       external_id = tenant.external_id
       assert %Api.Tenant{name: "tenant"} = Cache.get_tenant_by_external_id(external_id)
-      Api.update_tenant(tenant, %{name: "new name"})
+
+      changeset = Api.Tenant.changeset(tenant, %{name: "new name"})
+      Repo.update!(changeset)
       assert %Api.Tenant{name: "new name"} = Tenants.get_tenant_by_external_id(external_id)
       assert %Api.Tenant{name: "tenant"} = Cache.get_tenant_by_external_id(external_id)
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Invalidate cache on any Tenant update

## What is the current behavior?

It was invalidating only for a specific set of changes

## What is the new behavior?

Any change triggers cache invalidation

## Additional context

Add any other context or screenshots.
