### PR TITLE
fix: malformed PG changes subscriptions should not retry

### DIFF
--- a/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
+++ b/lib/extensions/postgres_cdc_rls/worker_supervisor.ex
@@ -6,7 +6,7 @@ defmodule Extensions.PostgresCdcRls.WorkerSupervisor do
   alias PostgresCdcRls.ReplicationPoller
   alias PostgresCdcRls.SubscriptionManager
   alias PostgresCdcRls.SubscriptionsChecker
-  alias Realtime.Api
+  alias Realtime.Tenants.Cache
   alias Realtime.PostgresCdc.Exception
 
   def start_link(args) do
@@ -17,7 +17,7 @@ defmodule Extensions.PostgresCdcRls.WorkerSupervisor do
   @impl true
   def init(%{"id" => tenant} = args) when is_binary(tenant) do
     Logger.metadata(external_id: tenant, project: tenant)
-    unless Api.get_tenant_by_external_id(tenant, :primary), do: raise(Exception)
+    unless Cache.get_tenant_by_external_id(tenant), do: raise(Exception)
 
     subscribers_pids_table = :ets.new(__MODULE__, [:public, :bag])
     subscribers_nodes_table = :ets.new(__MODULE__, [:public, :set])

--- a/lib/realtime/postgres_cdc.ex
+++ b/lib/realtime/postgres_cdc.ex
@@ -80,7 +80,7 @@ defmodule Realtime.PostgresCdc do
   end
 
   @callback handle_connect(any()) :: {:ok, any()} | nil
-  @callback handle_after_connect(any(), any(), any()) :: {:ok, any()} | {:error, any()}
+  @callback handle_after_connect(any(), any(), any()) :: {:ok, any()} | {:error, any()} | {:error, any(), any()}
   @callback handle_subscribe(any(), any(), any()) :: :ok
   @callback handle_stop(any(), any()) :: any()
 end

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -297,6 +297,12 @@ defmodule RealtimeWeb.RealtimeChannel do
             push_system_message("postgres_changes", socket, "ok", message, channel_name)
             {:noreply, assign(socket, :pg_sub_ref, nil)}
 
+          {:error, :malformed_subscription_params, error} ->
+            maybe_log_warning(socket, "RealtimeDisabledForConfiguration", error)
+            push_system_message("postgres_changes", socket, "error", error, channel_name)
+            # No point in retrying if the params are invalid
+            {:noreply, assign(socket, :pg_sub_ref, nil)}
+
           error ->
             maybe_log_warning(socket, "RealtimeDisabledForConfiguration", error)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.57.0",
+      version: "2.57.1",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -100,7 +100,7 @@ defmodule Realtime.Integration.RtChannelTest do
                              "channel" => "any",
                              "extension" => "postgres_changes",
                              "message" =>
-                               "{:error, \"Unable to subscribe to changes with given parameters. Please check Realtime is enabled for the given connect parameters: [event: INSERT, schema: public]\"}",
+                               "{:error, \"Unable to subscribe to changes with given parameters. Please check Realtime is enabled for the given connect parameters: [schema: public, table: *, filters: []]\"}",
                              "status" => "error"
                            },
                            ref: nil,

--- a/test/realtime/extensions/cdc_rls/subscription_manager_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscription_manager_test.exs
@@ -145,7 +145,7 @@ defmodule Realtime.Extensions.CdcRls.SubscriptionManagerTest do
 
     pg_change_params = %{
       id: uuid,
-      params: %{"event" => "*", "schema" => "public"},
+      subscription_params: {"public", "*", []},
       claims: %{
         "exp" => System.system_time(:second) + 100_000,
         "iat" => 0,


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Avoid retrying subscription creation for PG changes when params are malformed. They will never succeed.
* Perform subscription param validation before sending the RPC call and start a database transaction.

## What is the current behavior?

Send RPC call which validates subscription params inside a database transaction that gets rollbacked when an error happens. It also retries indefinitely. 
