### PR TITLE
fix: reduce error rate calls for too_many_connections

### DIFF
--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -77,6 +77,7 @@ defmodule Realtime.Tenants.Connect do
           | {:error, :tenant_database_unavailable}
           | {:error, :initializing}
           | {:error, :tenant_database_connection_initializing}
+          | {:error, :tenant_db_too_many_connections}
           | {:error, :connect_rate_limit_reached}
           | {:error, :rpc_error, term()}
   def lookup_or_start_connection(tenant_id, opts \\ []) when is_binary(tenant_id) do

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -615,8 +615,8 @@ defmodule Realtime.Tenants.ConnectTest do
       log =
         capture_log(fn ->
           res =
-            for _ <- 1..50 do
-              Process.sleep(200)
+            for _ <- 1..10 do
+              Process.sleep(250)
               Connect.lookup_or_start_connection(tenant.external_id)
             end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reduce the rate counter for too_many_connections to reduce noise and have a more effective rate limit