### PR TITLE
fix: no-op when presence track is issued with the same payload

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.66.0",
+      version: "2.66.1",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -94,7 +94,7 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
       assert_receive {[:realtime, :connections], %{connected: 1, limit: 200, connected_cluster: 2},
                       %{tenant: ^external_id}}
 
-      refute_receive :_
+      refute_receive _
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Avoid doing any work if presence payload has not changed.

## What is the current behavior?

We end up issuing a `presence_diff` for no good reason.

## What is the new behavior?

Do nothing.

## Additional context

Add any other context or screenshots.
