### PR TITLE
fix: Repo.Replica returns main Repo if master region

### DIFF
--- a/lib/realtime/repo_replica.ex
+++ b/lib/realtime/repo_replica.ex
@@ -45,6 +45,7 @@ defmodule Realtime.Repo.Replica do
       end
 
     region = Application.get_env(:realtime, :region)
+    master_region = Application.get_env(:realtime, :master_region) || region
     replica = Map.get(replicas, region)
     replica_conf = Application.get_env(:realtime, replica)
 
@@ -54,6 +55,9 @@ defmodule Realtime.Repo.Replica do
         Realtime.Repo
 
       is_nil(replica_conf) ->
+        Realtime.Repo
+
+      region == master_region ->
         Realtime.Repo
 
       true ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.67.5",
+      version: "2.67.6",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/repo_replica_test.exs
+++ b/test/realtime/repo_replica_test.exs
@@ -6,10 +6,12 @@ defmodule Realtime.Repo.ReplicaTest do
   setup do
     previous_platform = Application.get_env(:realtime, :platform)
     previous_region = Application.get_env(:realtime, :region)
+    previous_master_region = Application.get_env(:realtime, :master_region)
 
     on_exit(fn ->
       Application.put_env(:realtime, :platform, previous_platform)
       Application.put_env(:realtime, :region, previous_region)
+      Application.put_env(:realtime, :master_region, previous_master_region)
     end)
   end
 
@@ -17,11 +19,19 @@ defmodule Realtime.Repo.ReplicaTest do
     for {region, mod} <- Replica.replicas_aws() do
       setup do
         Application.put_env(:realtime, :platform, :aws)
+        Application.put_env(:realtime, :master_region, "special-region")
+        :ok
       end
 
       test "handles #{region} region" do
         Application.put_env(:realtime, :region, unquote(region))
         replica_asserts(unquote(mod), Replica.replica())
+      end
+
+      test "defaults to Realtime.Repo if region is equal to master region on #{region}" do
+        Application.put_env(:realtime, :region, unquote(region))
+        Application.put_env(:realtime, :master_region, unquote(region))
+        replica_asserts(Realtime.Repo, Replica.replica())
       end
     end
 
@@ -35,6 +45,8 @@ defmodule Realtime.Repo.ReplicaTest do
     for {region, mod} <- Replica.replicas_fly() do
       setup do
         Application.put_env(:realtime, :platform, :fly)
+        Application.put_env(:realtime, :master_region, "special-region")
+        :ok
       end
 
       test "handles #{region} region" do


### PR DESCRIPTION
## What kind of change does this PR introduce?

main Repo should be used if main region
