### PR TITLE
fix: change ReplicationConnection to ignore unknown tables

### DIFF
--- a/lib/realtime/adapters/postgres/decoder.ex
+++ b/lib/realtime/adapters/postgres/decoder.ex
@@ -210,10 +210,15 @@ defmodule Realtime.Adapters.Postgres.Decoder do
          <<"I", relation_id::integer-32, "N", number_of_columns::integer-16, tuple_data::binary>>,
          relations
        ) do
-    relation = relations |> Map.get(relation_id) |> Map.get(:columns)
-    {<<>>, decoded_tuple_data} = decode_tuple_data(tuple_data, number_of_columns, relation)
+    relation = relations |> get_in([relation_id, :columns])
 
-    %Insert{relation_id: relation_id, tuple_data: decoded_tuple_data}
+    if relation do
+      {<<>>, decoded_tuple_data} = decode_tuple_data(tuple_data, number_of_columns, relation)
+
+      %Insert{relation_id: relation_id, tuple_data: decoded_tuple_data}
+    else
+      %Unsupported{}
+    end
   end
 
   defp decode_message_impl(<<"Y", data_type_id::integer-32, namespace_and_name::binary>>, _relations) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.66.2",
+      version: "2.66.3",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Only realtime.messages should be processed

## What is the current behavior?

Any relation is processed and we try to decode data from tables we don't expect

## What is the new behavior?

No unexpected rows

## Additional context

Add any other context or screenshots.
