### PR TITLE
feat: add PartitonedTables

### DIFF
--- a/lib/realtime/monitoring/peep/partitioned_tables.ex
+++ b/lib/realtime/monitoring/peep/partitioned_tables.ex
@@ -1,0 +1,168 @@
+defmodule Realtime.Monitoring.Peep.PartitionedTables do
+  @moduledoc """
+  Peep.Storage implementation using N ETS tables with optional tag-based routing.
+
+  Each metric write is routed to a specific table based on a `:routing_tag` option.
+  If the routing tag is present in the metric's tags, `:erlang.phash2/2` is used to
+  select the table. Otherwise, the first table is used.
+
+  This reduces lock contention by routing different tag values (e.g. different tenants)
+  to different ETS tables, without partitioning metrics within a table.
+
+  ## Options
+
+    * `:tables` - number of ETS tables to create (default: `1`)
+    * `:routing_tag` - atom key used to select the target table (default: `nil`)
+
+  ## Example
+
+      {Realtime.Monitoring.Peep.PartitionedTables, [tables: 4, routing_tag: :tenant_id]}
+  """
+
+  alias Peep.Storage
+  alias Telemetry.Metrics
+
+  @behaviour Peep.Storage
+
+  @typep tids() :: tuple()
+  @typep state() :: {tids(), atom() | nil}
+
+  @spec new(keyword()) :: state()
+  @impl true
+  def new(opts) do
+    n_tables = Keyword.get(opts, :tables, 1)
+    routing_tag = Keyword.get(opts, :routing_tag, nil)
+
+    ets_opts = [
+      :public,
+      read_concurrency: false,
+      write_concurrency: true,
+      decentralized_counters: true
+    ]
+
+    tids = List.to_tuple(Enum.map(1..n_tables, fn _ -> :ets.new(__MODULE__, ets_opts) end))
+    {tids, routing_tag}
+  end
+
+  @impl true
+  def storage_size({tids, _routing_tag}) do
+    {size, memory} =
+      tids
+      |> Tuple.to_list()
+      |> Enum.reduce({0, 0}, fn tid, {size, memory} ->
+        {size + :ets.info(tid, :size), memory + :ets.info(tid, :memory)}
+      end)
+
+    %{
+      size: size,
+      memory: memory * :erlang.system_info(:wordsize)
+    }
+  end
+
+  @impl true
+  def insert_metric({tids, routing_tag}, id, %Metrics.Counter{}, _value, %{} = tags) do
+    tid = get_tid(tids, routing_tag, tags)
+    key = {id, tags}
+    :ets.update_counter(tid, key, {2, 1}, {key, 0})
+  end
+
+  def insert_metric({tids, routing_tag}, id, %Metrics.Sum{}, value, %{} = tags) do
+    tid = get_tid(tids, routing_tag, tags)
+    key = {id, tags}
+    :ets.update_counter(tid, key, {2, value}, {key, 0})
+  end
+
+  def insert_metric({tids, routing_tag}, id, %Metrics.LastValue{}, value, %{} = tags) do
+    tid = get_tid(tids, routing_tag, tags)
+    key = {id, tags}
+    :ets.insert(tid, {key, value})
+  end
+
+  def insert_metric({tids, routing_tag}, id, %Metrics.Distribution{} = metric, value, %{} = tags) do
+    tid = get_tid(tids, routing_tag, tags)
+    key = {id, tags}
+
+    atomics =
+      case :ets.lookup(tid, key) do
+        [{_key, ref}] ->
+          ref
+
+        [] ->
+          # Race condition: Multiple processes could be attempting to write to this key.
+          # :ets.insert_new/2 breaks ties so concurrent writers agree on which
+          # :atomics object to increment.
+          new_atomics = Storage.Atomics.new(metric)
+
+          case :ets.insert_new(tid, {key, new_atomics}) do
+            true ->
+              new_atomics
+
+            false ->
+              [{_key, atomics}] = :ets.lookup(tid, key)
+              atomics
+          end
+      end
+
+    Storage.Atomics.insert(atomics, value)
+  end
+
+  @impl true
+  def get_all_metrics({tids, _routing_tag}, %Peep.Persistent{ids_to_metrics: itm}) do
+    tids
+    |> Tuple.to_list()
+    |> Enum.flat_map(&:ets.tab2list/1)
+    |> Enum.reduce(%{}, fn {{id, tags}, value}, acc ->
+      %{^id => metric} = itm
+      put_in(acc, [Access.key(metric, %{}), tags], to_value(value))
+    end)
+  end
+
+  @impl true
+  def get_metric({tids, routing_tag}, id, %Metrics.Distribution{}, tags) do
+    tid = get_tid(tids, routing_tag, tags)
+    key = {id, tags}
+
+    case :ets.lookup(tid, key) do
+      [] -> nil
+      [{_key, atomics}] -> Storage.Atomics.values(atomics)
+    end
+  end
+
+  def get_metric({tids, routing_tag}, id, metric, tags) do
+    tid = get_tid(tids, routing_tag, tags)
+    key = {id, tags}
+
+    case :ets.lookup(tid, key) do
+      [] -> empty_value(metric)
+      [{_, value}] -> value
+    end
+  end
+
+  defp empty_value(%Metrics.Counter{}), do: 0
+  defp empty_value(%Metrics.Sum{}), do: 0
+  defp empty_value(%Metrics.LastValue{}), do: nil
+
+  @impl true
+  def prune_tags({tids, routing_tag}, patterns) do
+    patterns
+    |> Enum.group_by(&get_tid(tids, routing_tag, &1))
+    |> Enum.each(fn {tid, grouped} ->
+      match_spec = Enum.map(grouped, fn pattern -> {{{:_, pattern}, :_}, [], [true]} end)
+      :ets.select_delete(tid, match_spec)
+    end)
+
+    :ok
+  end
+
+  defp get_tid(tids, nil, _tags), do: elem(tids, 0)
+
+  defp get_tid(tids, routing_tag, tags) do
+    case Map.fetch(tags, routing_tag) do
+      {:ok, value} -> elem(tids, :erlang.phash2(value, tuple_size(tids)))
+      :error -> elem(tids, 0)
+    end
+  end
+
+  defp to_value(%Storage.Atomics{} = atomics), do: Storage.Atomics.values(atomics)
+  defp to_value(value), do: value
+end

--- a/lib/realtime/monitoring/prom_ex.ex
+++ b/lib/realtime/monitoring/prom_ex.ex
@@ -88,7 +88,7 @@ defmodule Realtime.PromEx do
         name: name,
         metrics: metrics,
         global_tags: Application.get_env(:realtime, :metrics_tags, %{}),
-        storage: {Realtime.Monitoring.Peep.Partitioned, 4}
+        storage: {Realtime.Monitoring.Peep.PartitionedTables, tables: 4, routing_tag: :tenant}
       )
     end
   end

--- a/test/realtime/metrics_pusher_test.exs
+++ b/test/realtime/metrics_pusher_test.exs
@@ -57,8 +57,8 @@ defmodule Realtime.MetricsPusherTest do
       {:ok, _pid} = start_and_allow_pusher(opts)
 
       # Receive both request bodies
-      assert_receive {:req_called, body1}, 100
-      assert_receive {:req_called, body2}, 100
+      assert_receive {:req_called, body1}, 300
+      assert_receive {:req_called, body2}, 300
 
       global_metric = ~r/beam_stats_run_queue_count/
       tenant_metric = ~r/realtime_channel_input_bytes/
@@ -86,8 +86,8 @@ defmodule Realtime.MetricsPusherTest do
       end)
 
       {:ok, _pid} = start_and_allow_pusher(opts)
-      assert_receive :req_called, 100
-      assert_receive :req_called, 100
+      assert_receive :req_called, 300
+      assert_receive :req_called, 300
     end
 
     test "sends request body untouched when compress=false" do
@@ -111,8 +111,8 @@ defmodule Realtime.MetricsPusherTest do
       end)
 
       {:ok, _pid} = start_and_allow_pusher(opts)
-      assert_receive :req_called, 100
-      assert_receive :req_called, 100
+      assert_receive :req_called, 300
+      assert_receive :req_called, 300
     end
 
     test "when request receives non 2XX response" do
@@ -134,8 +134,8 @@ defmodule Realtime.MetricsPusherTest do
           end)
 
           {:ok, pid} = start_and_allow_pusher(opts)
-          assert_receive :req_called, 100
-          assert_receive :req_called, 100
+          assert_receive :req_called, 300
+          assert_receive :req_called, 300
           assert Process.alive?(pid)
           # Wait enough for the log to be captured
           Process.sleep(100)
@@ -162,8 +162,8 @@ defmodule Realtime.MetricsPusherTest do
           end)
 
           {:ok, pid} = start_and_allow_pusher(opts)
-          assert_receive :req_called, 100
-          assert_receive :req_called, 100
+          assert_receive :req_called, 300
+          assert_receive :req_called, 300
           assert Process.alive?(pid)
           # Wait enough for the log to be captured
           Process.sleep(100)
@@ -190,8 +190,8 @@ defmodule Realtime.MetricsPusherTest do
       end)
 
       {:ok, _pid} = start_and_allow_pusher(opts)
-      assert_receive {:req_called, query_string}, 100
-      assert_receive {:req_called, _}, 100
+      assert_receive {:req_called, query_string}, 300
+      assert_receive {:req_called, _}, 300
 
       decoded_params = query_string |> String.split("&") |> Enum.map(&URI.decode_www_form/1)
       assert "extra_label=region=us-east-1" in decoded_params

--- a/test/realtime/monitoring/peep/partitioned_tables_test.exs
+++ b/test/realtime/monitoring/peep/partitioned_tables_test.exs
@@ -1,0 +1,158 @@
+Application.put_env(:peep, :test_storages, [
+  {Realtime.Monitoring.Peep.PartitionedTables, [tables: 4]},
+  {Realtime.Monitoring.Peep.PartitionedTables, [tables: 4, routing_tag: :tenant_id]},
+  {Realtime.Monitoring.Peep.PartitionedTables, [tables: 1]}
+])
+
+Code.require_file("../../../../deps/peep/test/shared/storage_test.exs", __DIR__)
+
+defmodule Realtime.Monitoring.Peep.PartitionedTablesTest do
+  use ExUnit.Case, async: true
+
+  alias Realtime.Monitoring.Peep.PartitionedTables
+  alias Telemetry.Metrics
+
+  describe "get_all_metrics" do
+    test "collects metrics from all tables" do
+      counter = Metrics.counter("all_metrics.test.counter")
+      last_value = Metrics.last_value("all_metrics.test.gauge")
+
+      n_tables = 4
+      tenant_a = "tenant-alpha"
+      tenant_b = "tenant-beta"
+
+      assert :erlang.phash2(tenant_a, n_tables) != :erlang.phash2(tenant_b, n_tables)
+
+      name = :"test_all_metrics_#{System.unique_integer([:positive])}"
+
+      {:ok, _} =
+        Peep.start_link(
+          name: name,
+          metrics: [counter, last_value],
+          storage: {PartitionedTables, [tables: n_tables, routing_tag: :tenant_id]}
+        )
+
+      tags_a = %{tenant_id: tenant_a}
+      tags_b = %{tenant_id: tenant_b}
+
+      for _ <- 1..3, do: Peep.insert_metric(name, counter, 1, tags_a)
+      for _ <- 1..7, do: Peep.insert_metric(name, counter, 1, tags_b)
+      for _ <- 1..11, do: Peep.insert_metric(name, counter, 1, %{})
+      Peep.insert_metric(name, last_value, 42, tags_a)
+      Peep.insert_metric(name, last_value, 99, tags_b)
+      Peep.insert_metric(name, last_value, 111, %{})
+
+      all = Peep.get_all_metrics(name)
+
+      assert all[counter][tags_a] == 3
+      assert all[counter][tags_b] == 7
+      assert all[counter][%{}] == 11
+      assert all[last_value][tags_a] == 42
+      assert all[last_value][tags_b] == 99
+      assert all[last_value][%{}] == 111
+    end
+  end
+
+  describe "routing tag" do
+    test "routes different tag values to different tables" do
+      n_tables = 4
+      routing_tag = :tenant_id
+      {tids, ^routing_tag} = PartitionedTables.new(tables: n_tables, routing_tag: routing_tag)
+
+      counter = Metrics.counter("routing.test.counter")
+      id = :erlang.phash2(counter)
+
+      tenant_a = "tenant-alpha"
+      tenant_b = "tenant-beta"
+
+      index_a = :erlang.phash2(tenant_a, n_tables)
+      index_b = :erlang.phash2(tenant_b, n_tables)
+
+      # Ensure the two tenants map to different tables for this test to be meaningful
+      assert index_a != index_b,
+             "tenant-alpha and tenant-beta must hash to different table indices"
+
+      tags_a = %{tenant_id: tenant_a}
+      tags_b = %{tenant_id: tenant_b}
+
+      for _ <- 1..10 do
+        PartitionedTables.insert_metric({tids, routing_tag}, id, counter, 1, tags_a)
+        PartitionedTables.insert_metric({tids, routing_tag}, id, counter, 1, tags_b)
+      end
+
+      # Each tenant's data is in its own table
+      assert :ets.lookup(elem(tids, index_a), {id, tags_a}) != []
+      assert :ets.lookup(elem(tids, index_b), {id, tags_b}) != []
+
+      # Cross-table: each tenant's key must NOT exist in the other's table
+      assert :ets.lookup(elem(tids, index_a), {id, tags_b}) == []
+      assert :ets.lookup(elem(tids, index_b), {id, tags_a}) == []
+    end
+
+    test "falls back to first table when routing tag is absent from tags" do
+      n_tables = 4
+      routing_tag = :tenant_id
+      {tids, ^routing_tag} = PartitionedTables.new(tables: n_tables, routing_tag: routing_tag)
+
+      counter = Metrics.counter("fallback.test.counter")
+      id = :erlang.phash2(counter)
+      tags = %{env: :prod}
+
+      PartitionedTables.insert_metric({tids, routing_tag}, id, counter, 1, tags)
+
+      assert :ets.lookup(elem(tids, 0), {id, tags}) != []
+
+      for i <- 1..(n_tables - 1) do
+        assert :ets.lookup(elem(tids, i), {id, tags}) == []
+      end
+    end
+
+    test "prune_tags targets only the relevant table for patterns with routing tag" do
+      n_tables = 4
+      routing_tag = :tenant_id
+      {tids, ^routing_tag} = PartitionedTables.new(tables: n_tables, routing_tag: routing_tag)
+
+      counter = Metrics.counter("prune.targeted.test.counter")
+      id = :erlang.phash2(counter)
+
+      tenant_a = "tenant-alpha"
+      tenant_b = "tenant-beta"
+
+      index_a = :erlang.phash2(tenant_a, n_tables)
+      index_b = :erlang.phash2(tenant_b, n_tables)
+      assert index_a != index_b
+
+      tags_a = %{tenant_id: tenant_a}
+      tags_b = %{tenant_id: tenant_b}
+
+      PartitionedTables.insert_metric({tids, routing_tag}, id, counter, 1, tags_a)
+      PartitionedTables.insert_metric({tids, routing_tag}, id, counter, 1, tags_b)
+
+      # Prune only tenant A using a targeted pattern
+      :ok = PartitionedTables.prune_tags({tids, routing_tag}, [tags_a])
+
+      assert :ets.lookup(elem(tids, index_a), {id, tags_a}) == []
+      assert :ets.lookup(elem(tids, index_b), {id, tags_b}) != []
+    end
+
+    test "prune_tags targets table 0 when pattern has no routing tag" do
+      n_tables = 4
+      routing_tag = :tenant_id
+      {tids, ^routing_tag} = PartitionedTables.new(tables: n_tables, routing_tag: routing_tag)
+
+      counter = Metrics.counter("prune.broadcast.test.counter")
+      id = :erlang.phash2(counter)
+
+      # Tags with no routing key → written to table 0
+      tags = %{env: :prod}
+      PartitionedTables.insert_metric({tids, routing_tag}, id, counter, 1, tags)
+
+      assert :ets.lookup(elem(tids, 0), {id, tags}) != []
+
+      # Pattern without routing tag → deletes from table 0 only
+      :ok = PartitionedTables.prune_tags({tids, routing_tag}, [%{env: :prod}])
+
+      assert :ets.lookup(elem(tids, 0), {id, tags}) == []
+    end
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Peep.Storage implementation using N ETS tables with optional tag-based routing.

Each metric write is routed to a specific table based on a `:routing_tag` option. If the routing tag is present in the metric's tags, `:erlang.phash2/2` is used to select the table. Otherwise, the first table is used.

This reduces lock contention by routing different tag values (e.g. different tenants) to different ETS tables, without partitioning metrics within a table.

If a metric does not have a routing_tag to route we just put the on the first table. This way we never have a metric/tag combination in more than 1 table simplifying most operations.