### PR TITLE
fix: invalid PG changes subscriptions should not retry

### DIFF
--- a/lib/extensions/postgres_cdc_rls/cdc_rls.ex
+++ b/lib/extensions/postgres_cdc_rls/cdc_rls.ex
@@ -49,7 +49,7 @@ defmodule Extensions.PostgresCdcRls do
           {:cont, {:ok, [%{id: params.id, claims: params.claims, subscription_params: subscription_params} | acc]}}
 
         {:error, reason} ->
-          {:halt, {:error, :malformed_subscription_params, reason}}
+          {:halt, {:error, {:malformed_subscription_params, reason}}}
       end
     end)
   end

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -297,7 +297,7 @@ defmodule RealtimeWeb.RealtimeChannel do
             push_system_message("postgres_changes", socket, "ok", message, channel_name)
             {:noreply, assign(socket, :pg_sub_ref, nil)}
 
-          {:error, :malformed_subscription_params, error} ->
+          {:error, {reason, error}} when reason in [:malformed_subscription_params, :subscription_insert_failed] ->
             maybe_log_warning(socket, "RealtimeDisabledForConfiguration", error)
             push_system_message("postgres_changes", socket, "error", error, channel_name)
             # No point in retrying if the params are invalid

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.57.1",
+      version: "2.57.2",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/dev_seeds.exs
+++ b/priv/repo/dev_seeds.exs
@@ -1,5 +1,3 @@
-import Ecto.Adapters.SQL, only: [query!: 3]
-
 alias Realtime.Api.Tenant
 alias Realtime.Database
 alias Realtime.Repo

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -100,7 +100,7 @@ defmodule Realtime.Integration.RtChannelTest do
                              "channel" => "any",
                              "extension" => "postgres_changes",
                              "message" =>
-                               "{:error, \"Unable to subscribe to changes with given parameters. Please check Realtime is enabled for the given connect parameters: [schema: public, table: *, filters: []]\"}",
+                               "Unable to subscribe to changes with given parameters. Please check Realtime is enabled for the given connect parameters: [schema: public, table: *, filters: []]",
                              "status" => "error"
                            },
                            ref: nil,

--- a/test/realtime/gen_rpc_pub_sub_test.exs
+++ b/test/realtime/gen_rpc_pub_sub_test.exs
@@ -107,7 +107,7 @@ defmodule Realtime.GenRpcPubSubTest do
         assert_receive ^message
 
         # Remote nodes received the broadcast
-        assert_receive {:relay, :"us_node@127.0.0.1", ^message}, 1000
+        assert_receive {:relay, :"us_node@127.0.0.1", ^message}, 5000
         assert_receive {:relay, :"ap2_nodeX@127.0.0.1", ^message}, 1000
         assert_receive {:relay, :"ap2_nodeY@127.0.0.1", ^message}, 1000
         refute_receive _any


### PR DESCRIPTION
## What kind of change does this PR introduce?

It will not retry for:

* Table that does not exist
* Realtime publication does not exist
* Column does not exist

And any other unrecoverable* errors when inserting subscriptions. I think it's fair to expect people to reconnect if they changed a table or add a new table.

## What is the current behavior?

We keep retrying ad-infinitum 

## What is the new behavior?

We only retry for temporary errors like RPC timeouts or database timeouts

## Additional context

Add any other context or screenshots.
