### PR TITLE
fix: use default storage for peep

### DIFF
--- a/lib/realtime/metrics_cleaner.ex
+++ b/lib/realtime/metrics_cleaner.ex
@@ -38,11 +38,10 @@ defmodule Realtime.MetricsCleaner do
   defp loop_and_cleanup_metrics_table do
     tenant_ids = Realtime.Tenants.Connect.list_tenants() |> MapSet.new()
 
-    {_, tids} = Peep.Persistent.storage(Realtime.PromEx.Metrics)
+    {_, tid} = Peep.Persistent.storage(Realtime.PromEx.Metrics)
 
-    tids
-    |> Tuple.to_list()
-    |> Stream.flat_map(fn tid -> :ets.select(tid, @peep_filter_spec) end)
+    tid
+    |> :ets.select(@peep_filter_spec)
     |> Enum.uniq()
     |> Stream.reject(fn tenant_id -> MapSet.member?(tenant_ids, tenant_id) end)
     |> Enum.map(fn tenant_id -> %{tenant: tenant_id} end)

--- a/lib/realtime/monitoring/prom_ex.ex
+++ b/lib/realtime/monitoring/prom_ex.ex
@@ -66,7 +66,7 @@ defmodule Realtime.PromEx do
 
   defmodule Store do
     @moduledoc false
-    # Custom store to set global tags and striped storage
+    # Custom store to set global tags
 
     @behaviour PromEx.Storage
 
@@ -82,7 +82,7 @@ defmodule Realtime.PromEx do
         name: name,
         metrics: metrics,
         global_tags: Application.get_env(:realtime, :metrics_tags, %{}),
-        storage: :striped
+        storage: :default
       )
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.67.3",
+      version: "2.67.4",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use default storage for peep
