### PR TITLE
fix: add tenant_id tag to GenRpc calls from CdcRls

### DIFF
--- a/lib/realtime/postgres_cdc.ex
+++ b/lib/realtime/postgres_cdc.ex
@@ -16,8 +16,8 @@ defmodule Realtime.PostgresCdc do
     apply(module, :handle_connect, [opts])
   end
 
-  def after_connect(module, connect_response, extension, params) do
-    apply(module, :handle_after_connect, [connect_response, extension, params])
+  def after_connect(module, connect_response, extension, params, tenant) do
+    apply(module, :handle_after_connect, [connect_response, extension, params, tenant])
   end
 
   def subscribe(module, pg_change_params, tenant, metadata) do
@@ -80,7 +80,8 @@ defmodule Realtime.PostgresCdc do
   end
 
   @callback handle_connect(any()) :: {:ok, any()} | nil
-  @callback handle_after_connect(any(), any(), any()) :: {:ok, any()} | {:error, any()} | {:error, any(), any()}
+  @callback handle_after_connect(any(), any(), any(), tenant_id :: String.t()) ::
+              {:ok, any()} | {:error, any()} | {:error, any(), any()}
   @callback handle_subscribe(any(), any(), any()) :: :ok
   @callback handle_stop(any(), any()) :: any()
 end

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -290,7 +290,7 @@ defmodule RealtimeWeb.RealtimeChannel do
 
     case PostgresCdc.connect(module, args) do
       {:ok, response} ->
-        case PostgresCdc.after_connect(module, response, postgres_extension, pg_change_params) do
+        case PostgresCdc.after_connect(module, response, postgres_extension, pg_change_params, tenant) do
           {:ok, _response} ->
             message = "Subscribed to PostgreSQL"
             maybe_log_info(socket, message)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.57.4",
+      version: "2.57.5",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
We were not tagging the metric and the logs generated by errors on these calls.
