### PR TITLE
chore: force RateCounter tick during tests

### DIFF
--- a/test/integration/distributed_realtime_channel_test.exs
+++ b/test/integration/distributed_realtime_channel_test.exs
@@ -12,7 +12,7 @@ defmodule Realtime.Integration.DistributedRealtimeChannelTest do
   setup do
     tenant = Realtime.Api.get_tenant_by_external_id("dev_tenant")
 
-    Realtime.RateCounter.stop(tenant.external_id)
+    RateCounterHelper.stop(tenant.external_id)
 
     Connect.shutdown(tenant.external_id)
     # Sleeping so that syn can forget about this Connect process

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -14,7 +14,6 @@ defmodule Realtime.Integration.RtChannelTest do
   alias Realtime.Api.Tenant
   alias Realtime.Database
   alias Realtime.Integration.WebsocketClient
-  alias Realtime.RateCounter
   alias Realtime.Tenants
   alias Realtime.Tenants.Connect
   alias Realtime.Tenants.ReplicationConnection
@@ -1768,7 +1767,7 @@ defmodule Realtime.Integration.RtChannelTest do
     end
 
     test "max_events_per_second limit respected", %{tenant: tenant, serializer: serializer} do
-      RateCounter.stop(tenant.external_id)
+      RateCounterHelper.stop(tenant.external_id)
 
       log =
         capture_log(fn ->
@@ -1842,6 +1841,7 @@ defmodule Realtime.Integration.RtChannelTest do
 
           # Wait for RateCounter tick
           Process.sleep(1000)
+
           # These ones will be blocked
           for _ <- 1..300 do
             WebsocketClient.join(socket, realtime_topic, %{config: config})
@@ -1997,7 +1997,7 @@ defmodule Realtime.Integration.RtChannelTest do
           start: {Agent, :start_link, [fn -> %{} end, [name: name]]}
         })
 
-      RateCounter.stop(tenant.external_id)
+      RateCounterHelper.stop(tenant.external_id)
       on_exit(fn -> :telemetry.detach({__MODULE__, tenant.external_id}) end)
       :telemetry.attach_many({__MODULE__, tenant.external_id}, events, &__MODULE__.handle_telemetry/4, name)
 
@@ -2018,7 +2018,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{topic: ^topic, event: "system"}, 5000
 
       # Wait for RateCounter to run
-      Process.sleep(2000)
+      RateCounterHelper.tick_tenant_rate_counters!(tenant.external_id)
 
       # Expected billed
       # 1 joins due to two sockets
@@ -2060,7 +2060,7 @@ defmodule Realtime.Integration.RtChannelTest do
       end
 
       # Wait for RateCounter to run
-      Process.sleep(2000)
+      RateCounterHelper.tick_tenant_rate_counters!(tenant.external_id)
 
       # Expected billed
       # 2 joins due to two sockets
@@ -2112,7 +2112,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{event: "presence_diff", payload: %{"joins" => _, "leaves" => %{}}, topic: ^topic}
 
       # Wait for RateCounter to run
-      Process.sleep(2000)
+      RateCounterHelper.tick_tenant_rate_counters!(tenant.external_id)
 
       # Expected billed
       # 2 joins due to two sockets
@@ -2161,7 +2161,7 @@ defmodule Realtime.Integration.RtChannelTest do
       end
 
       # Wait for RateCounter to run
-      Process.sleep(2000)
+      RateCounterHelper.tick_tenant_rate_counters!(tenant.external_id)
 
       # Expected billed
       # 2 joins due to two sockets
@@ -2189,7 +2189,7 @@ defmodule Realtime.Integration.RtChannelTest do
       assert_receive %Message{topic: ^topic, event: "system"}, 5000
 
       # Wait for RateCounter to run
-      Process.sleep(2000)
+      RateCounterHelper.tick_tenant_rate_counters!(tenant.external_id)
 
       # Expected billed
       # 1 joins due to one socket

--- a/test/realtime/extensions/cdc_rls/replication_poller_test.exs
+++ b/test/realtime/extensions/cdc_rls/replication_poller_test.exs
@@ -71,9 +71,6 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
                      },
                      500
 
-      # Wait for RateCounter to update
-      Process.sleep(1100)
-
       rate = Realtime.Tenants.db_events_per_second_rate(tenant)
 
       assert {:ok,
@@ -84,7 +81,7 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
                   measurement: :avg,
                   triggered: false
                 }
-              }} = RateCounter.get(rate)
+              }} = RateCounterHelper.tick!(rate)
 
       assert sum == 0
     end
@@ -133,11 +130,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
                      },
                      500
 
-      # Wait for RateCounter to update
-      Process.sleep(1100)
-
       rate = Realtime.Tenants.db_events_per_second_rate(tenant)
-      assert {:ok, %RateCounter{sum: sum}} = RateCounter.get(rate)
+      assert {:ok, %RateCounter{sum: sum}} = RateCounterHelper.tick!(rate)
       assert sum == 2
     end
 
@@ -183,11 +177,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
                      },
                      500
 
-      # Wait for RateCounter to update
-      Process.sleep(1100)
-
       rate = Realtime.Tenants.db_events_per_second_rate(tenant)
-      assert {:ok, %RateCounter{sum: sum}} = RateCounter.get(rate)
+      assert {:ok, %RateCounter{sum: sum}} = RateCounterHelper.tick!(rate)
       assert sum == 2
     end
 
@@ -236,11 +227,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
                      },
                      500
 
-      # Wait for RateCounter to update
-      Process.sleep(1100)
-
       rate = Realtime.Tenants.db_events_per_second_rate(tenant)
-      assert {:ok, %RateCounter{sum: sum}} = RateCounter.get(rate)
+      assert {:ok, %RateCounter{sum: sum}} = RateCounterHelper.tick!(rate)
       assert sum == 2
     end
 
@@ -300,11 +288,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
       assert {node(), MapSet.new([sub1, sub3])} in node_subs
       assert {:"someothernode@127.0.0.1", MapSet.new([sub2])} in node_subs
 
-      # Wait for RateCounter to update
-      Process.sleep(1100)
-
       rate = Realtime.Tenants.db_events_per_second_rate(tenant)
-      assert {:ok, %RateCounter{sum: sum}} = RateCounter.get(rate)
+      assert {:ok, %RateCounter{sum: sum}} = RateCounterHelper.tick!(rate)
       assert sum == 3
     end
   end

--- a/test/realtime/rate_counter/rate_counter_test.exs
+++ b/test/realtime/rate_counter/rate_counter_test.exs
@@ -316,37 +316,5 @@ defmodule Realtime.RateCounterTest do
     end
   end
 
-  describe "stop/1" do
-    test "stops rate counters for a given entity" do
-      entity_id = Ecto.UUID.generate()
-      fake_terms = Enum.map(1..10, fn _ -> {:domain, :"metric_#{random_string()}", Ecto.UUID.generate()} end)
-      terms = Enum.map(1..10, fn _ -> {:domain, :"metric_#{random_string()}", entity_id} end)
-
-      for term <- terms do
-        args = %Args{id: term}
-        {:ok, _} = RateCounter.new(args)
-        assert {:ok, %RateCounter{}} = RateCounter.get(args)
-      end
-
-      for term <- fake_terms do
-        args = %Args{id: term}
-        {:ok, _} = RateCounter.new(args)
-        assert {:ok, %RateCounter{}} = RateCounter.get(args)
-      end
-
-      assert :ok = RateCounter.stop(entity_id)
-      # Wait for processes to shut down and Registry to update
-      Process.sleep(100)
-
-      for term <- terms do
-        assert [] = Registry.lookup(Realtime.Registry.Unique, {RateCounter, :rate_counter, term})
-      end
-
-      for term <- fake_terms do
-        assert [{_pid, _value}] = Registry.lookup(Realtime.Registry.Unique, {RateCounter, :rate_counter, term})
-      end
-    end
-  end
-
   def handle_telemetry(event, measures, metadata, pid: pid), do: send(pid, {event, measures, metadata})
 end

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -105,8 +105,9 @@ defmodule Realtime.Tenants.AuthorizationTest do
               Authorization.get_read_authorizations(%Policies{}, pid, context.authorization_context)
           end
 
-          # Waiting for RateCounter to limit
-          Process.sleep(1100)
+          # Force RateCounter to tick
+          rate_counter = Realtime.Tenants.authorization_errors_per_second_rate(context.tenant)
+          RateCounterHelper.tick!(rate_counter)
           # The next auth requests will not call the database due to being rate limited
           reject(&Database.transaction/4)
 
@@ -134,8 +135,9 @@ defmodule Realtime.Tenants.AuthorizationTest do
               Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context)
           end
 
-          # Waiting for RateCounter to limit
-          Process.sleep(1100)
+          # Force RateCounter to tick
+          rate_counter = Realtime.Tenants.authorization_errors_per_second_rate(context.tenant)
+          RateCounterHelper.tick!(rate_counter)
           # The next auth requests will not call the database due to being rate limited
           reject(&Database.transaction/4)
 
@@ -191,8 +193,9 @@ defmodule Realtime.Tenants.AuthorizationTest do
             end)
 
           Task.await_many([t1, t2], 20_000)
-          # Wait for RateCounter log
-          Process.sleep(1000)
+          # Force RateCounter to tick and log error
+          rate_counter = Realtime.Tenants.authorization_errors_per_second_rate(context.tenant)
+          RateCounterHelper.tick!(rate_counter)
         end)
 
       external_id = context.tenant.external_id

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -40,9 +40,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
         assert Jason.decode!(data) == message(serializer, topic, @payload)
       end
 
-      Process.sleep(120)
-
-      {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
+      {:ok, %{avg: avg, bucket: buckets}} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
       assert Enum.sum(buckets) == 100
       assert avg > 0
     end
@@ -58,7 +56,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
       refute_received _any
 
-      {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
+      {:ok, %{avg: avg}} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
       assert avg == 0.0
     end
 
@@ -79,8 +77,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
         assert Jason.decode!(data) == message(serializer, topic, @payload)
       end
 
-      Process.sleep(120)
-      {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
+      {:ok, %{avg: avg, bucket: buckets}} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
       assert Enum.sum(buckets) == 100
       assert avg > 0.0
     end
@@ -174,7 +171,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
       refute_received _any
 
-      {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
+      {:ok, %{avg: avg}} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
       assert avg == 0.0
     end
 
@@ -256,8 +253,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
         assert Jason.decode!(data) == message(serializer, topic, @payload)
       end
 
-      Process.sleep(120)
-      {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
+      {:ok, %{avg: avg, bucket: buckets}} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
       assert Enum.sum(buckets) == 100
       assert avg > 0.0
     end
@@ -278,9 +274,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
         assert Jason.decode!(data) == message(serializer, topic, @payload)
       end
 
-      Process.sleep(120)
-
-      {:ok, %{avg: avg, bucket: buckets}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
+      {:ok, %{avg: avg, bucket: buckets}} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
       assert Enum.sum(buckets) == 100
       assert avg > 0.0
     end
@@ -375,7 +369,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
       assert log =~ "RlsPolicyError"
 
-      {:ok, %{avg: avg}} = RateCounter.get(Tenants.events_per_second_rate(tenant))
+      {:ok, %{avg: avg}} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
       assert avg == 0.0
     end
 

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -484,11 +484,8 @@ defmodule RealtimeWeb.RealtimeChannelTest do
 
       tenant_id = tenant.external_id
 
-      # Wait for RateCounter to tick
-      Process.sleep(1100)
-
       assert {:ok, %RateCounter{id: {:channel, :presence_events, ^tenant_id}, bucket: bucket}} =
-               RateCounter.get(socket.assigns.presence_rate_counter)
+               RateCounterHelper.tick!(socket.assigns.presence_rate_counter)
 
       # presence_state
       assert Enum.sum(bucket) == 1

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -141,12 +141,10 @@ defmodule RealtimeWeb.BroadcastControllerTest do
 
       assert conn.status == 422
 
-      # Wait for counters to increment. RateCounter tick is 1 second
-      Process.sleep(2000)
-      {:ok, rate_counter} = RateCounter.get(Tenants.requests_per_second_rate(tenant))
+      {:ok, rate_counter} = RateCounterHelper.tick!(Tenants.requests_per_second_rate(tenant))
       assert rate_counter.avg != 0.0
 
-      {:ok, rate_counter} = RateCounter.get(Tenants.events_per_second_rate(tenant))
+      {:ok, rate_counter} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
       assert rate_counter.avg == 0.0
 
       refute_receive {:socket_push, _, _}

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -3,7 +3,6 @@ defmodule Containers do
   alias Realtime.Tenants.Connect
   alias Containers.Container
   alias Realtime.Database
-  alias Realtime.RateCounter
   alias Realtime.Tenants.Migrations
 
   use GenServer
@@ -142,7 +141,7 @@ defmodule Containers do
 
       storage_up!(tenant)
 
-      RateCounter.stop(tenant.external_id)
+      RateCounterHelper.stop(tenant.external_id)
 
       # Automatically checkin the container at the end of the test
       ExUnit.Callbacks.on_exit(fn ->

--- a/test/support/rate_counter_helper.ex
+++ b/test/support/rate_counter_helper.ex
@@ -1,0 +1,41 @@
+defmodule RateCounterHelper do
+  alias Realtime.RateCounter
+
+  @spec stop(term()) :: :ok
+  def stop(tenant_id) do
+    keys =
+      Registry.select(Realtime.Registry.Unique, [
+        {{{:"$1", :_, {:_, :_, :"$2"}}, :"$3", :_}, [{:==, :"$1", RateCounter}, {:==, :"$2", tenant_id}], [:"$_"]}
+      ])
+
+    Enum.each(keys, fn {{_, _, key}, {pid, _}} ->
+      if Process.alive?(pid), do: GenServer.stop(pid)
+      Realtime.GenCounter.delete(key)
+      Cachex.del!(RateCounter, key)
+    end)
+
+    :ok
+  end
+
+  @spec tick!(RateCounter.Args.t()) :: RateCounter.t()
+  def tick!(args) do
+    [{pid, _}] = Registry.lookup(Realtime.Registry.Unique, {RateCounter, :rate_counter, args.id})
+    send(pid, :tick)
+    {:ok, :sys.get_state(pid)}
+  end
+
+  def tick_tenant_rate_counters!(tenant_id) do
+    keys =
+      Registry.select(Realtime.Registry.Unique, [
+        {{{:"$1", :_, {:_, :_, :"$2"}}, :"$3", :_}, [{:==, :"$1", RateCounter}, {:==, :"$2", tenant_id}], [:"$_"]}
+      ])
+
+    Enum.each(keys, fn {{_, _, _key}, {pid, _}} ->
+      send(pid, :tick)
+      # do a get_state to wait for the tick to be processed
+      :sys.get_state(pid)
+    end)
+
+    :ok
+  end
+end


### PR DESCRIPTION
We avoid waiting during tests and we ensure that RateCounter has processed the last gen counter changes

Less `Process.sleep` 😴 