### PR TITLE
fix: subscription must have string schema, table and filter

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Realtime.MixProject do
   def project do
     [
       app: :realtime,
-      version: "2.73.0",
+      version: "2.73.1",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -130,6 +130,24 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
       assert {:error, %DBConnection.ConnectionError{reason: :queue_timeout}} =
                Subscriptions.create(conn, "supabase_realtime_test", subscription_list, self(), self())
     end
+
+    test "invalid table" do
+      {:error,
+       "No subscription params provided. Please provide at least a `schema` or `table` to subscribe to: %{\"schema\" => \"public\", \"table\" => %{\"actually a\" => \"map\"}}"} =
+        Subscriptions.parse_subscription_params(%{"schema" => "public", "table" => %{"actually a" => "map"}})
+    end
+
+    test "invalid schema" do
+      {:error,
+       "No subscription params provided. Please provide at least a `schema` or `table` to subscribe to: %{\"schema\" => %{\"actually a\" => \"map\"}, \"table\" => \"images\"}"} =
+        Subscriptions.parse_subscription_params(%{"table" => "images", "schema" => %{"actually a" => "map"}})
+    end
+
+    test "invalid filter" do
+      {:error,
+       "No subscription params provided. Please provide at least a `schema` or `table` to subscribe to: %{\"filter\" => ~c\"{\", \"schema\" => \"public\", \"table\" => \"images\"}"} =
+        Subscriptions.parse_subscription_params(%{"schema" => "public", "table" => "images", "filter" => [123]})
+    end
   end
 
   describe "delete_all/1" do


### PR DESCRIPTION
## What kind of change does this PR introduce?

And invalid schema, table or filter could cause issues hard to debug. Now we return an error message.
