### PR TITLE
fix: speed up tenant connected metrics

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.67.4",
+      version: "2.67.5",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -104,11 +104,20 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
       UsersCounter.add(self(), bad_tenant_id)
 
       _ = Rpc.call(node, FakeUserCounter, :fake_add, [external_id])
+
+      # fake empty tenant_id
+      empty_tenant = tenant_fixture()
+      empty_tenant_id = empty_tenant.external_id
+      :syn.register(Realtime.Tenants.Connect, empty_tenant_id, self(), %{conn: nil})
+
       Process.sleep(500)
       Tenant.execute_tenant_metrics()
 
       assert_receive {[:realtime, :connections], %{connected: 1, limit: 200, connected_cluster: 2},
                       %{tenant: ^external_id}}
+
+      assert_receive {[:realtime, :connections], %{connected: 0, limit: 200, connected_cluster: 0},
+                      %{tenant: ^empty_tenant_id}}
 
       refute_receive {[:realtime, :connections], %{connected: 1, limit: 200, connected_cluster: 2},
                       %{tenant: ^bad_tenant_id}}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Speed up tenant connected metrics

Instead of issuing a `select_count` per tenant this PR changes so that an ETS scan is done for the whole cluster counts and another ETS scan is done for the current node.
