### PR TITLE
fix: Subscriptions.create transaction should timeout early

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -4,7 +4,7 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
   """
   use Realtime.Logs
 
-  import Postgrex, only: [transaction: 2, query: 3, rollback: 2]
+  import Postgrex, only: [transaction: 3, query: 3, rollback: 2]
 
   @type conn() :: Postgrex.conn()
   @type filter :: {binary, binary, binary}
@@ -18,27 +18,33 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
           | {:error, Exception.t() | {:exit, term} | {:subscription_insert_failed, String.t()}}
 
   def create(conn, publication, subscription_list, manager, caller) do
-    transaction(conn, fn conn ->
-      Enum.map(subscription_list, fn %{id: id, claims: claims, subscription_params: params} ->
-        case query(conn, publication, id, claims, params) do
-          {:ok, %{num_rows: num} = result} when num > 0 ->
-            send(manager, {:subscribed, {caller, id}})
-            result
+    opts = [timeout: 10_000]
 
-          {:ok, _} ->
-            msg =
-              "Unable to subscribe to changes with given parameters. Please check Realtime is enabled for the given connect parameters: [#{params_to_log(params)}]"
+    transaction(
+      conn,
+      fn conn ->
+        Enum.map(subscription_list, fn %{id: id, claims: claims, subscription_params: params} ->
+          case query(conn, publication, id, claims, params) do
+            {:ok, %{num_rows: num} = result} when num > 0 ->
+              send(manager, {:subscribed, {caller, id}})
+              result
 
-            rollback(conn, {:subscription_insert_failed, msg})
+            {:ok, _} ->
+              msg =
+                "Unable to subscribe to changes with given parameters. Please check Realtime is enabled for the given connect parameters: [#{params_to_log(params)}]"
 
-          {:error, exception} ->
-            msg =
-              "Unable to subscribe to changes with given parameters. An exception happened so please check your connect parameters: [#{params_to_log(params)}]. Exception: #{Exception.message(exception)}"
+              rollback(conn, {:subscription_insert_failed, msg})
 
-            rollback(conn, {:subscription_insert_failed, msg})
-        end
-      end)
-    end)
+            {:error, exception} ->
+              msg =
+                "Unable to subscribe to changes with given parameters. An exception happened so please check your connect parameters: [#{params_to_log(params)}]. Exception: #{Exception.message(exception)}"
+
+              rollback(conn, {:subscription_insert_failed, msg})
+          end
+        end)
+      end,
+      opts
+    )
   rescue
     e in DBConnection.ConnectionError -> {:error, e}
   catch

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -138,7 +138,7 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
     test "timeout", %{conn: conn} do
       {:ok, subscription_params} = Subscriptions.parse_subscription_params(%{"schema" => "public", "table" => "test"})
 
-      Task.start(fn -> Postgrex.query!(conn, "SELECT pg_sleep(20)", []) end)
+      Task.start(fn -> Postgrex.query!(conn, "SELECT pg_sleep(11)", []) end)
 
       subscription_list = [%{claims: %{"role" => "anon"}, id: UUID.uuid1(), subscription_params: subscription_params}]
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The RPC timeout is currently sitting at 15s (also the default `Postgrex.transaction/2,3` timeout)

https://github.com/supabase/realtime/blob/a3538e9fbf60ebf0583bac97cfd986fb96a82077/lib/extensions/postgres_cdc_rls/cdc_rls.ex#L64

10 seconds should be plenty of time to create subscriptions