### PR TITLE
feat: encode PG change payload only once

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.58.2",
+      version: "2.59.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
+++ b/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
@@ -273,7 +273,7 @@ defmodule Realtime.Extensions.CdcRlsTest do
       assert_receive {
         :telemetry,
         [:realtime, :tenants, :payload, :size],
-        %{size: 341},
+        %{size: _},
         %{tenant: "dev_tenant", message_type: :postgres_changes}
       }
     end

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -75,20 +75,18 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       {:ok, conn} = Connect.lookup_or_start_connection(tenant.external_id)
       %{rows: [[id]]} = Postgrex.query!(conn, "insert into test (details) values ('test') returning id", [])
 
-      assert_push "postgres_changes",
-                  %{
-                    data: %Realtime.Adapters.Changes.NewRecord{
-                      table: "test",
-                      type: "INSERT",
-                      record: %{"details" => "test", "id" => ^id},
-                      columns: [%{"name" => "id", "type" => "int4"}, %{"name" => "details", "type" => "text"}],
-                      errors: nil,
-                      schema: "public",
-                      commit_timestamp: _
-                    },
-                    ids: [^sub_id]
-                  },
-                  500
+      assert_push "postgres_changes", %{data: data, ids: [^sub_id]}, 500
+
+      # we encode and decode because the data is a Jason.Fragment
+      assert %{
+               "table" => "test",
+               "type" => "INSERT",
+               "record" => %{"details" => "test", "id" => ^id},
+               "columns" => [%{"name" => "id", "type" => "int4"}, %{"name" => "details", "type" => "text"}],
+               "errors" => nil,
+               "schema" => "public",
+               "commit_timestamp" => _
+             } = Jason.encode!(data) |> Jason.decode!()
 
       refute_receive _any
     end
@@ -127,20 +125,18 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       {:ok, conn} = Connect.lookup_or_start_connection(tenant.external_id)
       %{rows: [[id]]} = Postgrex.query!(conn, "insert into test (details) values ('test') returning id", [])
 
-      assert_push "postgres_changes",
-                  %{
-                    data: %Realtime.Adapters.Changes.NewRecord{
-                      table: "test",
-                      type: "INSERT",
-                      record: %{"details" => "test", "id" => ^id},
-                      columns: [%{"name" => "id", "type" => "int4"}, %{"name" => "details", "type" => "text"}],
-                      errors: nil,
-                      schema: "public",
-                      commit_timestamp: _
-                    },
-                    ids: [4_845_530, ^sub_id]
-                  },
-                  500
+      assert_push "postgres_changes", %{data: data, ids: [4_845_530, ^sub_id]}, 500
+
+      # we encode and decode because the data is a Jason.Fragment
+      assert %{
+               "table" => "test",
+               "type" => "INSERT",
+               "record" => %{"details" => "test", "id" => ^id},
+               "columns" => [%{"name" => "id", "type" => "int4"}, %{"name" => "details", "type" => "text"}],
+               "errors" => nil,
+               "schema" => "public",
+               "commit_timestamp" => _
+             } = Jason.encode!(data) |> Jason.decode!()
 
       refute_receive _any
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use `Jason.Fragment` to encode the change payload only once.

Also set fullsweet_after to 20 for this process as it consumes lots of binaries and it can reach the max heap size limit.

## What is the current behavior?

For each subscription Jason.encode is called with the whole message.

## What is the new behavior?

For each subscription Jason.encode is called using a fragment for the actual change which holds user data and can be quite large.

## Additional context

Add any other context or screenshots.
