### PR TITLE
fix: extract RealtimeWeb.Socket

### DIFF
--- a/lib/realtime_web/channels/user_socket.ex
+++ b/lib/realtime_web/channels/user_socket.ex
@@ -1,46 +1,5 @@
 defmodule RealtimeWeb.UserSocket do
-  # This is defined up here before `use Phoenix.Socket` is called so that we can define `Phoenix.Socket.init/1`
-  # It has to be overridden because we need to set the `max_heap_size` flag from the transport process context
-  @impl Phoenix.Socket.Transport
-  def handle_in({payload, opts}, {_state, socket} = full_state) do
-    Phoenix.Socket.__in__({payload, opts}, full_state)
-  rescue
-    e in Phoenix.Socket.InvalidMessageError ->
-      RealtimeWeb.RealtimeChannel.Logging.log_error(socket, "MalformedWebSocketMessage", e.message)
-      {:ok, full_state}
-
-    e in Jason.DecodeError ->
-      RealtimeWeb.RealtimeChannel.Logging.log_error(socket, "MalformedWebSocketMessage", Jason.DecodeError.message(e))
-      {:ok, full_state}
-
-    e ->
-      RealtimeWeb.RealtimeChannel.Logging.log_error(socket, "UnknownErrorOnWebSocketMessage", Exception.message(e))
-      {:ok, full_state}
-  end
-
-  @impl true
-  def init(state) when is_tuple(state) do
-    Process.flag(:max_heap_size, max_heap_size())
-    Process.send_after(self(), {:measure_traffic, 0, 0}, measure_traffic_interval_in_ms())
-    Phoenix.Socket.__init__(state)
-  end
-
-  @impl true
-  def handle_info(
-        {:measure_traffic, previous_recv, previous_send},
-        {_, %{assigns: assigns, transport_pid: transport_pid}} = state
-      ) do
-    tenant_external_id = Map.get(assigns, :tenant)
-
-    %{latest_recv: latest_recv, latest_send: latest_send} =
-      collect_traffic_telemetry(transport_pid, tenant_external_id, previous_recv, previous_send)
-
-    Process.send_after(self(), {:measure_traffic, latest_recv, latest_send}, measure_traffic_interval_in_ms())
-
-    {:ok, state}
-  end
-
-  use Phoenix.Socket
+  use RealtimeWeb.Socket
   use Realtime.Logs
 
   alias Realtime.Api.Tenant
@@ -52,6 +11,7 @@ defmodule RealtimeWeb.UserSocket do
   alias RealtimeWeb.ChannelsAuthorization
   alias RealtimeWeb.RealtimeChannel
   alias RealtimeWeb.RealtimeChannel.Logging
+
   ## Channels
   channel "realtime:*", RealtimeChannel
 
@@ -159,41 +119,5 @@ defmodule RealtimeWeb.UserSocket do
     {:error, reason}
   end
 
-  defp max_heap_size(), do: :persistent_term.get({__MODULE__, :websocket_max_heap_size})
-  defp measure_traffic_interval_in_ms(), do: :persistent_term.get({__MODULE__, :measure_traffic_interval_in_ms})
   defp connect_error_backoff_ms(), do: :persistent_term.get({__MODULE__, :connect_error_backoff_ms})
-
-  defp collect_traffic_telemetry(nil, _tenant_external_id, previous_recv, previous_send),
-    do: %{latest_recv: previous_recv, latest_send: previous_send}
-
-  defp collect_traffic_telemetry(transport_pid, tenant_external_id, previous_recv, previous_send) do
-    %{send_oct: latest_send, recv_oct: latest_recv} =
-      transport_pid
-      |> Process.info(:links)
-      |> then(fn {:links, links} -> links end)
-      |> Enum.filter(&is_port/1)
-      |> Enum.reduce(%{send_oct: 0, recv_oct: 0}, fn link, acc ->
-        case :inet.getstat(link, [:send_oct, :recv_oct]) do
-          {:ok, stats} ->
-            send_oct = Keyword.get(stats, :send_oct, 0)
-            recv_oct = Keyword.get(stats, :recv_oct, 0)
-
-            %{
-              send_oct: acc.send_oct + send_oct,
-              recv_oct: acc.recv_oct + recv_oct
-            }
-
-          {:error, _} ->
-            acc
-        end
-      end)
-
-    send_delta = max(0, latest_send - previous_send)
-    recv_delta = max(0, latest_recv - previous_recv)
-
-    :telemetry.execute([:realtime, :channel, :output_bytes], %{size: send_delta}, %{tenant: tenant_external_id})
-    :telemetry.execute([:realtime, :channel, :input_bytes], %{size: recv_delta}, %{tenant: tenant_external_id})
-
-    %{latest_recv: latest_recv, latest_send: latest_send}
-  end
 end

--- a/lib/realtime_web/socket.ex
+++ b/lib/realtime_web/socket.ex
@@ -1,0 +1,130 @@
+defmodule RealtimeWeb.Socket do
+  @moduledoc """
+  A drop-in replacement for `use Phoenix.Socket` that adds Realtime-specific
+  transport behaviour:
+
+    * Sets `:max_heap_size` on the transport process during `init/1`
+    * Schedules periodic traffic measurement via `handle_info/2`
+    * Wraps `handle_in/2` with error handling for malformed WebSocket messages
+  """
+
+  defmacro __using__(opts) do
+    quote do
+      import Phoenix.Socket
+      @behaviour Phoenix.Socket
+      @before_compile Phoenix.Socket
+      Module.register_attribute(__MODULE__, :phoenix_channels, accumulate: true)
+      @phoenix_socket_options unquote(opts)
+
+      @behaviour Phoenix.Socket.Transport
+
+      @doc false
+      def child_spec(opts) do
+        Phoenix.Socket.__child_spec__(__MODULE__, opts, @phoenix_socket_options)
+      end
+
+      @doc false
+      def drainer_spec(opts) do
+        Phoenix.Socket.__drainer_spec__(__MODULE__, opts, @phoenix_socket_options)
+      end
+
+      @doc false
+      def connect(map), do: Phoenix.Socket.__connect__(__MODULE__, map, @phoenix_socket_options)
+
+      @doc false
+      def init(state) when is_tuple(state) do
+        Process.flag(:max_heap_size, :persistent_term.get({__MODULE__, :websocket_max_heap_size}))
+
+        Process.send_after(
+          self(),
+          {:measure_traffic, 0, 0},
+          :persistent_term.get({__MODULE__, :measure_traffic_interval_in_ms})
+        )
+
+        Phoenix.Socket.__init__(state)
+      end
+
+      @doc false
+      def handle_in({payload, opts}, {_state, socket} = full_state) do
+        Phoenix.Socket.__in__({payload, opts}, full_state)
+      rescue
+        e in Phoenix.Socket.InvalidMessageError ->
+          RealtimeWeb.RealtimeChannel.Logging.log_error(socket, "MalformedWebSocketMessage", e.message)
+          {:ok, full_state}
+
+        e in Jason.DecodeError ->
+          RealtimeWeb.RealtimeChannel.Logging.log_error(
+            socket,
+            "MalformedWebSocketMessage",
+            Jason.DecodeError.message(e)
+          )
+
+          {:ok, full_state}
+
+        e ->
+          RealtimeWeb.RealtimeChannel.Logging.log_error(socket, "UnknownErrorOnWebSocketMessage", Exception.message(e))
+          {:ok, full_state}
+      end
+
+      @doc false
+      def handle_info(
+            {:measure_traffic, previous_recv, previous_send},
+            {_, %{assigns: assigns, transport_pid: transport_pid}} = state
+          ) do
+        tenant_external_id = Map.get(assigns, :tenant)
+
+        %{latest_recv: latest_recv, latest_send: latest_send} =
+          RealtimeWeb.Socket.collect_traffic_telemetry(
+            transport_pid,
+            tenant_external_id,
+            previous_recv,
+            previous_send
+          )
+
+        Process.send_after(
+          self(),
+          {:measure_traffic, latest_recv, latest_send},
+          :persistent_term.get({__MODULE__, :measure_traffic_interval_in_ms})
+        )
+
+        {:ok, state}
+      end
+
+      def handle_info(message, state), do: Phoenix.Socket.__info__(message, state)
+
+      @doc false
+      def terminate(reason, state), do: Phoenix.Socket.__terminate__(reason, state)
+    end
+  end
+
+  @doc false
+  def collect_traffic_telemetry(nil, _tenant_external_id, previous_recv, previous_send),
+    do: %{latest_recv: previous_recv, latest_send: previous_send}
+
+  def collect_traffic_telemetry(transport_pid, tenant_external_id, previous_recv, previous_send) do
+    %{send_oct: latest_send, recv_oct: latest_recv} =
+      transport_pid
+      |> Process.info(:links)
+      |> then(fn {:links, links} -> links end)
+      |> Enum.filter(&is_port/1)
+      |> Enum.reduce(%{send_oct: 0, recv_oct: 0}, fn link, acc ->
+        case :inet.getstat(link, [:send_oct, :recv_oct]) do
+          {:ok, stats} ->
+            send_oct = Keyword.get(stats, :send_oct, 0)
+            recv_oct = Keyword.get(stats, :recv_oct, 0)
+            %{send_oct: acc.send_oct + send_oct, recv_oct: acc.recv_oct + recv_oct}
+
+          {:error, _} ->
+            acc
+        end
+      end)
+
+    send_delta = max(0, latest_send - previous_send)
+    recv_delta = max(0, latest_recv - previous_recv)
+
+    :telemetry.execute([:realtime, :channel, :output_bytes], %{size: send_delta}, %{tenant: tenant_external_id})
+    :telemetry.execute([:realtime, :channel, :input_bytes], %{size: recv_delta}, %{tenant: tenant_external_id})
+
+    %{latest_recv: latest_recv, latest_send: latest_send}
+  end
+end

--- a/test/realtime_web/socket_test.exs
+++ b/test/realtime_web/socket_test.exs
@@ -1,0 +1,64 @@
+defmodule RealtimeWeb.SocketTest do
+  use ExUnit.Case, async: true
+
+  alias RealtimeWeb.Socket
+
+  describe "collect_traffic_telemetry/4" do
+    test "returns previous values unchanged when transport_pid is nil" do
+      assert Socket.collect_traffic_telemetry(nil, "tenant", 42, 99) ==
+               %{latest_recv: 42, latest_send: 99}
+    end
+
+    test "fires no telemetry when transport_pid is nil" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:realtime, :channel, :output_bytes]])
+
+      Socket.collect_traffic_telemetry(nil, "tenant", 0, 0)
+
+      refute_received {[:realtime, :channel, :output_bytes], ^ref, _, _}
+    end
+
+    test "returns zero stats when transport process has no port links" do
+      pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert Socket.collect_traffic_telemetry(pid, "tenant", 0, 0) ==
+               %{latest_recv: 0, latest_send: 0}
+
+      Process.exit(pid, :kill)
+    end
+
+    test "fires output_bytes and input_bytes telemetry with correct tenant metadata" do
+      pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:realtime, :channel, :output_bytes],
+          [:realtime, :channel, :input_bytes]
+        ])
+
+      Socket.collect_traffic_telemetry(pid, "my-tenant", 0, 0)
+
+      assert_received {[:realtime, :channel, :output_bytes], ^ref, %{size: 0}, %{tenant: "my-tenant"}}
+      assert_received {[:realtime, :channel, :input_bytes], ^ref, %{size: 0}, %{tenant: "my-tenant"}}
+
+      Process.exit(pid, :kill)
+    end
+
+    test "delta is clamped to zero when previous stats exceed current (no negative deltas)" do
+      pid = spawn(fn -> Process.sleep(:infinity) end)
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:realtime, :channel, :output_bytes],
+          [:realtime, :channel, :input_bytes]
+        ])
+
+      # No port links → latest = 0, but previous > 0 → delta would be negative without max(0, ...)
+      Socket.collect_traffic_telemetry(pid, "tenant", 1000, 500)
+
+      assert_received {[:realtime, :channel, :output_bytes], ^ref, %{size: 0}, _}
+      assert_received {[:realtime, :channel, :input_bytes], ^ref, %{size: 0}, _}
+
+      Process.exit(pid, :kill)
+    end
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

A drop-in replacement for `use Phoenix.Socket` that adds Realtime-specific transport behaviour:
* Sets `:max_heap_size` on the transport process during `init/1`
* Schedules periodic traffic measurement via `handle_info/2`
* Wraps `handle_in/2` with error handling for malformed WebSocket messages


This way we can avoid hacking around on UserSocket and we still mostly use `Phoenix.Socket` in the end without forking the code