### PR TITLE
chore: fix flaky test monitoring plugin

### DIFF
--- a/test/realtime/monitoring/prom_ex/plugins/tenants_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenants_test.exs
@@ -10,7 +10,7 @@ defmodule Realtime.PromEx.Plugins.TenantsTest do
     use PromEx, otp_app: :realtime_test_tenants
     @impl true
     def plugins do
-      [{Tenants, poll_rate: 100}]
+      [{Tenants, poll_rate: 50}]
     end
   end
 


### PR DESCRIPTION
increase rate to avoid timing issues


<img width="813" height="209" alt="fix__prevent_crash_when_logging_channel_termination_reason_·_supabase_realtime_2a14eb5" src="https://github.com/user-attachments/assets/9c993bf0-3b4f-4d6d-9c60-0dcc3f4cd1c5" />
