### PR TITLE
fix: properly clean up subscriptions when oids changed

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscription_manager.ex
+++ b/lib/extensions/postgres_cdc_rls/subscription_manager.ex
@@ -153,6 +153,9 @@ defmodule Extensions.PostgresCdcRls.SubscriptionManager do
           end
           |> :ets.foldl([], state.subscribers_pids_table)
 
+          :ets.delete_all_objects(state.subscribers_pids_table)
+          :ets.delete_all_objects(state.subscribers_nodes_table)
+
           new_oids
       end
 

--- a/test/realtime/extensions/cdc_rls/subscription_manager_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscription_manager_test.exs
@@ -172,6 +172,8 @@ defmodule Realtime.Extensions.CdcRls.SubscriptionManagerTest do
       send(pid, :check_oids)
 
       assert_receive :postgres_subscribe, 1000
+      assert :ets.tab2list(args["subscribers_pids_table"]) == []
+      assert :ets.tab2list(args["subscribers_nodes_table"]) == []
     end
 
     test "logs error when subscription deletion fails during check_delete_queue", %{


### PR DESCRIPTION
## What kind of change does this PR introduce?

We were calling `Process.demonitor/2` but we were not cleaning up the tables when subscriptions were re-set.

This way we kept trying to check for these pids but when a node was gone we would still try to contact them on SubscriptionChecker