### PR TITLE
chore: fix up coveralls merger step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,14 +75,19 @@ jobs:
       - name: Start epmd
         run: epmd -daemon
       - name: Run tests
-        run: MIX_TEST_PARTITION=${{ matrix.partition }} MAX_CASES=3 mix coveralls.github --partitions 4 --parallel --flagname partition-${{ matrix.partition }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: MIX_TEST_PARTITION=${{ matrix.partition }} mix coveralls.lcov --partitions 4
+      - name: Upload coverage
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: partition-${{ matrix.partition }}
+          parallel: true
+          file: cover/lcov.info
 
   coverage:
     name: Merge Coverage
     needs: tests
-    if: always()
+    if: ${{ needs.tests.result == 'success' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - uses: coverallsapp/github-action@v2


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix up coveralls merger step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test coverage reporting: coverage generation is decoupled from upload, uploads are handled as a separate step, and coverage merges now run only after successful tests.
  * Better support for parallel/partitioned test runs, producing more reliable and timely coverage results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->