### PR TITLE
fix: handle nil postgres_changes as empty list

### DIFF
--- a/lib/realtime_web/channels/payloads/config.ex
+++ b/lib/realtime_web/channels/payloads/config.ex
@@ -22,6 +22,7 @@ defmodule RealtimeWeb.Channels.Payloads.Config do
       attrs
       |> Enum.map(fn
         {k, v} when is_list(v) -> {k, Enum.filter(v, fn v -> v != nil end)}
+        {"postgres_changes", nil} -> {"postgres_changes", []}
         {k, v} -> {k, v}
       end)
       |> Map.new()

--- a/test/realtime_web/channels/payloads/join_test.exs
+++ b/test/realtime_web/channels/payloads/join_test.exs
@@ -120,6 +120,12 @@ defmodule RealtimeWeb.Channels.Payloads.JoinTest do
       assert {:ok, %Join{config: %Config{postgres_changes: []}}} = Join.validate(config)
     end
 
+    test "handles postgres changes as nil as empty array" do
+      config = %{"config" => %{"postgres_changes" => nil}}
+
+      assert {:ok, %Join{config: %Config{postgres_changes: []}}} = Join.validate(config)
+    end
+
     test "accepts string 'true' for boolean fields" do
       config = %{
         "config" => %{


### PR DESCRIPTION
## What kind of change does this PR introduce?

handle nil postgres_changes as empty list