### PR TITLE
feat: separate node from tenant metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,83 +313,127 @@ This is the list of operational codes that can help you understand your deployme
 
 ## Observability and Metrics
 
-Supabase Realtime exposes comprehensive metrics for monitoring performance, resource usage, and application behavior. These metrics are exposed in Prometheus format and can be scraped by any compatible monitoring system.
+Supabase Realtime exposes comprehensive metrics for monitoring performance, resource usage, and application behavior. These metrics are exposed in Prometheus format and can be scraped by any compatible monitoring system (Victoria Metrics, Prometheus, Grafana Agent, etc.).
+
+### Metrics Endpoints
+
+Metrics are split across two endpoints with different priorities, allowing you to configure different scrape intervals in your monitoring system:
+
+| Endpoint | Priority | Recommended Scrape Interval | Contents |
+|----------|----------|------------------------------|----------|
+| `GET /metrics` | **High** | 30s | BEAM/VM, OS, Phoenix, distributed infra, and global aggregated tenant totals (no `tenant` label) |
+| `GET /metrics/tenant` | **Low** | 60s | Per-tenant labeled metrics (connection counts, channel events, replication, authorization) |
+| `GET /metrics/:region` | **High** | 30s | Same as `/metrics` scoped to a specific region |
+| `GET /metrics/:region/tenant` | **Low** | 60s | Same as `/metrics/tenant` scoped to a specific region |
+
+All endpoints require a `Bearer` JWT token in the `Authorization` header signed with `METRICS_JWT_SECRET`.
+
+**Victoria Metrics scrape configuration example:**
+
+```yaml
+scrape_configs:
+  - job_name: realtime_global
+    scrape_interval: 30s
+    bearer_token: <METRICS_JWT_SECRET_TOKEN>
+    static_configs:
+      - targets: ["<host>:4000"]
+    metrics_path: /metrics
+
+  - job_name: realtime_tenant
+    scrape_interval: 60s
+    bearer_token: <METRICS_JWT_SECRET_TOKEN>
+    static_configs:
+      - targets: ["<host>:4000"]
+    metrics_path: /metrics/tenant
+```
 
 ### Metric Scopes
 
 Metrics are classified by their scope to help you understand what they measure:
 
-- **Per-Tenant**: Metrics tagged with a tenant identifier measure activity scoped to individual tenants. Use these to identify tenant-specific performance issues, resource usage patterns, or anomalies. Per-tenant metrics include a `tenant` label in Prometheus output.
+- **Per-Tenant**: Metrics tagged with a `tenant` label measure activity scoped to individual tenants. Exposed on `/metrics/tenant`.
+- **Global Aggregate**: Metrics prefixed with `realtime_channel_global_*` or `realtime_connections_global_*` aggregate tenant data without the `tenant` label, suitable for cluster-wide dashboards. Exposed on `/metrics`.
 - **Per-Node**: Metrics measure activity on the current Realtime node. Without explicit per-node indication, assume metrics apply to the local node.
-- **Global/Cluster**: Metrics prefixed with `realtime_channel_global_*` aggregate data across all nodes in the cluster.
-- **BEAM/Erlang VM**: Metrics prefixed with `beam_*` and `phoenix_*` expose Erlang runtime internals.
-- **Infrastructure**: Metrics prefixed with `osmon_*`, `gen_rpc_*`, and `dist_*` measure system-level resources and cluster communication.
+- **BEAM/Erlang VM**: Metrics prefixed with `beam_*` and `phoenix_*` expose Erlang runtime internals. Exposed on `/metrics`.
+- **Infrastructure**: Metrics prefixed with `osmon_*`, `gen_rpc_*`, and `dist_*` measure system-level resources and cluster communication. Exposed on `/metrics`.
 
 ### Connection & Tenant Metrics
 
 These metrics track WebSocket connections and tenant activity across the Realtime cluster.
 
-| Metric | Type | Description | Scope |
-|--------|------|-------------|-------|
-| `realtime_tenants_connected` | Gauge | Number of connected tenants per Realtime node. Use this to understand tenant distribution across your cluster and identify load imbalances. | Per-Node |
-| `realtime_connections_connected` | Gauge | Active WebSocket connections that have at least one subscribed channel. Indicates active client engagement with Realtime features (broadcast, presence, or postgres_changes). | **Per-Tenant** |
-| `realtime_connections_connected_cluster` | Gauge | Cluster-wide active WebSocket connections for each tenant across all nodes. Use this to understand total tenant engagement across the cluster. | **Per-Tenant** |
-| `phoenix_connections_total` | Gauge | Total WebSocket connections including those without active channels. Useful for understanding connection overhead and comparing against active connections. | Per-Node |
-| `realtime_channel_joins` | Counter | Rate of channel join attempts per second. Monitor this to detect sudden spikes in connection activity or identify problematic clients performing excessive joins. | **Per-Tenant** |
+| Metric | Type | Description | Scope | Endpoint |
+|--------|------|-------------|-------|----------|
+| `realtime_tenants_connected` | Gauge | Number of connected tenants per Realtime node. Use this to understand tenant distribution across your cluster and identify load imbalances. | Per-Node | `/metrics` |
+| `realtime_connections_global_connected` | Gauge | Node total of active WebSocket connections across all tenants. Aggregated without a `tenant` label for cluster-wide dashboards. | Global Aggregate | `/metrics` |
+| `realtime_connections_global_connected_cluster` | Gauge | Cluster-wide total of active WebSocket connections across all tenants. | Global Aggregate | `/metrics` |
+| `realtime_connections_connected` | Gauge | Active WebSocket connections that have at least one subscribed channel. Indicates active client engagement with Realtime features. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_connections_connected_cluster` | Gauge | Cluster-wide active WebSocket connections for each individual tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `phoenix_connections_total` | Gauge | Total open connections to the Ranch listener (includes idle connections waiting for data). | Per-Node | `/metrics` |
+| `phoenix_connections_active` | Gauge | Connections actively processing a WebSocket frame or HTTP request. Divide by `phoenix_connections_max` to get a saturation ratio. | Per-Node | `/metrics` |
+| `phoenix_connections_max` | Gauge | The configured Ranch connection limit. When `phoenix_connections_total` approaches this the node is saturated and new connections will be queued. | Per-Node | `/metrics` |
+| `realtime_channel_joins` | Counter | Rate of channel join attempts per second per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_channel_global_joins` | Counter | Global rate of channel join attempts per second across all tenants. | Global Aggregate | `/metrics` |
 
 ### Event Metrics
 
 These metrics measure the volume and types of events flowing through your Realtime system, segmented by feature type.
 
-| Metric | Type | Description | Scope |
-|--------|------|-------------|-------|
-| `realtime_channel_events` | Counter | Broadcast events per second. Tracks messages sent through the broadcast feature across all connected clients. | **Per-Tenant** |
-| `realtime_channel_presence_events` | Counter | Presence events per second. Includes online/offline status updates and custom presence metadata synchronization. | **Per-Tenant** |
-| `realtime_channel_db_events` | Counter | Postgres Changes events per second. Represents database changes that were detected and broadcast to subscribed clients. | **Per-Tenant** |
-| `realtime_channel_global_events` | Counter | Global broadcast events per second across the entire cluster. Compare this to single-node broadcasts to understand cross-node event propagation. | Global |
-| `realtime_channel_global_presence_events` | Counter | Global presence events per second across the cluster. Monitor this to track cluster-wide presence synchronization overhead. | Global |
-| `realtime_channel_global_db_events` | Counter | Global Postgres Changes events per second across the cluster. Indicates how changes propagate and replicate across nodes. | Global |
+| Metric | Type | Description | Scope | Endpoint |
+|--------|------|-------------|-------|----------|
+| `realtime_channel_events` | Counter | Broadcast events per second per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_channel_presence_events` | Counter | Presence events per second per tenant. Includes online/offline status updates and custom presence metadata synchronization. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_channel_db_events` | Counter | Postgres Changes events per second per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_channel_global_events` | Counter | Global broadcast events per second across all tenants. Compare against per-tenant values for outlier detection. | Global Aggregate | `/metrics` |
+| `realtime_channel_global_presence_events` | Counter | Global presence events per second across all tenants. | Global Aggregate | `/metrics` |
+| `realtime_channel_global_db_events` | Counter | Global Postgres Changes events per second across all tenants. | Global Aggregate | `/metrics` |
 
 ### Payload & Traffic Metrics
 
 These metrics provide insight into data volume, message sizes, and network I/O characteristics.
 
-| Metric | Type | Description | Scope |
-|--------|------|-------------|-------|
-| `realtime_payload_size_bucket` | Histogram | Distribution of payload sizes for broadcast, postgres_changes, and presence events across all tenants. Helps identify performance issues caused by large message sizes and optimize payload compression settings. | Per-Node |
-| `realtime_tenants_payload_size_bucket` | Histogram | Per-tenant payload size distribution. Use this to identify tenants generating unusually large messages and troubleshoot tenant-specific performance issues. | **Per-Tenant** |
-| `realtime_channel_input_bytes` | Counter | Total ingress bytes received by all channels. Track this alongside `output_bytes` to understand asymmetric traffic patterns and capacity planning needs. | **Per-Tenant** |
-| `realtime_channel_output_bytes` | Counter | Total egress bytes sent to all clients. Large egress values may indicate inefficient broadcast patterns or excessive event generation. | **Per-Tenant** |
+| Metric | Type | Description | Scope | Endpoint |
+|--------|------|-------------|-------|----------|
+| `realtime_payload_size_bucket` | Histogram | Global payload size distribution across all tenants, tagged by message type. Use for cluster-wide sizing and capacity planning. | Global Aggregate | `/metrics` |
+| `realtime_tenants_payload_size_bucket` | Histogram | Per-tenant payload size distribution. Use this to identify tenants generating unusually large messages. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_channel_input_bytes` | Counter | Total ingress bytes per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_channel_output_bytes` | Counter | Total egress bytes per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_channel_global_input_bytes` | Counter | Global total ingress bytes across all tenants. | Global Aggregate | `/metrics` |
+| `realtime_channel_global_output_bytes` | Counter | Global total egress bytes across all tenants. | Global Aggregate | `/metrics` |
 
 ### Latency & Performance Metrics
 
 These metrics measure end-to-end latency and processing performance across different Realtime operations.
 
-| Metric | Type | Description | Scope |
-|--------|------|-------------|-------|
-| `realtime_replication_poller_query_duration_bucket` | Histogram | Postgres Changes query latency in milliseconds. Includes network I/O to the database and WAL log reading. High values may indicate database performance issues. | **Per-Tenant** |
-| `realtime_replication_poller_query_duration_count` | Counter | Number of database polling queries executed per second. Use with query duration to calculate average latency. | **Per-Tenant** |
-| `realtime_tenants_broadcast_from_database_latency_committed_at_bucket` | Histogram | Time from database commit to client broadcast, measured from the commit timestamp. Indicates end-to-end latency for database-driven changes. | **Per-Tenant** |
-| `realtime_tenants_broadcast_from_database_latency_inserted_at_bucket` | Histogram | Alternative latency measurement using insert timestamp. Useful if commit timestamps are unavailable or for measuring application-layer latency. | **Per-Tenant** |
-| `realtime_tenants_replay_bucket` | Histogram | Latency of broadcast replay in milliseconds. Measures time taken to replay messages to newly connected clients. | **Per-Tenant** |
-| `realtime_rpc_bucket` | Histogram | Inter-node RPC call duration across the Realtime cluster. Monitor this to identify network issues or overloaded cluster nodes. | Global |
-| `realtime_tenants_read_authorization_check_bucket` | Histogram | RLS policy evaluation time for read operations in milliseconds. High values indicate complex RLS policies or database performance issues. | **Per-Tenant** |
-| `realtime_tenants_read_authorization_check_count` | Counter | Number of read authorization checks per second. Monitor this alongside bucket metrics to identify high authorization load. | **Per-Tenant** |
-| `realtime_tenants_write_authorization_check_bucket` | Histogram | RLS policy evaluation time for write operations in milliseconds. Typically higher than read checks due to more complex policy logic. | **Per-Tenant** |
+| Metric | Type | Description | Scope | Endpoint |
+|--------|------|-------------|-------|----------|
+| `realtime_replication_poller_query_duration_bucket` | Histogram | Postgres Changes query latency in milliseconds per tenant. High values may indicate database performance issues. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_replication_poller_query_duration_count` | Counter | Number of database polling queries executed per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_tenants_broadcast_from_database_latency_committed_at_bucket` | Histogram | Time from database commit to client broadcast per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_tenants_broadcast_from_database_latency_inserted_at_bucket` | Histogram | Alternative latency using insert timestamp per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_tenants_replay_bucket` | Histogram | Broadcast replay latency per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_global_rpc_bucket` | Histogram | Inter-node RPC call latency distribution, tagged by `success` and `mechanism`. | Global Aggregate | `/metrics` |
+| `realtime_global_rpc_count` | Counter | Total inter-node RPC calls. Divide failed by total to get error rate. | Global Aggregate | `/metrics` |
+| `realtime_tenants_read_authorization_check_bucket` | Histogram | RLS policy evaluation time for read operations per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_tenants_read_authorization_check_count` | Counter | Number of read authorization checks per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_tenants_write_authorization_check_bucket` | Histogram | RLS policy evaluation time for write operations per tenant. | **Per-Tenant** | `/metrics/tenant` |
+| `phoenix_channel_handled_in_duration_milliseconds_bucket` | Histogram | Time for the application to respond to a channel message. High p99 values indicate slow message handlers. | Per-Node | `/metrics` |
+| `phoenix_socket_connected_duration_milliseconds_bucket` | Histogram | Time to establish a WebSocket socket connection, tagged by `result`/`transport`/`serializer`. | Per-Node | `/metrics` |
 
 ### Authorization & Error Metrics
 
-These metrics track security policy enforcement and error rates across authorization and RPC operations.
+These metrics track security policy enforcement and error rates.
 
-| Metric | Type | Description | Scope |
-|--------|------|-------------|-------|
-| `realtime_channel_error` | Counter | Unhandled channel errors per second that should not occur during normal operation. Any non-zero value warrants investigation and potential bug reporting. | Per-Node |
-| `phoenix_channel_joined_total` | Counter | Total channel join attempts with success/error status. High error rates indicate client configuration issues, insufficient resources, or policy violations. | Per-Node |
-| `realtime_global_rpc_count` | Counter | Global RPC success and failure counts across the cluster. Failed RPCs may indicate inter-node communication issues or temporary overload conditions. | Global |
+| Metric | Type | Description | Scope | Endpoint |
+|--------|------|-------------|-------|----------|
+| `realtime_channel_error` | Counter | Unhandled channel errors per tenant. Any non-zero value warrants investigation. | **Per-Tenant** | `/metrics/tenant` |
+| `realtime_channel_global_error` | Counter | Global unhandled channel error count across all tenants, tagged by error code. | Global Aggregate | `/metrics` |
+| `phoenix_channel_joined_total` | Counter | WebSocket channel join attempts tagged by `result` (`ok`/`error`) and `transport`. Use `result="error"` rate to detect client or policy issues. | Per-Node | `/metrics` |
 
 ### BEAM/Erlang VM Metrics
 
 These metrics provide insight into the underlying Erlang runtime that powers Realtime, critical for capacity planning and debugging performance issues.
+
+All BEAM/Erlang VM metrics are served from `GET /metrics`.
 
 #### Memory Metrics
 
@@ -427,7 +471,7 @@ These metrics provide insight into the underlying Erlang runtime that powers Rea
 
 ### Infrastructure Metrics
 
-These metrics expose system-level resource usage and inter-node cluster communication.
+These metrics expose system-level resource usage and inter-node cluster communication. All infrastructure metrics are served from `GET /metrics`.
 
 #### Node Metrics
 
@@ -451,7 +495,7 @@ These metrics expose system-level resource usage and inter-node cluster communic
 | `dist_send_pending_bytes` | Gauge | Bytes pending in Erlang distribution queues. Works with queue size to diagnose cluster communication issues. |
 | `dist_send_bytes` | Counter | Total bytes sent via Erlang distribution protocol. Includes all cluster metadata and RPC traffic. |
 | `dist_recv_bytes` | Counter | Total bytes received via Erlang distribution protocol. Compare with send to validate symmetric communication. |
-do
+
 ## License
 
 This repo is licensed under Apache 2.0.

--- a/config/config.exs
+++ b/config/config.exs
@@ -85,6 +85,7 @@ config :gen_rpc,
 
 config :prom_ex, :storage_adapter, Realtime.PromEx.Store
 config :realtime, Realtime.PromEx, ets_flush_interval: 90_000
+config :realtime, Realtime.TenantPromEx, ets_flush_interval: 90_000
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -69,6 +69,7 @@ defmodule Realtime.Application do
         Realtime.ErlSysMon,
         Realtime.GenCounter,
         Realtime.PromEx,
+        Realtime.TenantPromEx,
         {Realtime.Telemetry.Logger, handler_id: "telemetry-logger"},
         RealtimeWeb.Telemetry,
         {Cluster.Supervisor, [topologies, [name: Realtime.ClusterSupervisor]]},

--- a/lib/realtime/metrics_cleaner.ex
+++ b/lib/realtime/metrics_cleaner.ex
@@ -120,7 +120,7 @@ defmodule Realtime.MetricsCleaner do
 
       vacant_tenant_ids
       |> Enum.map(fn tenant_id -> %{tenant: tenant_id} end)
-      |> then(&Peep.prune_tags(Realtime.PromEx.Metrics, &1))
+      |> then(&Peep.prune_tags(Realtime.TenantPromEx.Metrics, &1))
 
       # Delete them from the table
       :ets.select_delete(cleaner_table, [

--- a/lib/realtime/monitoring/prom_ex.ex
+++ b/lib/realtime/monitoring/prom_ex.ex
@@ -1,13 +1,19 @@
 defmodule Realtime.PromEx do
-  alias Realtime.PromEx.Plugins.Channels
   alias Realtime.PromEx.Plugins.Distributed
   alias Realtime.PromEx.Plugins.GenRpc
   alias Realtime.PromEx.Plugins.OsMon
   alias Realtime.PromEx.Plugins.Phoenix
-  alias Realtime.PromEx.Plugins.Tenant
+  alias Realtime.PromEx.Plugins.TenantGlobal
   alias Realtime.PromEx.Plugins.Tenants
 
   @moduledoc """
+  PromEx configuration for global metrics (BEAM, OS, Phoenix, distributed infrastructure).
+
+  These are higher-priority metrics. Configure your Victoria Metrics scrape interval
+  lower compared to the tenant metrics endpoint.
+
+  Exposes metrics via `/metrics` and `/metrics/:region`.
+
   Be sure to add the following to finish setting up PromEx:
 
   1. Update your configuration (config.exs, dev.exs, prod.exs, releases.exs, etc) to
@@ -96,8 +102,7 @@ defmodule Realtime.PromEx do
       {Phoenix, router: RealtimeWeb.Router, poll_rate: poll_rate, metric_prefix: [:phoenix]},
       {OsMon, poll_rate: poll_rate},
       {Tenants, poll_rate: poll_rate},
-      {Tenant, poll_rate: poll_rate},
-      {Channels, poll_rate: poll_rate},
+      {TenantGlobal, poll_rate: poll_rate},
       {Distributed, poll_rate: poll_rate},
       {GenRpc, poll_rate: poll_rate}
     ]
@@ -126,7 +131,7 @@ defmodule Realtime.PromEx do
     ]
   end
 
-  def get_metrics do
+  def get_global_metrics do
     metrics = PromEx.get_metrics(Realtime.PromEx)
 
     Realtime.PromEx.__ets_cron_flusher_name__()
@@ -134,4 +139,7 @@ defmodule Realtime.PromEx do
 
     metrics
   end
+
+  @doc deprecated: "Use get_global_metrics/0 instead"
+  def get_metrics, do: get_global_metrics()
 end

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -44,15 +44,6 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           tags: [:tenant, :message_type],
           unit: :byte,
           reporter_options: [peep_bucket_calculator: PayloadSize.Buckets]
-        ),
-        distribution(
-          [:realtime, :payload, :size],
-          event_name: [:realtime, :tenants, :payload, :size],
-          measurement: :size,
-          description: "Payload size",
-          tags: [:message_type],
-          unit: :byte,
-          reporter_options: [peep_bucket_calculator: PayloadSize.Buckets]
         )
       ]
     )
@@ -154,12 +145,6 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           tags: [:tenant]
         ),
         sum(
-          [:realtime, :channel, :global, :events],
-          event_name: [:realtime, :rate_counter, :channel, :events],
-          measurement: :sum,
-          description: "Global sum of messages sent on a Realtime Channel."
-        ),
-        sum(
           [:realtime, :channel, :presence_events],
           event_name: [:realtime, :rate_counter, :channel, :presence_events],
           measurement: :sum,
@@ -167,23 +152,11 @@ defmodule Realtime.PromEx.Plugins.Tenant do
           tags: [:tenant]
         ),
         sum(
-          [:realtime, :channel, :global, :presence_events],
-          event_name: [:realtime, :rate_counter, :channel, :presence_events],
-          measurement: :sum,
-          description: "Global sum of presence messages sent on a Realtime Channel."
-        ),
-        sum(
           [:realtime, :channel, :db_events],
           event_name: [:realtime, :rate_counter, :channel, :db_events],
           measurement: :sum,
           description: "Sum of db messages sent on a Realtime Channel.",
           tags: [:tenant]
-        ),
-        sum(
-          [:realtime, :channel, :global, :db_events],
-          event_name: [:realtime, :rate_counter, :channel, :db_events],
-          measurement: :sum,
-          description: "Global sum of db messages sent on a Realtime Channel."
         ),
         sum(
           [:realtime, :channel, :joins],

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant_global.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant_global.ex
@@ -1,0 +1,134 @@
+defmodule Realtime.PromEx.Plugins.TenantGlobal do
+  @moduledoc """
+  Global aggregated variants of per-tenant metrics.
+
+  Subscribes to the same telemetry events as the Tenant plugin but records
+  metrics without the tenant tag, enabling cluster-wide aggregation.
+  These live on the global endpoint (/metrics) for high-priority scraping.
+  """
+
+  use PromEx.Plugin
+  alias Realtime.PromEx.Plugins.Tenant
+  alias Realtime.Telemetry
+  alias Realtime.UsersCounter
+
+  @global_connections_event [:prom_ex, :plugin, :realtime, :connections, :global]
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate, 5_000)
+
+    [
+      Polling.build(
+        :realtime_global_connections,
+        poll_rate,
+        {__MODULE__, :execute_global_connection_metrics, []},
+        [
+          last_value(
+            [:realtime, :connections, :global, :connected],
+            event_name: @global_connections_event,
+            description: "The node total count of connected clients across all tenants.",
+            measurement: :connected
+          ),
+          last_value(
+            [:realtime, :connections, :global, :connected_cluster],
+            event_name: @global_connections_event,
+            description: "The cluster total count of connected clients across all tenants.",
+            measurement: :connected_cluster
+          )
+        ],
+        detach_on_error: false
+      )
+    ]
+  end
+
+  @impl true
+  def event_metrics(_opts) do
+    [
+      channel_global_events(),
+      payload_global_size_metrics()
+    ]
+  end
+
+  def execute_global_connection_metrics do
+    cluster_counts = UsersCounter.tenant_counts()
+    local_tenant_counts = UsersCounter.local_tenant_counts()
+
+    connected = local_tenant_counts |> Map.values() |> Enum.sum()
+    connected_cluster = cluster_counts |> Map.values() |> Enum.sum()
+
+    Telemetry.execute(
+      @global_connections_event,
+      %{connected: connected, connected_cluster: connected_cluster},
+      %{}
+    )
+  end
+
+  defp payload_global_size_metrics do
+    Event.build(
+      :realtime_global_payload_size_metrics,
+      [
+        distribution(
+          [:realtime, :payload, :size],
+          event_name: [:realtime, :tenants, :payload, :size],
+          measurement: :size,
+          description: "Global payload size across all tenants",
+          tags: [:message_type],
+          unit: :byte,
+          reporter_options: [peep_bucket_calculator: Tenant.PayloadSize.Buckets]
+        )
+      ]
+    )
+  end
+
+  defp channel_global_events do
+    Event.build(
+      :realtime_global_channel_event_metrics,
+      [
+        sum(
+          [:realtime, :channel, :global, :events],
+          event_name: [:realtime, :rate_counter, :channel, :events],
+          measurement: :sum,
+          description: "Global sum of messages sent on a Realtime Channel."
+        ),
+        sum(
+          [:realtime, :channel, :global, :presence_events],
+          event_name: [:realtime, :rate_counter, :channel, :presence_events],
+          measurement: :sum,
+          description: "Global sum of presence messages sent on a Realtime Channel."
+        ),
+        sum(
+          [:realtime, :channel, :global, :db_events],
+          event_name: [:realtime, :rate_counter, :channel, :db_events],
+          measurement: :sum,
+          description: "Global sum of db messages sent on a Realtime Channel."
+        ),
+        sum(
+          [:realtime, :channel, :global, :joins],
+          event_name: [:realtime, :rate_counter, :channel, :joins],
+          measurement: :sum,
+          description: "Global sum of Realtime Channel joins."
+        ),
+        sum(
+          [:realtime, :channel, :global, :input_bytes],
+          event_name: [:realtime, :channel, :input_bytes],
+          description: "Global sum of input bytes sent on sockets.",
+          measurement: :size
+        ),
+        sum(
+          [:realtime, :channel, :global, :output_bytes],
+          event_name: [:realtime, :channel, :output_bytes],
+          description: "Global sum of output bytes sent on sockets.",
+          measurement: :size
+        ),
+        counter(
+          [:realtime, :channel, :global, :error],
+          event_name: [:realtime, :channel, :error],
+          measurement: :code,
+          tags: [:code],
+          description: "Global count of errors in Realtime channel initialization."
+        )
+      ]
+    )
+  end
+end

--- a/lib/realtime/monitoring/tenant_prom_ex.ex
+++ b/lib/realtime/monitoring/tenant_prom_ex.ex
@@ -1,0 +1,35 @@
+defmodule Realtime.TenantPromEx do
+  alias Realtime.PromEx.Plugins.Channels
+  alias Realtime.PromEx.Plugins.Tenant
+
+  @moduledoc """
+  PromEx configuration for tenant-level metrics.
+
+  These metrics are per-tenant and considered secondary priority for scraping.
+  Configure your Victoria Metrics scrape interval higher (e.g. 60s) compared
+  to the global metrics endpoint.
+
+  Exposes metrics via `/metrics/tenant` and `/metrics/:region/tenant`.
+  """
+
+  use PromEx, otp_app: :realtime
+
+  @impl true
+  def plugins do
+    poll_rate = Application.get_env(:realtime, :prom_poll_rate)
+
+    [
+      {Tenant, poll_rate: poll_rate},
+      {Channels, poll_rate: poll_rate}
+    ]
+  end
+
+  def get_metrics do
+    metrics = PromEx.get_metrics(Realtime.TenantPromEx)
+
+    Realtime.TenantPromEx.__ets_cron_flusher_name__()
+    |> PromEx.ETSCronFlusher.defer_ets_flush()
+
+    metrics
+  end
+end

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -76,7 +76,9 @@ defmodule RealtimeWeb.Router do
     pipe_through(:metrics)
 
     get("/", MetricsController, :index)
+    get("/tenant", MetricsController, :tenant)
     get("/:region", MetricsController, :region)
+    get("/:region/tenant", MetricsController, :region_tenant)
   end
 
   scope "/api" do

--- a/test/realtime/metrics_cleaner_test.exs
+++ b/test/realtime/metrics_cleaner_test.exs
@@ -32,7 +32,7 @@ defmodule Realtime.MetricsCleanerTest do
       Beacon.join(:users, "vacant-tenant1", pid2)
       Beacon.join(:users, "vacant-tenant2", pid3)
 
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
 
       assert String.contains?(metrics, "tenant=\"occupied-tenant\"")
       assert String.contains?(metrics, "tenant=\"vacant-tenant1\"")
@@ -50,7 +50,7 @@ defmodule Realtime.MetricsCleanerTest do
       Process.sleep(200)
 
       # Nothing changes yet (threshold not reached)
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
 
       assert String.contains?(metrics, "tenant=\"occupied-tenant\"")
       assert String.contains?(metrics, "tenant=\"vacant-tenant1\"")
@@ -60,7 +60,7 @@ defmodule Realtime.MetricsCleanerTest do
       Process.sleep(2200)
 
       # vacant tenant metrics are now gone
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
 
       assert String.contains?(metrics, "tenant=\"occupied-tenant\"")
       refute String.contains?(metrics, "tenant=\"vacant-tenant1\"")
@@ -78,7 +78,7 @@ defmodule Realtime.MetricsCleanerTest do
 
       Beacon.join(:users, "reconnect-tenant", pid)
 
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
       assert String.contains?(metrics, "tenant=\"reconnect-tenant\"")
 
       start_supervised!(
@@ -97,7 +97,7 @@ defmodule Realtime.MetricsCleanerTest do
       Process.sleep(2200)
 
       # Metrics should still be present
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
       assert String.contains?(metrics, "tenant=\"reconnect-tenant\"")
     end
   end
@@ -122,7 +122,7 @@ defmodule Realtime.MetricsCleanerTest do
         %{tenant: "disconnected-tenant2"}
       )
 
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
 
       assert String.contains?(metrics, "tenant=\"connected-tenant\"")
       assert String.contains?(metrics, "tenant=\"disconnected-tenant1\"")
@@ -143,7 +143,7 @@ defmodule Realtime.MetricsCleanerTest do
       Process.sleep(200)
 
       # Nothing changes yet (threshold not reached)
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
 
       assert String.contains?(metrics, "tenant=\"connected-tenant\"")
       assert String.contains?(metrics, "tenant=\"disconnected-tenant1\"")
@@ -153,7 +153,7 @@ defmodule Realtime.MetricsCleanerTest do
       Process.sleep(2200)
 
       # disconnected tenant metrics are now gone
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
 
       assert String.contains?(metrics, "tenant=\"connected-tenant\"")
       refute String.contains?(metrics, "tenant=\"disconnected-tenant1\"")
@@ -167,7 +167,7 @@ defmodule Realtime.MetricsCleanerTest do
         %{tenant: "reconnect-tenant"}
       )
 
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
       assert String.contains?(metrics, "tenant=\"reconnect-tenant\"")
 
       start_supervised!(
@@ -185,7 +185,7 @@ defmodule Realtime.MetricsCleanerTest do
       Process.sleep(2200)
 
       # Metrics should still be present
-      metrics = Realtime.PromEx.get_metrics() |> IO.iodata_to_binary()
+      metrics = Realtime.TenantPromEx.get_metrics() |> IO.iodata_to_binary()
       assert String.contains?(metrics, "tenant=\"reconnect-tenant\"")
     end
   end

--- a/test/realtime/metrics_pusher_test.exs
+++ b/test/realtime/metrics_pusher_test.exs
@@ -138,7 +138,7 @@ defmodule Realtime.MetricsPusherTest do
 
       log =
         capture_log(fn ->
-          Req.Test.expect(MetricsPusher, fn conn ->
+          Req.Test.expect(MetricsPusher, fn _conn ->
             send(parent, :req_called)
             raise RuntimeError, "unexpected error"
           end)

--- a/test/realtime_web/controllers/metrics_controller_test.exs
+++ b/test/realtime_web/controllers/metrics_controller_test.exs
@@ -7,6 +7,100 @@ defmodule RealtimeWeb.MetricsControllerTest do
   import ExUnit.CaptureLog
   use Mimic
 
+  # Metrics that must appear on GET /metrics (global endpoint)
+  @global_metrics [
+    # BEAM / OS
+    "beam_system_schedulers_online_info",
+    "osmon_ram_usage",
+    # Phoenix WebSocket channel, socket, and connection capacity
+    "phoenix_channel_joined_total",
+    "phoenix_channel_handled_in_duration_milliseconds",
+    "phoenix_socket_connected_duration_milliseconds",
+    "phoenix_connections_active",
+    "phoenix_connections_max",
+    # GenRPC call latency
+    "realtime_global_rpc",
+    # Global aggregates of tenant activity (no tenant label)
+    "realtime_channel_global_events",
+    "realtime_channel_global_presence_events",
+    "realtime_channel_global_db_events",
+    "realtime_channel_global_joins",
+    "realtime_channel_global_input_bytes",
+    "realtime_channel_global_output_bytes",
+    "realtime_channel_global_error",
+    "realtime_payload_size"
+  ]
+
+  # Metrics that must appear on GET /metrics/tenant (tenant endpoint)
+  @tenant_metrics [
+    # Per-tenant channel events
+    "realtime_channel_events",
+    "realtime_channel_presence_events",
+    "realtime_channel_db_events",
+    "realtime_channel_joins",
+    "realtime_channel_input_bytes",
+    "realtime_channel_output_bytes",
+    # Per-tenant payload size
+    "realtime_tenants_payload_size",
+    # Per-tenant latency / replication
+    "realtime_replication_poller_query_duration",
+    "realtime_tenants_read_authorization_check",
+    "realtime_tenants_write_authorization_check",
+    "realtime_tenants_broadcast_from_database_latency_committed_at",
+    "realtime_tenants_broadcast_from_database_latency_inserted_at",
+    "realtime_tenants_replay",
+    # Per-tenant errors
+    "realtime_channel_error"
+  ]
+
+  # Fires every telemetry event needed to populate all event-based metrics
+  defp fire_all_tenant_events do
+    tenant_meta = %{tenant: "test_tenant"}
+
+    :telemetry.execute([:realtime, :channel, :error], %{code: 1}, %{code: 404})
+    :telemetry.execute([:realtime, :rate_counter, :channel, :events], %{sum: 5}, tenant_meta)
+    :telemetry.execute([:realtime, :rate_counter, :channel, :presence_events], %{sum: 3}, tenant_meta)
+    :telemetry.execute([:realtime, :rate_counter, :channel, :db_events], %{sum: 2}, tenant_meta)
+    :telemetry.execute([:realtime, :rate_counter, :channel, :joins], %{sum: 1}, tenant_meta)
+    :telemetry.execute([:realtime, :channel, :input_bytes], %{size: 1024}, tenant_meta)
+    :telemetry.execute([:realtime, :channel, :output_bytes], %{size: 2048}, tenant_meta)
+
+    :telemetry.execute(
+      [:realtime, :tenants, :payload, :size],
+      %{size: 512},
+      Map.put(tenant_meta, :message_type, "broadcast")
+    )
+
+    :telemetry.execute([:realtime, :replication, :poller, :query, :stop], %{duration: 100}, tenant_meta)
+    :telemetry.execute([:realtime, :tenants, :read_authorization_check], %{latency: 10}, tenant_meta)
+    :telemetry.execute([:realtime, :tenants, :write_authorization_check], %{latency: 15}, tenant_meta)
+
+    :telemetry.execute(
+      [:realtime, :tenants, :broadcast_from_database],
+      %{latency_committed_at: 50, latency_inserted_at: 40},
+      tenant_meta
+    )
+
+    :telemetry.execute([:realtime, :tenants, :replay], %{latency: 20}, tenant_meta)
+    :telemetry.execute([:realtime, :rpc], %{latency: 5}, %{success: true, mechanism: :erpc})
+
+    :telemetry.execute([:phoenix, :channel_joined], %{}, %{
+      result: :ok,
+      socket: %Phoenix.Socket{transport: :websocket, endpoint: RealtimeWeb.Endpoint}
+    })
+
+    :telemetry.execute([:phoenix, :channel_handled_in], %{duration: 500_000}, %{
+      socket: %Phoenix.Socket{endpoint: RealtimeWeb.Endpoint}
+    })
+
+    :telemetry.execute([:phoenix, :socket_connected], %{duration: 200_000}, %{
+      result: :ok,
+      endpoint: RealtimeWeb.Endpoint,
+      transport: :websocket,
+      serializer: Phoenix.Socket.V2.JSONSerializer
+    })
+  end
+
   setup_all do
     metrics_tags = %{
       region: "ap-southeast-2",
@@ -22,31 +116,51 @@ defmodule RealtimeWeb.MetricsControllerTest do
     :ok
   end
 
-  describe "GET /metrics" do
-    setup %{conn: conn} do
-      # The metrics pipeline requires authentication
-      jwt_secret = Application.fetch_env!(:realtime, :metrics_jwt_secret)
-      token = generate_jwt_token(jwt_secret, %{})
-      authenticated_conn = put_req_header(conn, "authorization", "Bearer #{token}")
+  setup %{conn: conn} do
+    jwt_secret = Application.fetch_env!(:realtime, :metrics_jwt_secret)
+    token = generate_jwt_token(jwt_secret, %{})
 
-      {:ok, conn: authenticated_conn}
+    {:ok, conn: put_req_header(conn, "authorization", "Bearer #{token}")}
+  end
+
+  describe "GET /metrics" do
+    test "contains all expected global metrics", %{conn: conn} do
+      fire_all_tenant_events()
+
+      response =
+        conn
+        |> get(~p"/metrics")
+        |> text_response(200)
+
+      for metric <- @global_metrics do
+        assert response =~ "# HELP #{metric}", "expected global metric #{metric} to be present"
+      end
     end
 
-    test "returns 200", %{conn: conn} do
-      assert response =
-               conn
-               |> get(~p"/metrics")
-               |> text_response(200)
+    test "does not contain per-tenant labeled metrics", %{conn: conn} do
+      fire_all_tenant_events()
 
-      # Check prometheus like metrics
-      assert response =~
-               "# HELP beam_system_schedulers_online_info The number of scheduler threads that are online."
+      response =
+        conn
+        |> get(~p"/metrics")
+        |> text_response(200)
+
+      for metric <- @tenant_metrics do
+        refute response =~ "# HELP #{metric}\n", "expected tenant metric #{metric} to be absent from global endpoint"
+      end
+    end
+
+    test "includes region tags from all nodes", %{conn: conn} do
+      response =
+        conn
+        |> get(~p"/metrics")
+        |> text_response(200)
 
       assert response =~ "region=\"ap-southeast-2\""
       assert response =~ "region=\"us-east-1\""
     end
 
-    test "returns 200 and log on timeout", %{conn: conn} do
+    test "returns 200 and logs error on node timeout", %{conn: conn} do
       Mimic.stub(GenRpc, :call, fn node, mod, func, args, opts ->
         if node != node() do
           {:error, :rpc_error, :timeout}
@@ -57,97 +171,195 @@ defmodule RealtimeWeb.MetricsControllerTest do
 
       log =
         capture_log(fn ->
-          assert response =
-                   conn
-                   |> get(~p"/metrics")
-                   |> text_response(200)
+          response =
+            conn
+            |> get(~p"/metrics")
+            |> text_response(200)
 
-          # Check prometheus like metrics
-          assert response =~
-                   "# HELP beam_system_schedulers_online_info The number of scheduler threads that are online."
-
-          refute response =~ "region=\"ap-southeast-2"
-          assert response =~ "region=\"us-east-1"
+          refute response =~ "region=\"ap-southeast-2\""
+          assert response =~ "region=\"us-east-1\""
         end)
 
       assert log =~ "Cannot fetch metrics from the node"
     end
 
     test "returns 403 when authorization header is missing", %{conn: conn} do
-      assert conn
-             |> delete_req_header("authorization")
-             |> get(~p"/metrics")
-             |> response(403)
+      conn
+      |> delete_req_header("authorization")
+      |> get(~p"/metrics")
+      |> response(403)
     end
 
     test "returns 403 when authorization header is wrong", %{conn: conn} do
-      token = generate_jwt_token("bad_secret", %{})
-
-      assert _ =
-               conn
-               |> put_req_header("authorization", "Bearer #{token}")
-               |> get(~p"/metrics")
-               |> response(403)
+      conn
+      |> put_req_header("authorization", "Bearer #{generate_jwt_token("bad_secret", %{})}")
+      |> get(~p"/metrics")
+      |> response(403)
     end
   end
 
-  describe "GET /metrics/:region" do
-    setup %{conn: conn} do
-      # The metrics pipeline requires authentication
-      jwt_secret = Application.fetch_env!(:realtime, :metrics_jwt_secret)
-      token = generate_jwt_token(jwt_secret, %{})
-      authenticated_conn = put_req_header(conn, "authorization", "Bearer #{token}")
+  describe "GET /metrics/tenant" do
+    test "contains all expected tenant metrics", %{conn: conn} do
+      fire_all_tenant_events()
 
-      {:ok, conn: authenticated_conn}
+      response =
+        conn
+        |> get(~p"/metrics/tenant")
+        |> text_response(200)
+
+      for metric <- @tenant_metrics do
+        assert response =~ "# HELP #{metric}", "expected tenant metric #{metric} to be present"
+      end
     end
 
-    test "returns 200", %{conn: conn} do
-      assert response =
-               conn
-               |> get(~p"/metrics/ap-southeast-2")
-               |> text_response(200)
+    test "does not contain global aggregated or BEAM metrics", %{conn: conn} do
+      fire_all_tenant_events()
 
-      # Check prometheus like metrics
-      assert response =~
-               "# HELP beam_system_schedulers_online_info The number of scheduler threads that are online."
+      response =
+        conn
+        |> get(~p"/metrics/tenant")
+        |> text_response(200)
 
-      assert response =~ "region=\"ap-southeast-2\""
-      refute response =~ "region=\"us-east-1\""
+      for metric <- @global_metrics do
+        refute response =~ "# HELP #{metric}\n", "expected global metric #{metric} to be absent from tenant endpoint"
+      end
     end
 
-    test "returns 200 and log on timeout", %{conn: conn} do
+    test "returns 200 and logs error on node timeout", %{conn: conn} do
       Mimic.stub(GenRpc, :call, fn _node, _mod, _func, _args, _opts ->
         {:error, :rpc_error, :timeout}
       end)
 
       log =
         capture_log(fn ->
-          assert response =
-                   conn
-                   |> get(~p"/metrics/ap-southeast-2")
-                   |> text_response(200)
-
-          assert response == ""
+          assert conn |> get(~p"/metrics/tenant") |> text_response(200) == ""
         end)
 
       assert log =~ "Cannot fetch metrics from the node"
     end
 
     test "returns 403 when authorization header is missing", %{conn: conn} do
-      assert conn
-             |> delete_req_header("authorization")
-             |> get(~p"/metrics/ap-southeast-2")
-             |> response(403)
+      conn
+      |> delete_req_header("authorization")
+      |> get(~p"/metrics/tenant")
+      |> response(403)
     end
 
     test "returns 403 when authorization header is wrong", %{conn: conn} do
-      token = generate_jwt_token("bad_secret", %{})
+      conn
+      |> put_req_header("authorization", "Bearer #{generate_jwt_token("bad_secret", %{})}")
+      |> get(~p"/metrics/tenant")
+      |> response(403)
+    end
+  end
 
-      assert _ =
-               conn
-               |> put_req_header("authorization", "Bearer #{token}")
-               |> get(~p"/metrics/ap-southeast-2")
-               |> response(403)
+  describe "GET /metrics/:region" do
+    test "returns global metrics scoped to the given region", %{conn: conn} do
+      response =
+        conn
+        |> get(~p"/metrics/ap-southeast-2")
+        |> text_response(200)
+
+      assert response =~ "# HELP beam_system_schedulers_online_info"
+      assert response =~ "region=\"ap-southeast-2\""
+      refute response =~ "region=\"us-east-1\""
+    end
+
+    test "does not contain per-tenant labeled metrics", %{conn: conn} do
+      fire_all_tenant_events()
+
+      response =
+        conn
+        |> get(~p"/metrics/us-east-1")
+        |> text_response(200)
+
+      for metric <- @tenant_metrics do
+        refute response =~ "# HELP #{metric}\n",
+               "expected tenant metric #{metric} to be absent from region global endpoint"
+      end
+    end
+
+    test "returns 200 and logs error on node timeout", %{conn: conn} do
+      Mimic.stub(GenRpc, :call, fn _node, _mod, _func, _args, _opts ->
+        {:error, :rpc_error, :timeout}
+      end)
+
+      log =
+        capture_log(fn ->
+          assert conn |> get(~p"/metrics/ap-southeast-2") |> text_response(200) == ""
+        end)
+
+      assert log =~ "Cannot fetch metrics from the node"
+    end
+
+    test "returns 403 when authorization header is missing", %{conn: conn} do
+      conn
+      |> delete_req_header("authorization")
+      |> get(~p"/metrics/ap-southeast-2")
+      |> response(403)
+    end
+
+    test "returns 403 when authorization header is wrong", %{conn: conn} do
+      conn
+      |> put_req_header("authorization", "Bearer #{generate_jwt_token("bad_secret", %{})}")
+      |> get(~p"/metrics/ap-southeast-2")
+      |> response(403)
+    end
+  end
+
+  describe "GET /metrics/:region/tenant" do
+    test "returns tenant metrics scoped to the given region", %{conn: conn} do
+      fire_all_tenant_events()
+
+      response =
+        conn
+        |> get(~p"/metrics/us-east-1/tenant")
+        |> text_response(200)
+
+      for metric <- @tenant_metrics do
+        assert response =~ "# HELP #{metric}", "expected tenant metric #{metric} to be present"
+      end
+    end
+
+    test "does not contain global aggregated or BEAM metrics", %{conn: conn} do
+      fire_all_tenant_events()
+
+      response =
+        conn
+        |> get(~p"/metrics/ap-southeast-2/tenant")
+        |> text_response(200)
+
+      for metric <- @global_metrics do
+        refute response =~ "# HELP #{metric}\n",
+               "expected global metric #{metric} to be absent from region tenant endpoint"
+      end
+    end
+
+    test "returns 200 and logs error on node timeout", %{conn: conn} do
+      Mimic.stub(GenRpc, :call, fn _node, _mod, _func, _args, _opts ->
+        {:error, :rpc_error, :timeout}
+      end)
+
+      log =
+        capture_log(fn ->
+          assert conn |> get(~p"/metrics/ap-southeast-2/tenant") |> text_response(200) == ""
+        end)
+
+      assert log =~ "Cannot fetch metrics from the node"
+    end
+
+    test "returns 403 when authorization header is missing", %{conn: conn} do
+      conn
+      |> delete_req_header("authorization")
+      |> get(~p"/metrics/ap-southeast-2/tenant")
+      |> response(403)
+    end
+
+    test "returns 403 when authorization header is wrong", %{conn: conn} do
+      conn
+      |> put_req_header("authorization", "Bearer #{generate_jwt_token("bad_secret", %{})}")
+      |> get(~p"/metrics/ap-southeast-2/tenant")
+      |> response(403)
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

To improve operations we are going to separate tenant metrics from node metrics so we also separate product bound from operational bound workflows
