### PR TITLE
fix: jwt secret migration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.68.6",
+      version: "2.68.7",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20251204170944_nullable_jwt_secrets.exs
+++ b/priv/repo/migrations/20251204170944_nullable_jwt_secrets.exs
@@ -3,7 +3,7 @@ defmodule Realtime.Repo.Migrations.NullableJwtSecrets do
 
   def change do
     alter table(:tenants) do
-      modify :jwt_secret, :string, null: true
+      modify :jwt_secret, :text, null: true
     end
 
     create constraint(:tenants, :jwt_secret_or_jwt_jwks_required,

--- a/priv/repo/migrations/20251218000543_ensure_jwt_secret_is_text.exs
+++ b/priv/repo/migrations/20251218000543_ensure_jwt_secret_is_text.exs
@@ -1,0 +1,9 @@
+defmodule Realtime.Repo.Migrations.EnsureJwtSecretIsText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenants) do
+      modify :jwt_secret, :text, null: true
+    end
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

`jwt_secret` must be `:text` 

Fixed the migration for the case where the migration failed to run and added a new migration to ensure that `text` is the right type