### PR TITLE
feat: speed up pg changes poller by not re-encoding user data

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replications.ex
+++ b/lib/extensions/postgres_cdc_rls/replications.ex
@@ -72,7 +72,18 @@ defmodule Extensions.PostgresCdcRls.Replications do
   def list_changes(conn, slot_name, publication, max_changes, max_record_bytes) do
     query(
       conn,
-      "select * from realtime.list_changes($1, $2, $3, $4)",
+      """
+      SELECT wal->>'type' as type,
+             wal->>'schema' as schema,
+             wal->>'table' as table,
+             wal->>'columns' as columns,
+             wal->>'record' as record,
+             wal->>'old_record' as old_record,
+             wal->>'commit_timestamp' as commit_timestamp,
+             subscription_ids,
+             errors
+      FROM realtime.list_changes($1, $2, $3, $4)
+      """,
       [
         publication,
         slot_name,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.59.1",
+      version: "2.60.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

record, old_record and columns coming from walrus query are relayed without decoding and encoding their jsonb representation

## What is the current behavior?

We rebuild record, old_record and columns when encoding the JSON payload

## What is the new behavior?

record, old_record and columns

## Additional context

Add any other context or screenshots.
