### PR TITLE
chore: fix prod build to use the new tag to build the image

### DIFF
--- a/.github/workflows/prod_build.yml
+++ b/.github/workflows/prod_build.yml
@@ -45,6 +45,10 @@ jobs:
     outputs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
       - id: meta
         uses: docker/metadata-action@v5
         with:
@@ -65,6 +69,7 @@ jobs:
       - id: build
         uses: useblacksmith/build-push-action@v2
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/${{ env.arch }}
@@ -80,6 +85,8 @@ jobs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
 
       - id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
## What kind of change does this PR introduce?

With the recent change we were still running `docker build` on the original git ref and not on the new ref we created with the new commit to change the `mix.exs` version.