### PR TITLE
fix: coalesce wal data if not available on list_changes function

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replications.ex
+++ b/lib/extensions/postgres_cdc_rls/replications.ex
@@ -76,9 +76,9 @@ defmodule Extensions.PostgresCdcRls.Replications do
       SELECT wal->>'type' as type,
              wal->>'schema' as schema,
              wal->>'table' as table,
-             wal->>'columns' as columns,
-             wal->>'record' as record,
-             wal->>'old_record' as old_record,
+             COALESCE(wal->>'columns', '[]') as columns,
+             COALESCE(wal->>'record', '{}') as record,
+             COALESCE(wal->>'old_record', '{}') as old_record,
              wal->>'commit_timestamp' as commit_timestamp,
              subscription_ids,
              errors

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.68.1",
+      version: "2.68.2",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Account for empty columns, record and old_record just like we did before:

https://github.com/supabase/realtime/blob/617afae68ecb56547f8320008d26f55f5620d3b5/lib/extensions/postgres_cdc_rls/replication_poller.ex#L286-L294

It fixes #1648 