### PR TITLE
fix: prevent crash when logging channel termination reason

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -509,7 +509,7 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   @impl true
   def terminate(reason, %{transport_pid: transport_pid}) do
-    Logger.debug("Channel terminated with reason: #{reason}")
+    Logger.debug("Channel terminated with reason: #{inspect(reason)}")
     :telemetry.execute([:prom_ex, :plugin, :realtime, :disconnected], %{})
     Tracker.untrack(transport_pid)
     :ok


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix to prevent crash when logging channel termination reason. 

## What is the current behavior?

An error is thrown when logging the termination reason if it's a tuple (e.g. `{:shutdown, :left}`).
```
[error] GenServer #PID<0.3906.0> terminating
** (Protocol.UndefinedError) protocol String.Chars not implemented for type Tuple. This protocol is implemented for the following type(s): Atom, BitString, Date, DateTime, Decimal, ExJsonSchema.Schema.Ref, ExJsonSchema.Validator.Error.AdditionalItems, ExJsonSchema.Validator.Error.AdditionalProperties, ExJsonSchema.Validator.Error.AllOf, ExJsonSchema.Validator.Error.AnyOf, ExJsonSchema.Validator.Error.Const, ExJsonSchema.Validator.Error.Contains, ExJsonSchema.Validator.Error.ContentEncoding, ExJsonSchema.Validator.Error.ContentMediaType, ExJsonSchema.Validator.Error.Dependencies, ExJsonSchema.Validator.Error.Enum, ExJsonSchema.Validator.Error.False, ExJsonSchema.Validator.Error.Format, ExJsonSchema.Validator.Error.IfThenElse, ExJsonSchema.Validator.Error.ItemsNotAllowed, ExJsonSchema.Validator.Error.MaxItems, ExJsonSchema.Validator.Error.MaxLength, ExJsonSchema.Validator.Error.MaxProperties, ExJsonSchema.Validator.Error.Maximum, ExJsonSchema.Validator.Error.MinItems, ExJsonSchema.Validator.Error.MinLength, ExJsonSchema.Validator.Error.MinProperties, ExJsonSchema.Validator.Error.Minimum, ExJsonSchema.Validator.Error.MultipleOf, ExJsonSchema.Validator.Error.Not, ExJsonSchema.Validator.Error.OneOf, ExJsonSchema.Validator.Error.Pattern, ExJsonSchema.Validator.Error.PropertyNames, ExJsonSchema.Validator.Error.Required, ExJsonSchema.Validator.Error.Type, ExJsonSchema.Validator.Error.UniqueItems, Float, Integer, List, NaiveDateTime, OpenApiSpex.Cast.Error, Phoenix.LiveComponent.CID, Postgrex.Copy, Postgrex.Query, Time, URI, Version, Version.Requirement

Got value:

    {:shutdown, :left}

    (elixir 1.18.4) lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir 1.18.4) lib/string/chars.ex:22: String.Chars.to_string/1
    (realtime 2.74.2) lib/realtime_web/channels/realtime_channel.ex:512: RealtimeWeb.RealtimeChannel.terminate/2
    (stdlib 6.2.1) gen_server.erl:2393: :gen_server.try_terminate/3
    (stdlib 6.2.1) gen_server.erl:2594: :gen_server.terminate/10
    (stdlib 6.2.1) proc_lib.erl:340: :proc_lib.wake_up/3
```

## What is the new behavior?

The logging adopts the same convention as other Phoenix `terminate` handlers using `inspect`.

## Additional context

We observed frequent GenServer crashes on channel disconnects. My troubleshooting identified this log line as the culprit.