### PR TITLE
fix: use beacon on connected tenant metrics

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -5,7 +5,6 @@ defmodule Realtime.PromEx.Plugins.Tenant do
   require Logger
   alias Realtime.Telemetry
   alias Realtime.Tenants
-  alias Realtime.UsersCounter
 
   @impl true
   def polling_metrics(opts) do
@@ -84,9 +83,9 @@ defmodule Realtime.PromEx.Plugins.Tenant do
   end
 
   def execute_tenant_metrics do
-    tenants = Tenants.list_connected_tenants(Node.self())
-    cluster_counts = UsersCounter.tenant_counts()
-    node_counts = UsersCounter.tenant_counts(Node.self())
+    tenants = Beacon.groups(:users)
+    cluster_counts = Beacon.member_counts(:users)
+    node_counts = Beacon.local_member_counts(:users)
 
     for t <- tenants do
       tenant = Tenants.Cache.get_tenant_by_external_id(t)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.74.0",
+      version: "2.73.5",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Uses Beacon instead of syn for the tenant connected metrics

## Additional context

Follow-up from #1664 
