### PR TITLE
fix: add granularity to unable to set policies errors

### DIFF
--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -152,9 +152,8 @@ defmodule Realtime.Tenants.Authorization do
     end
   end
 
-  def get_write_authorizations(db_conn, authorization_context) do
-    get_write_authorizations(%Policies{}, db_conn, authorization_context)
-  end
+  def get_write_authorizations(db_conn, authorization_context),
+    do: get_write_authorizations(%Policies{}, db_conn, authorization_context)
 
   defp handle_policies_result(result, rate_counter) do
     case result do
@@ -167,10 +166,10 @@ defmodule Realtime.Tenants.Authorization do
       {:error, %Postgrex.Error{postgres: %{code: :invalid_parameter_value}} = error} ->
         {:error, :rls_policy_error, error}
 
-      {:error, %MatchError{term: {:error, %Postgrex.Error{postgres: %{code: :query_canceled}} = error}}} ->
+      {:error, %Postgrex.Error{postgres: %{code: :query_canceled}} = error} ->
         {:error, :query_canceled, error}
 
-      {:error, %MatchError{term: {:error, %Postgrex.Error{postgres: %{code: :check_violation, table: "messages"}}}}} ->
+      {:error, %Postgrex.Error{postgres: %{code: :check_violation, table: "messages"}}} ->
         {:error, :missing_partition}
 
       {:error, %ConnectionError{reason: :queue_timeout}} ->

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -60,7 +60,13 @@ defmodule Realtime.Tenants.Authorization do
   Automatically uses RPC if the database connection is not in the same node
   """
   @spec get_read_authorizations(Policies.t(), pid(), t(), keyword()) ::
-          {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error | :query_canceled, any()}
+          {:ok, Policies.t()}
+          | {:error, :rls_policy_error, Postgrex.Error.t()}
+          | {:error, :query_canceled, Postgrex.Error.t()}
+          | {:error, :missing_partition}
+          | {:error, :increase_connection_pool}
+          | {:error, :tenant_database_unavailable}
+          | {:error, any()}
   def get_read_authorizations(policies, db_conn, authorization_context, opts \\ [])
 
   def get_read_authorizations(policies, db_conn, authorization_context, opts) when node() == node(db_conn) do
@@ -109,7 +115,13 @@ defmodule Realtime.Tenants.Authorization do
   Automatically uses RPC if the database connection is not in the same node
   """
   @spec get_write_authorizations(Policies.t(), pid(), t(), keyword()) ::
-          {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error | :query_canceled, any()}
+          {:ok, Policies.t()}
+          | {:error, :rls_policy_error, Postgrex.Error.t()}
+          | {:error, :query_canceled, Postgrex.Error.t()}
+          | {:error, :missing_partition}
+          | {:error, :increase_connection_pool}
+          | {:error, :tenant_database_unavailable}
+          | {:error, any()}
   def get_write_authorizations(policies, db_conn, authorization_context, opts \\ [])
 
   def get_write_authorizations(policies, db_conn, authorization_context, opts) when node() == node(db_conn) do

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -108,7 +108,7 @@ defmodule Realtime.Tenants.Authorization do
 
   Automatically uses RPC if the database connection is not in the same node
   """
-  @spec get_write_authorizations(Policies.t(), pid(), __MODULE__.t(), keyword()) ::
+  @spec get_write_authorizations(Policies.t(), pid(), t(), keyword()) ::
           {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error | :query_canceled, any()}
   def get_write_authorizations(policies, db_conn, authorization_context, opts \\ [])
 

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -60,7 +60,7 @@ defmodule Realtime.Tenants.Authorization do
   Automatically uses RPC if the database connection is not in the same node
   """
   @spec get_read_authorizations(Policies.t(), pid(), t(), keyword()) ::
-          {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error, any()}
+          {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error | :query_canceled, any()}
   def get_read_authorizations(policies, db_conn, authorization_context, opts \\ [])
 
   def get_read_authorizations(policies, db_conn, authorization_context, opts) when node() == node(db_conn) do
@@ -109,7 +109,7 @@ defmodule Realtime.Tenants.Authorization do
   Automatically uses RPC if the database connection is not in the same node
   """
   @spec get_write_authorizations(Policies.t(), pid(), __MODULE__.t(), keyword()) ::
-          {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error, any()}
+          {:ok, Policies.t()} | {:error, any()} | {:error, :rls_policy_error | :query_canceled, any()}
   def get_write_authorizations(policies, db_conn, authorization_context, opts \\ [])
 
   def get_write_authorizations(policies, db_conn, authorization_context, opts) when node() == node(db_conn) do
@@ -164,6 +164,15 @@ defmodule Realtime.Tenants.Authorization do
       {:ok, {:error, %Postgrex.Error{} = error}} ->
         {:error, :rls_policy_error, error}
 
+      {:error, %Postgrex.Error{postgres: %{code: :invalid_parameter_value}} = error} ->
+        {:error, :rls_policy_error, error}
+
+      {:error, %MatchError{term: {:error, %Postgrex.Error{postgres: %{code: :query_canceled}} = error}}} ->
+        {:error, :query_canceled, error}
+
+      {:error, %MatchError{term: {:error, %Postgrex.Error{postgres: %{code: :check_violation, table: "messages"}}}}} ->
+        {:error, :missing_partition}
+
       {:error, %ConnectionError{reason: :queue_timeout}} ->
         GenCounter.add(rate_counter.id)
         {:error, :increase_connection_pool}
@@ -171,6 +180,9 @@ defmodule Realtime.Tenants.Authorization do
       {:error, {:exit, _}} ->
         GenCounter.add(rate_counter.id)
         {:error, :increase_connection_pool}
+
+      {:error, %ConnectionError{}} ->
+        {:error, :tenant_database_unavailable}
 
       {:error, error} ->
         {:error, error}

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -193,6 +193,12 @@ defmodule RealtimeWeb.RealtimeChannel do
       {:error, :tenant_database_unavailable} ->
         log_error(socket, "UnableToConnectToProject", "Realtime was unable to connect to the project database")
 
+      {:error, :query_canceled, error} ->
+        log_error(socket, "QueryCanceled", error)
+
+      {:error, :missing_partition} ->
+        log_error(socket, "MissingPartition", "Realtime was unable to find the expected messages partition")
+
       {:error, :rpc_error, :timeout} ->
         log_error(socket, "TimeoutOnRpcCall", "Node request timeout")
 
@@ -519,14 +525,25 @@ defmodule RealtimeWeb.RealtimeChannel do
       {:error, :unable_to_set_policies, _msg} ->
         shutdown_response(socket, "Realtime was unable to connect to the project database")
 
-      {:error, error} ->
-        shutdown_response(socket, inspect(error))
+      {:error, :tenant_database_unavailable} ->
+        shutdown_response(socket, "Realtime was unable to connect to the project database")
+
+      {:error, :query_canceled, error} ->
+        log_error(socket, "QueryCanceled", error)
+        shutdown_response(socket, "Query was cancelled, please try again")
+
+      {:error, :missing_partition} ->
+        log_error(socket, "MissingPartition", "Realtime was unable to find the expected messages partition")
+        shutdown_response(socket, "Realtime was unable to connect to the project database")
 
       {:error, :rpc_error, :timeout} ->
         shutdown_response(socket, "Node request timeout")
 
       {:error, :rpc_error, reason} ->
         shutdown_response(socket, "RPC call error: " <> inspect(reason))
+
+      {:error, error} ->
+        shutdown_response(socket, inspect(error))
     end
   end
 
@@ -857,8 +874,11 @@ defmodule RealtimeWeb.RealtimeChannel do
 
         {:error, :unauthorized, "You do not have permissions to read from this Channel topic: #{topic}"}
 
-      {:error, error} ->
+      {:error, %_{} = error} ->
         {:error, :unable_to_set_policies, error}
+
+      other ->
+        other
     end
   end
 

--- a/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
@@ -66,6 +66,21 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
         log_error("RlsPolicyError", error)
         {:noreply, socket}
 
+      {:error, :query_canceled, error} ->
+        log_error("QueryCanceled", error)
+        {:noreply, socket}
+
+      {:error, :missing_partition} ->
+        log_error("MissingPartition", "Realtime was unable to find the expected messages partition")
+        {:noreply, socket}
+
+      {:error, :tenant_database_unavailable} ->
+        log_error("UnableToConnectToProject", "Realtime was unable to connect to the project database")
+        {:noreply, socket}
+
+      {:error, :increase_connection_pool} ->
+        {:noreply, socket}
+
       {:error, error} ->
         log_error("UnableToSetPolicies", error)
         {:noreply, socket}

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -57,7 +57,11 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
           | {:error,
              :invalid_payload
              | :rls_policy_error
+             | :query_canceled
+             | :missing_partition
+             | :tenant_database_unavailable
              | :unable_to_set_policies
+             | :increase_connection_pool
              | :rate_limit_exceeded
              | :client_rate_limit_exceeded
              | :unable_to_track_presence
@@ -90,6 +94,20 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
       {:error, :rls_policy_error, error} ->
         log_error("RlsPolicyError", error)
         {:error, :rls_policy_error}
+
+      {:error, :query_canceled, error} ->
+        log_error("QueryCanceled", error)
+        {:error, :query_canceled}
+
+      {:error, :missing_partition} ->
+        log_error("MissingPartition", "Realtime was unable to find the expected messages partition")
+        {:error, :missing_partition}
+
+      {:error, :tenant_database_unavailable} ->
+        {:error, :tenant_database_unavailable}
+
+      {:error, :increase_connection_pool} ->
+        {:error, :increase_connection_pool}
 
       {:error, error} ->
         log_error("UnableToSetPolicies", error)

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -245,6 +245,73 @@ defmodule Realtime.Tenants.AuthorizationTest do
     end
   end
 
+  describe "database error classification" do
+    @tag role: "anon", policies: []
+    test "invalid_parameter_value Postgrex error is classified as rls_policy_error", context do
+      stub(Database, :transaction, fn _, _, _, _ ->
+        {:error,
+         %Postgrex.Error{postgres: %{code: :invalid_parameter_value, message: "role \"super_admin\" does not exist"}}}
+      end)
+
+      assert {:error, :rls_policy_error, %Postgrex.Error{}} =
+               Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+
+      assert {:error, :rls_policy_error, %Postgrex.Error{}} =
+               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+    end
+
+    @tag role: "anon", policies: []
+    test "MatchError wrapping query_canceled is classified as query_canceled", context do
+      query_canceled = %Postgrex.Error{
+        postgres: %{code: :query_canceled, message: "canceling statement due to user request"}
+      }
+
+      stub(Database, :transaction, fn _, _, _, _ ->
+        {:error, %MatchError{term: {:error, query_canceled}}}
+      end)
+
+      assert {:error, :query_canceled, %Postgrex.Error{}} =
+               Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+
+      assert {:error, :query_canceled, %Postgrex.Error{}} =
+               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+    end
+
+    @tag role: "anon", policies: []
+    test "MatchError wrapping check_violation on messages is classified as missing_partition", context do
+      check_violation = %Postgrex.Error{
+        postgres: %{
+          code: :check_violation,
+          table: "messages",
+          message: "no partition of relation \"messages\" found for row"
+        }
+      }
+
+      stub(Database, :transaction, fn _, _, _, _ ->
+        {:error, %MatchError{term: {:error, check_violation}}}
+      end)
+
+      assert {:error, :missing_partition} =
+               Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+
+      assert {:error, :missing_partition} =
+               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+    end
+
+    @tag role: "anon", policies: []
+    test "DBConnection.ConnectionError is classified as tenant_database_unavailable", context do
+      stub(Database, :transaction, fn _, _, _, _ ->
+        {:error, %DBConnection.ConnectionError{message: "ssl recv: closed", severity: :error, reason: :error}}
+      end)
+
+      assert {:error, :tenant_database_unavailable} =
+               Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+
+      assert {:error, :tenant_database_unavailable} =
+               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+    end
+  end
+
   describe "telemetry" do
     @tag role: "authenticated",
          policies: [

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -261,13 +261,13 @@ defmodule Realtime.Tenants.AuthorizationTest do
     end
 
     @tag role: "anon", policies: []
-    test "MatchError wrapping query_canceled is classified as query_canceled", context do
+    test "query_canceled is classified as query_canceled", context do
       query_canceled = %Postgrex.Error{
         postgres: %{code: :query_canceled, message: "canceling statement due to user request"}
       }
 
       stub(Database, :transaction, fn _, _, _, _ ->
-        {:error, %MatchError{term: {:error, query_canceled}}}
+        {:error, query_canceled}
       end)
 
       assert {:error, :query_canceled, %Postgrex.Error{}} =
@@ -278,7 +278,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
     end
 
     @tag role: "anon", policies: []
-    test "MatchError wrapping check_violation on messages is classified as missing_partition", context do
+    test "check_violation on messages is classified as missing_partition", context do
       check_violation = %Postgrex.Error{
         postgres: %{
           code: :check_violation,
@@ -288,7 +288,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
       }
 
       stub(Database, :transaction, fn _, _, _, _ ->
-        {:error, %MatchError{term: {:error, check_violation}}}
+        {:error, check_violation}
       end)
 
       assert {:error, :missing_partition} =

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -355,6 +355,20 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
       end
     end
 
+    test "increase_connection_pool from write authorization does not log UnableToSetPolicies",
+         %{topic: topic, tenant: tenant, db_conn: db_conn} do
+      socket = socket_fixture(tenant, topic)
+
+      stub(Authorization, :get_write_authorizations, fn _, _, _ -> {:error, :increase_connection_pool} end)
+
+      log =
+        capture_log(fn ->
+          {:noreply, _socket} = BroadcastHandler.handle(%{}, db_conn, socket)
+        end)
+
+      refute log =~ "UnableToSetPolicies"
+    end
+
     @tag policies: [:broken_write_presence]
     test "handle failing rls policy", %{topic: topic, tenant: tenant, db_conn: db_conn} do
       socket = socket_fixture(tenant, topic)

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -277,6 +277,26 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
       end
     end
 
+    test "increase_connection_pool from write authorization returns error and does not log UnableToSetPolicies",
+         %{tenant: tenant, topic: topic, db_conn: db_conn} do
+      stub(Authorization, :get_write_authorizations, fn _, _, _ -> {:error, :increase_connection_pool} end)
+
+      key = random_string()
+      socket = socket_fixture(tenant, topic, key)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :increase_connection_pool} =
+                   PresenceHandler.handle(
+                     %{"event" => "track", "payload" => %{"metadata" => random_string()}},
+                     db_conn,
+                     socket
+                   )
+        end)
+
+      refute log =~ "UnableToSetPolicies"
+    end
+
     @tag policies: [:authenticated_read_broadcast_and_presence, :broken_write_presence]
     test "handle failing rls policy", %{tenant: tenant, topic: topic, db_conn: db_conn} do
       expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context ->

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -725,18 +725,59 @@ defmodule RealtimeWeb.RealtimeChannelTest do
              end) =~ "UnknownErrorOnChannel: Realtime was unable to connect to the project database"
     end
 
-    test "unexpected error while setting policies", %{tenant: tenant} do
+    test "unexpected error while setting policies logs UnknownErrorOnChannel", %{tenant: tenant} do
       jwt = Generators.generate_jwt_token(tenant)
       {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
 
       expect(Authorization, :get_read_authorizations, fn _, _, _, _ ->
-        {:error, "Realtime was unable to connect to the project database"}
+        {:error, "unexpected error"}
+      end)
+
+      assert capture_log(fn ->
+               assert {:error, %{reason: "Unknown Error on Channel"}} =
+                        subscribe_and_join(socket, "realtime:test", %{"config" => %{"private" => true}})
+             end) =~ "UnknownErrorOnChannel"
+    end
+
+    test "struct error while setting policies logs UnableToSetPolicies", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      expect(Authorization, :get_read_authorizations, fn _, _, _, _ ->
+        {:error, %DBConnection.ConnectionError{message: "unexpected error", reason: :error, severity: :error}}
       end)
 
       assert capture_log(fn ->
                assert {:error, %{reason: "Realtime was unable to connect to the project database"}} =
                         subscribe_and_join(socket, "realtime:test", %{"config" => %{"private" => true}})
              end) =~ "UnableToSetPolicies"
+    end
+
+    test "query canceled during join logs QueryCanceled", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      expect(Authorization, :get_read_authorizations, fn _, _, _, _ ->
+        {:error, :query_canceled,
+         %Postgrex.Error{postgres: %{code: :query_canceled, message: "canceling statement due to user request"}}}
+      end)
+
+      assert capture_log(fn ->
+               assert {:error, _} =
+                        subscribe_and_join(socket, "realtime:test", %{"config" => %{"private" => true}})
+             end) =~ "QueryCanceled"
+    end
+
+    test "missing partition during join logs MissingPartition", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      expect(Authorization, :get_read_authorizations, fn _, _, _, _ -> {:error, :missing_partition} end)
+
+      assert capture_log(fn ->
+               assert {:error, _} =
+                        subscribe_and_join(socket, "realtime:test", %{"config" => %{"private" => true}})
+             end) =~ "MissingPartition"
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

add granularity to unable to set policies errors