### PR TITLE
fix: change metrics cleaner to also clean up Connect shutdown

### DIFF
--- a/lib/realtime/syn_handler.ex
+++ b/lib/realtime/syn_handler.ex
@@ -29,6 +29,11 @@ defmodule Realtime.SynHandler do
     end
   end
 
+  @impl true
+  def on_process_registered(scope, name, _pid, _meta, _reason) do
+    :telemetry.execute([:syn, scope, :registered], %{}, %{name: name})
+  end
+
   @doc """
   When processes registered with :syn are unregistered, either manually or by stopping, this
   callback is invoked.
@@ -40,6 +45,8 @@ defmodule Realtime.SynHandler do
   """
   @impl true
   def on_process_unregistered(scope, name, pid, _meta, reason) do
+    :telemetry.execute([:syn, scope, :unregistered], %{}, %{name: name})
+
     case Atom.to_string(scope) do
       @postgres_cdc_scope_prefix <> _ = scope ->
         Endpoint.local_broadcast(PostgresCdc.syn_topic(name), scope <> "_down", %{pid: pid, reason: reason})

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.71.3",
+      version: "2.71.4",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/metrics_cleaner_test.exs
+++ b/test/realtime/metrics_cleaner_test.exs
@@ -2,8 +2,9 @@ defmodule Realtime.MetricsCleanerTest do
   use Realtime.DataCase, async: true
 
   alias Realtime.MetricsCleaner
+  alias Realtime.Tenants.Connect
 
-  describe "metrics cleanup" do
+  describe "metrics cleanup - vacant websockets" do
     test "cleans up metrics for users that have been disconnected" do
       :telemetry.execute(
         [:realtime, :connections],
@@ -48,15 +49,15 @@ defmodule Realtime.MetricsCleanerTest do
       # Wait for clean up to run
       Process.sleep(200)
 
-      # Nothing changes
+      # Nothing changes yet (threshold not reached)
       metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
 
       assert String.contains?(metrics, "tenant=\"occupied-tenant\"")
       assert String.contains?(metrics, "tenant=\"vacant-tenant1\"")
       assert String.contains?(metrics, "tenant=\"vacant-tenant2\"")
 
-      # Wait for clean up to run again
-      Process.sleep(2100)
+      # Wait for threshold to pass and cleanup to run
+      Process.sleep(2200)
 
       # vacant tenant metrics are now gone
       metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
@@ -64,6 +65,128 @@ defmodule Realtime.MetricsCleanerTest do
       assert String.contains?(metrics, "tenant=\"occupied-tenant\"")
       refute String.contains?(metrics, "tenant=\"vacant-tenant1\"")
       refute String.contains?(metrics, "tenant=\"vacant-tenant2\"")
+    end
+
+    test "does not clean up metrics if websockets reconnect before threshold" do
+      :telemetry.execute(
+        [:realtime, :connections],
+        %{connected: 1, connected_cluster: 10, limit: 100},
+        %{tenant: "reconnect-tenant"}
+      )
+
+      pid = spawn_link(fn -> Process.sleep(:infinity) end)
+
+      Beacon.join(:users, "reconnect-tenant", pid)
+
+      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      assert String.contains?(metrics, "tenant=\"reconnect-tenant\"")
+
+      start_supervised!(
+        {MetricsCleaner, [metrics_cleaner_schedule_timer_in_ms: 100, vacant_metric_threshold_in_seconds: 1]}
+      )
+
+      # Disconnect
+      Beacon.leave(:users, "reconnect-tenant", pid)
+      Process.sleep(500)
+
+      # Reconnect before threshold
+      pid2 = spawn_link(fn -> Process.sleep(:infinity) end)
+      Beacon.join(:users, "reconnect-tenant", pid2)
+
+      # Wait for cleanup to run
+      Process.sleep(2200)
+
+      # Metrics should still be present
+      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      assert String.contains?(metrics, "tenant=\"reconnect-tenant\"")
+    end
+  end
+
+  describe "metrics cleanup - disconnected tenants" do
+    test "cleans up metrics for tenants that have been unregistered" do
+      :telemetry.execute(
+        [:realtime, :connections],
+        %{connected: 1, connected_cluster: 10, limit: 100},
+        %{tenant: "connected-tenant"}
+      )
+
+      :telemetry.execute(
+        [:realtime, :connections],
+        %{connected: 0, connected_cluster: 20, limit: 100},
+        %{tenant: "disconnected-tenant1"}
+      )
+
+      :telemetry.execute(
+        [:realtime, :connections],
+        %{connected: 0, connected_cluster: 20, limit: 100},
+        %{tenant: "disconnected-tenant2"}
+      )
+
+      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+
+      assert String.contains?(metrics, "tenant=\"connected-tenant\"")
+      assert String.contains?(metrics, "tenant=\"disconnected-tenant1\"")
+      assert String.contains?(metrics, "tenant=\"disconnected-tenant2\"")
+
+      start_supervised!(
+        {MetricsCleaner, [metrics_cleaner_schedule_timer_in_ms: 100, vacant_metric_threshold_in_seconds: 1]}
+      )
+
+      # Simulate tenant registration (connected)
+      :telemetry.execute([:syn, Connect, :registered], %{}, %{name: "connected-tenant"})
+
+      # Simulate tenant unregistration (disconnected)
+      :telemetry.execute([:syn, Connect, :unregistered], %{}, %{name: "disconnected-tenant1"})
+      :telemetry.execute([:syn, Connect, :unregistered], %{}, %{name: "disconnected-tenant2"})
+
+      # Wait for clean up to run
+      Process.sleep(200)
+
+      # Nothing changes yet (threshold not reached)
+      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+
+      assert String.contains?(metrics, "tenant=\"connected-tenant\"")
+      assert String.contains?(metrics, "tenant=\"disconnected-tenant1\"")
+      assert String.contains?(metrics, "tenant=\"disconnected-tenant2\"")
+
+      # Wait for threshold to pass and cleanup to run
+      Process.sleep(2200)
+
+      # disconnected tenant metrics are now gone
+      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+
+      assert String.contains?(metrics, "tenant=\"connected-tenant\"")
+      refute String.contains?(metrics, "tenant=\"disconnected-tenant1\"")
+      refute String.contains?(metrics, "tenant=\"disconnected-tenant2\"")
+    end
+
+    test "does not clean up metrics if tenant reconnects before threshold" do
+      :telemetry.execute(
+        [:realtime, :connections],
+        %{connected: 1, connected_cluster: 10, limit: 100},
+        %{tenant: "reconnect-tenant"}
+      )
+
+      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      assert String.contains?(metrics, "tenant=\"reconnect-tenant\"")
+
+      start_supervised!(
+        {MetricsCleaner, [metrics_cleaner_schedule_timer_in_ms: 100, vacant_metric_threshold_in_seconds: 1]}
+      )
+
+      # Simulate tenant unregistration
+      :telemetry.execute([:syn, Connect, :unregistered], %{}, %{name: "reconnect-tenant"})
+      Process.sleep(500)
+
+      # Re-register before threshold
+      :telemetry.execute([:syn, Connect, :registered], %{}, %{name: "reconnect-tenant"})
+
+      # Wait for cleanup to run
+      Process.sleep(2200)
+
+      # Metrics should still be present
+      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      assert String.contains?(metrics, "tenant=\"reconnect-tenant\"")
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Once the tenant `Connect` shuts down we clean up after threshold has passed

## What is the current behavior?

We might have some leftover metrics which are unrelated to websockets:

* broadcast payload size from `API /broadcast`
* Replication latency buckets from ReplicationConnection (which is linked to Connect)

## What is the new behavior?

Once `Connect` unregisters we wait some time and remove metrics. It uses syn's handler to know when a tenant Connect has registered and unregistered

## Additional context

Add any other context or screenshots.
