### PR TITLE
fix: gather connected metrics for all tenants

### DIFF
--- a/lib/realtime/metrics_cleaner.ex
+++ b/lib/realtime/metrics_cleaner.ex
@@ -35,12 +35,10 @@ defmodule Realtime.MetricsCleaner do
     Process.send_after(self(), :check, interval)
   end
 
-  @table_name :"syn_registry_by_name_Elixir.Realtime.Tenants.Connect"
   @metrics_table Realtime.PromEx.Metrics
   @filter_spec [{{{:_, %{tenant: :"$1"}}, :_}, [], [:"$1"]}]
-  @tenant_id_spec [{{:"$1", :_, :_, :_, :_, :_}, [], [:"$1"]}]
   defp loop_and_cleanup_metrics_table do
-    tenant_ids = :ets.select(@table_name, @tenant_id_spec)
+    tenant_ids = Realtime.Tenants.Connect.list_tenants()
 
     :ets.select(@metrics_table, @filter_spec)
     |> Enum.uniq()

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -89,7 +89,7 @@ defmodule Realtime.PromEx.Plugins.Tenant do
   end
 
   def execute_tenant_metrics do
-    tenants = Tenants.list_connected_tenants(Node.self())
+    tenants = Tenants.Connect.list_tenants()
 
     for t <- tenants do
       count = UsersCounter.tenant_users(Node.self(), t)

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -16,15 +16,6 @@ defmodule Realtime.Tenants do
   alias Realtime.UsersCounter
 
   @doc """
-  Gets a list of connected tenant `external_id` strings in the cluster or a node.
-  """
-  @spec list_connected_tenants(atom()) :: [String.t()]
-  def list_connected_tenants(node) do
-    UsersCounter.scopes()
-    |> Enum.flat_map(fn scope -> :syn.group_names(scope, node) end)
-  end
-
-  @doc """
   Gets the database connection pid managed by the Tenants.Connect process.
 
   ## Examples

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -38,6 +38,14 @@ defmodule Realtime.Tenants.Connect do
             connected_users_bucket: [1],
             check_connect_region_interval: nil
 
+  @tenant_id_spec [{{:"$1", :_, :_, :_, :_, :_}, [], [:"$1"]}]
+  @spec list_tenants() :: [binary]
+  def list_tenants() do
+    :syn_registry_by_name
+    |> :syn_backbone.get_table_name(__MODULE__)
+    |> :ets.select(@tenant_id_spec)
+  end
+
   @doc "Check if Connect has finished setting up connections"
   def ready?(tenant_id) do
     case whereis(tenant_id) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.66.3",
+      version: "2.66.4",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -75,6 +75,7 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
 
       on_exit(fn -> :telemetry.detach(__MODULE__) end)
 
+      {:ok, _} = Realtime.Tenants.Connect.lookup_or_start_connection(tenant.external_id)
       {:ok, node} = Clustered.start(@aux_mod)
       %{tenant: tenant, node: node}
     end

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -50,6 +50,19 @@ defmodule Realtime.Tenants.ConnectTest do
     end
   end
 
+  describe "list_tenants/0" do
+    test "lists all tenants with active connections", %{tenant: tenant1} do
+      tenant2 = Containers.checkout_tenant(run_migrations: true)
+      assert {:ok, _} = Connect.lookup_or_start_connection(tenant1.external_id)
+      assert {:ok, _} = Connect.lookup_or_start_connection(tenant2.external_id)
+
+      list_tenants = Connect.list_tenants() |> MapSet.new()
+      tenants = MapSet.new([tenant1.external_id, tenant2.external_id])
+
+      assert MapSet.subset?(tenants, list_tenants)
+    end
+  end
+
   describe "handle cold start" do
     test "multiple processes connecting calling Connect.connect", %{tenant: tenant} do
       parent = self()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use list of `Connect` tenants to report websocket connected metrics
