### PR TITLE
chore: fix flaky gen rpc pub sub test

### DIFF
--- a/test/realtime/gen_rpc_pub_sub_test.exs
+++ b/test/realtime/gen_rpc_pub_sub_test.exs
@@ -48,9 +48,13 @@ defmodule Realtime.GenRpcPubSubTest do
   for regional_broadcasting <- [true, false] do
     describe "regional balancing = #{regional_broadcasting}" do
       setup do
-        value = Application.get_env(:realtime, :regional_broadcasting)
+        previous_region = Application.get_env(:realtime, :region)
+        Application.put_env(:realtime, :region, "us-east-1")
+        on_exit(fn -> Application.put_env(:realtime, :region, previous_region) end)
+
+        previous_regional_broadcast = Application.get_env(:realtime, :regional_broadcasting)
         Application.put_env(:realtime, :regional_broadcasting, unquote(regional_broadcasting))
-        on_exit(fn -> Application.put_env(:realtime, :regional_broadcasting, value) end)
+        on_exit(fn -> Application.put_env(:realtime, :regional_broadcasting, previous_regional_broadcast) end)
 
         :ok
       end

--- a/test/realtime/repo_replica_test.exs
+++ b/test/realtime/repo_replica_test.exs
@@ -1,5 +1,6 @@
 defmodule Realtime.Repo.ReplicaTest do
-  use ExUnit.Case
+  # application env being changed
+  use ExUnit.Case, async: false
   alias Realtime.Repo.Replica
 
   setup do

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -334,8 +334,9 @@ defmodule RealtimeWeb.TenantControllerTest do
     setup [:with_tenant]
 
     setup do
+      previous_region = Application.get_env(:realtime, :region)
       Application.put_env(:realtime, :region, "us-east-1")
-      on_exit(fn -> Application.put_env(:realtime, :region, nil) end)
+      on_exit(fn -> Application.put_env(:realtime, :region, previous_region) end)
     end
 
     test "health check when tenant does not exist", %{conn: conn} do


### PR DESCRIPTION
Looks like the `region` was being changed but not being properly reset. This should be fixed.