### PR TITLE
chore: fix test telemetry attaching to only expected tenant

### DIFF
--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -100,14 +100,14 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
   end
 
   describe "handle/3" do
-    setup do
+    setup %{tenant: tenant} do
       on_exit(fn -> :telemetry.detach(__MODULE__) end)
 
       :telemetry.attach(
         __MODULE__,
         [:realtime, :tenants, :payload, :size],
         &__MODULE__.handle_telemetry/4,
-        pid: self()
+        %{pid: self(), tenant: tenant}
       )
     end
 
@@ -613,5 +613,9 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
     }
   end
 
-  def handle_telemetry(event, measures, metadata, pid: pid), do: send(pid, {:telemetry, event, measures, metadata})
+  def handle_telemetry(event, measures, metadata, %{pid: pid, tenant: tenant}) do
+    if metadata[:tenant] == tenant.external_id do
+      send(pid, {:telemetry, event, measures, metadata})
+    end
+  end
 end

--- a/test/realtime_web/tenant_broadcaster_test.exs
+++ b/test/realtime_web/tenant_broadcaster_test.exs
@@ -33,6 +33,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
   end
 
   setup context do
+    tenant_id = random_string()
     Endpoint.subscribe(@topic)
 
     :erpc.call(context.node, Subscriber, :subscribe, [self(), @topic])
@@ -44,23 +45,23 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
       __MODULE__,
       [:realtime, :tenants, :payload, :size],
       &__MODULE__.handle_telemetry/4,
-      pid: self()
+      %{pid: self(), tenant: tenant_id}
     )
 
     original = Application.fetch_env!(:realtime, :pubsub_adapter)
     on_exit(fn -> Application.put_env(:realtime, :pubsub_adapter, original) end)
     Application.put_env(:realtime, :pubsub_adapter, context.pubsub_adapter)
 
-    :ok
+    {:ok, tenant_id: tenant_id}
   end
 
   for pubsub_adapter <- [:gen_rpc, :pg2] do
     describe "pubsub_broadcast/5 #{pubsub_adapter}" do
       @describetag pubsub_adapter: pubsub_adapter
 
-      test "pubsub_broadcast", %{node: node} do
+      test "pubsub_broadcast", %{node: node, tenant_id: tenant_id} do
         message = %Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
-        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_broadcast(tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -71,13 +72,13 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 114},
-          %{tenant: "realtime-dev", message_type: :broadcast}
+          %{tenant: ^tenant_id, message_type: :broadcast}
         }
       end
 
-      test "pubsub_broadcast list payload", %{node: node} do
+      test "pubsub_broadcast list payload", %{node: node, tenant_id: tenant_id} do
         message = %Broadcast{topic: @topic, event: "an event", payload: ["a", %{"b" => "c"}, 1, 23]}
-        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_broadcast(tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -88,13 +89,13 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 130},
-          %{tenant: "realtime-dev", message_type: :broadcast}
+          %{tenant: ^tenant_id, message_type: :broadcast}
         }
       end
 
-      test "pubsub_broadcast string payload", %{node: node} do
+      test "pubsub_broadcast string payload", %{node: node, tenant_id: tenant_id} do
         message = %Broadcast{topic: @topic, event: "an event", payload: "some text payload"}
-        TenantBroadcaster.pubsub_broadcast("realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_broadcast(tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -105,7 +106,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 119},
-          %{tenant: "realtime-dev", message_type: :broadcast}
+          %{tenant: ^tenant_id, message_type: :broadcast}
         }
       end
     end
@@ -113,7 +114,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
     describe "pubsub_broadcast_from/6 #{pubsub_adapter}" do
       @describetag pubsub_adapter: pubsub_adapter
 
-      test "pubsub_broadcast_from", %{node: node} do
+      test "pubsub_broadcast_from", %{node: node, tenant_id: tenant_id} do
         parent = self()
 
         spawn_link(fn ->
@@ -129,7 +130,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
 
         message = %Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
 
-        TenantBroadcaster.pubsub_broadcast_from("realtime-dev", self(), @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_broadcast_from(tenant_id, self(), @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive {:other_process, ^message}
 
@@ -140,7 +141,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 114},
-          %{tenant: "realtime-dev", message_type: :broadcast}
+          %{tenant: ^tenant_id, message_type: :broadcast}
         }
 
         # This process does not receive the message
@@ -151,11 +152,11 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
     describe "pubsub_direct_broadcast/6 #{pubsub_adapter}" do
       @describetag pubsub_adapter: pubsub_adapter
 
-      test "pubsub_direct_broadcast", %{node: node} do
+      test "pubsub_direct_broadcast", %{node: node, tenant_id: tenant_id} do
         message = %Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
 
-        TenantBroadcaster.pubsub_direct_broadcast(node(), "realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
-        TenantBroadcaster.pubsub_direct_broadcast(node, "realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_direct_broadcast(node(), tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_direct_broadcast(node, tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -166,15 +167,15 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 114},
-          %{tenant: "realtime-dev", message_type: :broadcast}
+          %{tenant: ^tenant_id, message_type: :broadcast}
         }
       end
 
-      test "pubsub_direct_broadcast list payload", %{node: node} do
+      test "pubsub_direct_broadcast list payload", %{node: node, tenant_id: tenant_id} do
         message = %Broadcast{topic: @topic, event: "an event", payload: ["a", %{"b" => "c"}, 1, 23]}
 
-        TenantBroadcaster.pubsub_direct_broadcast(node(), "realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
-        TenantBroadcaster.pubsub_direct_broadcast(node, "realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_direct_broadcast(node(), tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_direct_broadcast(node, tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -185,15 +186,15 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 130},
-          %{tenant: "realtime-dev", message_type: :broadcast}
+          %{tenant: ^tenant_id, message_type: :broadcast}
         }
       end
 
-      test "pubsub_direct_broadcast string payload", %{node: node} do
+      test "pubsub_direct_broadcast string payload", %{node: node, tenant_id: tenant_id} do
         message = %Broadcast{topic: @topic, event: "an event", payload: "some text payload"}
 
-        TenantBroadcaster.pubsub_direct_broadcast(node(), "realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
-        TenantBroadcaster.pubsub_direct_broadcast(node, "realtime-dev", @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_direct_broadcast(node(), tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
+        TenantBroadcaster.pubsub_direct_broadcast(node, tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
 
         assert_receive ^message
 
@@ -204,7 +205,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
           :telemetry,
           [:realtime, :tenants, :payload, :size],
           %{size: 119},
-          %{tenant: "realtime-dev", message_type: :broadcast}
+          %{tenant: ^tenant_id, message_type: :broadcast}
         }
       end
     end
@@ -213,35 +214,39 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
   describe "collect_payload_size/3" do
     @describetag pubsub_adapter: :gen_rpc
 
-    test "emit telemetry for struct" do
+    test "emit telemetry for struct", %{tenant_id: tenant_id} do
       TenantBroadcaster.collect_payload_size(
-        "realtime-dev",
+        tenant_id,
         %Phoenix.Socket.Broadcast{event: "broadcast", payload: %{"a" => "b"}},
         :broadcast
       )
 
       assert_receive {:telemetry, [:realtime, :tenants, :payload, :size], %{size: 65},
-                      %{tenant: "realtime-dev", message_type: :broadcast}}
+                      %{tenant: ^tenant_id, message_type: :broadcast}}
     end
 
-    test "emit telemetry for map" do
+    test "emit telemetry for map", %{tenant_id: tenant_id} do
       TenantBroadcaster.collect_payload_size(
-        "realtime-dev",
+        tenant_id,
         %{event: "broadcast", payload: %{"a" => "b"}},
         :postgres_changes
       )
 
       assert_receive {:telemetry, [:realtime, :tenants, :payload, :size], %{size: 53},
-                      %{tenant: "realtime-dev", message_type: :postgres_changes}}
+                      %{tenant: ^tenant_id, message_type: :postgres_changes}}
     end
 
-    test "emit telemetry for non-map" do
-      TenantBroadcaster.collect_payload_size("realtime-dev", "some blob", :presence)
+    test "emit telemetry for non-map", %{tenant_id: tenant_id} do
+      TenantBroadcaster.collect_payload_size(tenant_id, "some blob", :presence)
 
       assert_receive {:telemetry, [:realtime, :tenants, :payload, :size], %{size: 15},
-                      %{tenant: "realtime-dev", message_type: :presence}}
+                      %{tenant: ^tenant_id, message_type: :presence}}
     end
   end
 
-  def handle_telemetry(event, measures, metadata, pid: pid), do: send(pid, {:telemetry, event, measures, metadata})
+  def handle_telemetry(event, measures, metadata, %{pid: pid, tenant: tenant}) do
+    if metadata[:tenant] == tenant do
+      send(pid, {:telemetry, event, measures, metadata})
+    end
+  end
 end


### PR DESCRIPTION
Avoid async tests getting events from telemetry that is not related to the tested tenant