### PR TITLE
fix: disconnect when join rate limit is reached

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -165,6 +165,7 @@ defmodule RealtimeWeb.RealtimeChannel do
 
       {:error, :too_many_joins} ->
         msg = "ClientJoinRateLimitReached: Too many joins per second"
+        send(transport_pid, %Phoenix.Socket.Broadcast{event: "disconnect"})
         {:error, %{reason: msg}}
 
       {:error, :increase_connection_pool} ->

--- a/test/integration/rt_channel_test.exs
+++ b/test/integration/rt_channel_test.exs
@@ -1878,21 +1878,9 @@ defmodule Realtime.Integration.RtChannelTest do
           # Wait for RateCounter tick
           RateCounterHelper.tick_tenant_rate_counters!(tenant.external_id)
 
-          # These ones will be blocked
-          for _ <- 1..300 do
-            WebsocketClient.join(socket, realtime_topic, %{config: config})
-          end
-
-          assert_receive %Message{
-                           event: "phx_reply",
-                           payload: %{
-                             "response" => %{
-                               "reason" => "ClientJoinRateLimitReached: Too many joins per second"
-                             },
-                             "status" => "error"
-                           }
-                         },
-                         2000
+          # The next one will disconnect the socket
+          WebsocketClient.join(socket, realtime_topic, %{config: config})
+          assert_process_down(socket)
         end)
 
       assert log =~


### PR DESCRIPTION
## What kind of change does this PR introduce?

Disconnect socket when rate of joins has been reached
