### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/manual_prod_build.yml
+++ b/.github/workflows/manual_prod_build.yml
@@ -18,7 +18,7 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             supabase/realtime
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -51,14 +51,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             supabase/realtime
           tags: |
             type=raw,value=v${{ github.event.inputs.docker_tag }}_${{ env.arch }}
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -98,25 +98,25 @@ jobs:
           supabase/realtime@${{ needs.docker_arm_release.outputs.image_digest }}
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           aws-region: us-east-1
 
       - name: Login to ECR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: public.ecr.aws
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Mirror to ECR
-        uses: akhilerm/tag-push-action@v2.0.0
+        uses: akhilerm/tag-push-action@v2.2.0
         with:
           src: docker.io/supabase/realtime:v${{ github.event.inputs.docker_tag }}
           dst: |

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -17,19 +17,19 @@ jobs:
       id-token: write
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           aws-region: us-east-1
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: public.ecr.aws
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: akhilerm/tag-push-action@v2.1.0
+      - uses: akhilerm/tag-push-action@v2.2.0
         with:
           src: docker.io/supabase/realtime:${{ inputs.version }}
           dst: |

--- a/.github/workflows/prod_build.yml
+++ b/.github/workflows/prod_build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - id: semantic
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v6
         with:
           semantic_version: 18
         env:
@@ -40,7 +40,7 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             supabase/realtime
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             supabase/realtime
@@ -84,7 +84,7 @@ jobs:
             type=raw,value=v${{ needs.release.outputs.version }}_${{ env.arch }}
             type=raw,value=latest_${{ env.arch }}
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -130,25 +130,25 @@ jobs:
           supabase/realtime@${{ needs.docker_arm_release.outputs.image_digest }}
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           aws-region: us-east-1
 
       - name: Login to ECR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: public.ecr.aws
 
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Mirror to ECR
-        uses: akhilerm/tag-push-action@v2.0.0
+        uses: akhilerm/tag-push-action@v2.2.0
         with:
           src: docker.io/supabase/realtime:v${{ needs.release.outputs.version }}
           dst: |

--- a/.github/workflows/version_updated.yml
+++ b/.github/workflows/version_updated.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Verify Versions Updated
-        uses: step-security/changed-files@v45
+        uses: step-security/changed-files@v47
         id: verify_changed_files
         with:
           files: |


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `akhilerm/tag-push-action` | [`v2.0.0`](https://github.com/akhilerm/tag-push-action/releases/tag/v2.0.0), [`v2.1.0`](https://github.com/akhilerm/tag-push-action/releases/tag/v2.1.0) | [`v2.2.0`](https://github.com/akhilerm/tag-push-action/releases/tag/v2.2.0) | [Release](https://github.com/akhilerm/tag-push-action/releases/tag/v2) | manual_prod_build.yml, mirror.yml, prod_build.yml |
| `aws-actions/configure-aws-credentials` | [`v1`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1) | [`v5`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5) | [Release](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5) | manual_prod_build.yml, mirror.yml, prod_build.yml |
| `cycjimmy/semantic-release-action` | [`v3`](https://github.com/cycjimmy/semantic-release-action/releases/tag/v3) | [`v6`](https://github.com/cycjimmy/semantic-release-action/releases/tag/v6) | [Release](https://github.com/cycjimmy/semantic-release-action/releases/tag/v6) | prod_build.yml |
| `docker/login-action` | [`v2`](https://github.com/docker/login-action/releases/tag/v2) | [`v3`](https://github.com/docker/login-action/releases/tag/v3) | [Release](https://github.com/docker/login-action/releases/tag/v3) | manual_prod_build.yml, mirror.yml, prod_build.yml |
| `docker/metadata-action` | [`v4`](https://github.com/docker/metadata-action/releases/tag/v4) | [`v5`](https://github.com/docker/metadata-action/releases/tag/v5) | [Release](https://github.com/docker/metadata-action/releases/tag/v5) | manual_prod_build.yml, prod_build.yml |
| `step-security/changed-files` | [`v45`](https://github.com/step-security/changed-files/releases/tag/v45) | [`v47`](https://github.com/step-security/changed-files/releases/tag/v47) | [Release](https://github.com/step-security/changed-files/releases/tag/v47) | version_updated.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
