### PR TITLE
fix: fix subscription_check_filters migration to be idempotent

### DIFF
--- a/lib/realtime/tenants/repo/migrations/20211116045059_create_realtime_check_filters_trigger.ex
+++ b/lib/realtime/tenants/repo/migrations/20211116045059_create_realtime_check_filters_trigger.ex
@@ -4,7 +4,7 @@ defmodule Realtime.Tenants.Migrations.CreateRealtimeCheckFiltersTrigger do
   use Ecto.Migration
 
   def change do
-    execute("create function realtime.subscription_check_filters()
+    execute("create or replace function realtime.subscription_check_filters()
       returns trigger
       language plpgsql
     as $$


### PR DESCRIPTION
## What kind of change does this PR introduce?

Always create or replace