### PR TITLE
fix: restart RateCounters when their limits update

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -337,8 +337,10 @@ defmodule Realtime.Tenants do
       ]
     ]
 
-    %RateCounter.Args{id: {:channel, :authorization_errors, external_id}, opts: opts}
+    %RateCounter.Args{id: authorization_errors_per_second_key(external_id), opts: opts}
   end
+
+  def authorization_errors_per_second_key(tenant_id), do: {:channel, :authorization_errors, tenant_id}
 
   @spec subscription_errors_per_second_rate(String.t(), non_neg_integer) :: RateCounter.Args.t()
   def subscription_errors_per_second_rate(tenant_id, pool_size) do
@@ -356,8 +358,10 @@ defmodule Realtime.Tenants do
       ]
     ]
 
-    %RateCounter.Args{id: {:channel, :subscription_errors, tenant_id}, opts: opts}
+    %RateCounter.Args{id: subscription_errors_per_second_key(tenant_id), opts: opts}
   end
+
+  def subscription_errors_per_second_key(tenant_id), do: {:channel, :subscription_errors, tenant_id}
 
   @connect_errors_per_second_default 10
   @doc "RateCounter arguments for counting connect per second."
@@ -382,8 +386,10 @@ defmodule Realtime.Tenants do
       ]
     ]
 
-    %RateCounter.Args{id: {:database, :connect, tenant_id}, opts: opts}
+    %RateCounter.Args{id: connect_errors_per_second_key(tenant_id), opts: opts}
   end
+
+  def connect_errors_per_second_key(tenant_id), do: {:database, :connect, tenant_id}
 
   defp authorization_pool_size(%{extensions: [%{settings: settings} | _]}) do
     Database.pool_size_by_application_name("realtime_connect", settings)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.71.0",
+      version: "2.71.1",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/rate_counter/rate_counter_test.exs
+++ b/test/realtime/rate_counter/rate_counter_test.exs
@@ -301,6 +301,18 @@ defmodule Realtime.RateCounterTest do
     end
   end
 
+  describe "publish_update/1" do
+    test "cause shutdown with update message from update topic" do
+      args = %Args{id: {:domain, :metric, Ecto.UUID.generate()}}
+      {:ok, pid} = RateCounter.new(args)
+
+      Process.monitor(pid)
+      RateCounter.publish_update(args.id)
+
+      assert_receive {:DOWN, _ref, :process, ^pid, :normal}
+    end
+  end
+
   describe "get/1" do
     test "gets the state of a rate counter" do
       args = %Args{id: {:domain, :metric, Ecto.UUID.generate()}}


### PR DESCRIPTION
## What kind of change does this PR introduce?

It ensures that RateCounters are restarted when limits are updated.

It uses PubSub to notify the appropriate RateCounters
