### PR TITLE
feat: add feature flags mechanism to livedashboard

### DIFF
--- a/lib/realtime/api/feature_flag.ex
+++ b/lib/realtime/api/feature_flag.ex
@@ -1,0 +1,29 @@
+defmodule Realtime.Api.FeatureFlag do
+  @moduledoc """
+  Ecto schema for a global feature flag.
+
+  Flags have a name (unique) and a boolean enabled state. Per-tenant overrides
+  are stored separately on the `Realtime.Api.Tenant` schema as a JSONB map,
+  not as associations on this record.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "feature_flags" do
+    field :name, :string
+    field :enabled, :boolean, default: false
+    timestamps()
+  end
+
+  def changeset(flag, attrs) do
+    flag
+    |> cast(attrs, [:name, :enabled])
+    |> validate_required([:name])
+    |> unique_constraint(:name)
+  end
+end

--- a/lib/realtime/api/tenant.ex
+++ b/lib/realtime/api/tenant.ex
@@ -33,6 +33,7 @@ defmodule Realtime.Api.Tenant do
     field(:max_client_presence_events_per_window, :integer)
     field(:client_presence_window_ms, :integer)
     field(:presence_enabled, :boolean, default: false)
+    field(:feature_flags, :map, default: %{})
 
     has_many(:extensions, Realtime.Api.Extensions,
       foreign_key: :tenant_external_id,
@@ -82,7 +83,8 @@ defmodule Realtime.Api.Tenant do
       :broadcast_adapter,
       :max_client_presence_events_per_window,
       :client_presence_window_ms,
-      :presence_enabled
+      :presence_enabled,
+      :feature_flags
     ])
     |> validate_required([:external_id])
     |> check_constraint(:jwt_secret,

--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -121,6 +121,7 @@ defmodule Realtime.Application do
           id: Realtime.LogThrottle
         ),
         Realtime.Tenants.Cache,
+        Realtime.FeatureFlags.Cache,
         Realtime.RateCounter.DynamicSupervisor,
         Realtime.Latency,
         {Registry, keys: :duplicate, name: Realtime.Registry},

--- a/lib/realtime/feature_flags.ex
+++ b/lib/realtime/feature_flags.ex
@@ -29,7 +29,7 @@ defmodule Realtime.FeatureFlags do
   def upsert_flag(attrs) do
     %FeatureFlag{}
     |> FeatureFlag.changeset(attrs)
-    |> Repo.insert(on_conflict: {:replace, [:enabled, :updated_at]}, conflict_target: :name)
+    |> Repo.insert(on_conflict: {:replace, [:enabled, :updated_at]}, conflict_target: :name, returning: true)
   end
 
   @spec delete_flag(FeatureFlag.t()) :: {:ok, FeatureFlag.t()} | {:error, Ecto.Changeset.t()}

--- a/lib/realtime/feature_flags.ex
+++ b/lib/realtime/feature_flags.ex
@@ -1,0 +1,73 @@
+defmodule Realtime.FeatureFlags do
+  @moduledoc """
+  Manages feature flags with optional per-tenant overrides.
+
+  Each flag has a global enabled/disabled state. Tenants can override that state
+  via a JSONB map stored on the tenant record.
+
+  Use `enabled?/1` to check the global flag value only.
+  Use `enabled?/2` when the flag supports per-tenant overrides. Resolution order:
+    1. Tenant-specific override (if present)
+    2. Global flag value
+    3. `false` when the flag does not exist
+  """
+
+  import Ecto.Query
+  alias Realtime.Api
+  alias Realtime.FeatureFlags.Cache
+  alias Realtime.Repo
+  alias Realtime.Api.FeatureFlag
+  alias Realtime.Tenants.Cache, as: TenantsCache
+
+  @spec list_flags() :: [FeatureFlag.t()]
+  def list_flags, do: Repo.all(from f in FeatureFlag, order_by: [asc: f.name])
+
+  @spec get_flag(String.t()) :: FeatureFlag.t() | nil
+  def get_flag(name) when is_binary(name), do: Repo.get_by(FeatureFlag, name: name)
+
+  @spec upsert_flag(map()) :: {:ok, FeatureFlag.t()} | {:error, Ecto.Changeset.t()}
+  def upsert_flag(attrs) do
+    %FeatureFlag{}
+    |> FeatureFlag.changeset(attrs)
+    |> Repo.insert(on_conflict: {:replace, [:enabled, :updated_at]}, conflict_target: :name)
+  end
+
+  @spec delete_flag(FeatureFlag.t()) :: {:ok, FeatureFlag.t()} | {:error, Ecto.Changeset.t()}
+  def delete_flag(%FeatureFlag{} = flag), do: Repo.delete(flag)
+
+  @spec set_tenant_flag(String.t(), String.t(), boolean()) ::
+          {:ok, Realtime.Api.Tenant.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def set_tenant_flag(flag_name, tenant_id, enabled)
+      when is_binary(flag_name) and is_binary(tenant_id) and is_boolean(enabled) do
+    case Api.get_tenant_by_external_id(tenant_id, use_replica?: false) do
+      nil ->
+        {:error, :not_found}
+
+      tenant ->
+        updated_flags = Map.put(tenant.feature_flags, flag_name, enabled)
+        Api.update_tenant_by_external_id(tenant_id, %{feature_flags: updated_flags})
+    end
+  end
+
+  @spec enabled?(String.t()) :: boolean()
+  def enabled?(flag_name) when is_binary(flag_name) do
+    case Cache.get_flag(flag_name) do
+      nil -> false
+      %FeatureFlag{enabled: enabled} -> enabled
+    end
+  end
+
+  @spec enabled?(String.t(), String.t()) :: boolean()
+  def enabled?(flag_name, tenant_id) when is_binary(flag_name) and is_binary(tenant_id) do
+    case Cache.get_flag(flag_name) do
+      nil ->
+        false
+
+      %FeatureFlag{enabled: global_enabled} ->
+        case TenantsCache.get_tenant_by_external_id(tenant_id) do
+          nil -> global_enabled
+          %{feature_flags: flags} -> Map.get(flags, flag_name, global_enabled)
+        end
+    end
+  end
+end

--- a/lib/realtime/feature_flags/cache.ex
+++ b/lib/realtime/feature_flags/cache.ex
@@ -1,0 +1,55 @@
+defmodule Realtime.FeatureFlags.Cache do
+  @moduledoc """
+  In-process Cachex cache for `Realtime.Api.FeatureFlag` records.
+
+  Cache misses fall through to the database automatically via `Cachex.fetch/3`.
+  Nil results (flag not found) are intentionally not cached so that newly
+  created flags become visible without requiring an explicit invalidation.
+
+  Use `global_revalidate/1` after mutations to push the updated struct to all
+  cluster nodes. Use `distributed_invalidate_cache/1` after deletes.
+  """
+
+  require Cachex.Spec
+  alias Realtime.Api.FeatureFlag
+  alias Realtime.GenRpc
+  alias Realtime.FeatureFlags
+
+  def child_spec(_) do
+    tenant_cache_expiration = Application.get_env(:realtime, :tenant_cache_expiration)
+
+    %{
+      id: __MODULE__,
+      start: {Cachex, :start_link, [__MODULE__, [expiration: Cachex.Spec.expiration(default: tenant_cache_expiration)]]}
+    }
+  end
+
+  def get_flag(name) do
+    with {_, value} <-
+           Cachex.fetch(__MODULE__, cache_key(name), fn _key ->
+             with %FeatureFlag{} = flag <- FeatureFlags.get_flag(name),
+                  do: {:commit, flag},
+                  else: (_ -> {:ignore, nil})
+           end) do
+      value
+    end
+  end
+
+  def update_cache(%FeatureFlag{} = flag) do
+    Cachex.put(__MODULE__, cache_key(flag.name), flag)
+  end
+
+  def invalidate_cache(name) when is_binary(name) do
+    Cachex.del(__MODULE__, cache_key(name))
+  end
+
+  def global_revalidate(flag) do
+    GenRpc.multicast(__MODULE__, :update_cache, [flag])
+  end
+
+  def distributed_invalidate_cache(name) when is_binary(name) do
+    GenRpc.multicast(__MODULE__, :invalidate_cache, [name])
+  end
+
+  defp cache_key(name), do: {:get_flag, name}
+end

--- a/lib/realtime/feature_flags/cache.ex
+++ b/lib/realtime/feature_flags/cache.ex
@@ -6,8 +6,8 @@ defmodule Realtime.FeatureFlags.Cache do
   Nil results (flag not found) are intentionally not cached so that newly
   created flags become visible without requiring an explicit invalidation.
 
-  Use `global_revalidate/1` after mutations to push the updated struct to all
-  cluster nodes. Use `distributed_invalidate_cache/1` after deletes.
+  Use `global_update_cache/1` after mutations to push the updated struct to all
+  cluster nodes. Use `global_invalidate_cache/1` after deletes.
   """
 
   require Cachex.Spec
@@ -24,6 +24,7 @@ defmodule Realtime.FeatureFlags.Cache do
     }
   end
 
+  @spec get_flag(String.t()) :: FeatureFlag.t() | nil
   def get_flag(name) do
     with {_, value} <-
            Cachex.fetch(__MODULE__, cache_key(name), fn _key ->
@@ -35,20 +36,24 @@ defmodule Realtime.FeatureFlags.Cache do
     end
   end
 
+  @spec update_cache(FeatureFlag.t()) :: {:ok, boolean()} | {:error, boolean()}
   def update_cache(%FeatureFlag{} = flag) do
     Cachex.put(__MODULE__, cache_key(flag.name), flag)
   end
 
+  @spec invalidate_cache(String.t()) :: {:ok, boolean()} | {:error, boolean()}
   def invalidate_cache(name) when is_binary(name) do
     Cachex.del(__MODULE__, cache_key(name))
   end
 
-  def global_revalidate(flag) do
+  @spec global_update_cache(FeatureFlag.t()) :: :ok
+  def global_update_cache(%FeatureFlag{} = flag) do
     GenRpc.multicast(__MODULE__, :update_cache, [flag])
   end
 
-  def distributed_invalidate_cache(name) when is_binary(name) do
-    GenRpc.multicast(__MODULE__, :invalidate_cache, [name])
+  @spec global_invalidate_cache(FeatureFlag.t()) :: :ok
+  def global_invalidate_cache(%FeatureFlag{} = flag) do
+    GenRpc.multicast(__MODULE__, :invalidate_cache, [flag.name])
   end
 
   defp cache_key(name), do: {:get_flag, name}

--- a/lib/realtime_web/dashboard/feature_flags.ex
+++ b/lib/realtime_web/dashboard/feature_flags.ex
@@ -26,7 +26,7 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
 
     case FeatureFlags.upsert_flag(%{name: flag.name, enabled: !flag.enabled}) do
       {:ok, updated} ->
-        Cache.global_revalidate(updated)
+        Cache.global_update_cache(updated)
         flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
         {:noreply, assign(socket, flags: flags)}
 
@@ -39,7 +39,7 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
   def handle_event("create", %{"name" => name}, socket) when name != "" do
     case FeatureFlags.upsert_flag(%{name: String.trim(name), enabled: false}) do
       {:ok, flag} ->
-        Cache.global_revalidate(flag)
+        Cache.global_update_cache(flag)
         flags = Enum.sort_by([flag | socket.assigns.flags], & &1.name)
         {:noreply, assign(socket, flags: flags)}
 
@@ -57,7 +57,7 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
 
     case FeatureFlags.delete_flag(flag) do
       {:ok, _} ->
-        Cache.distributed_invalidate_cache(flag.name)
+        Cache.global_invalidate_cache(flag)
         {:noreply, assign(socket, flags: Enum.reject(socket.assigns.flags, &(&1.id == id)))}
 
       {:error, _} ->

--- a/lib/realtime_web/dashboard/feature_flags.ex
+++ b/lib/realtime_web/dashboard/feature_flags.ex
@@ -1,0 +1,224 @@
+defmodule RealtimeWeb.Dashboard.FeatureFlags do
+  @moduledoc """
+  Phoenix LiveDashboard page for managing feature flags.
+
+  Provides a UI to create, toggle, and delete global feature flags, and to
+  search for a tenant and override the flag value for that specific tenant.
+  """
+
+  use Phoenix.LiveDashboard.PageBuilder
+
+  alias Realtime.FeatureFlags
+  alias Realtime.FeatureFlags.Cache
+  alias Realtime.Tenants.Cache, as: TenantsCache
+
+  @impl true
+  def menu_link(_, _), do: {:ok, "Feature Flags"}
+
+  @impl true
+  def mount(_params, _, socket) do
+    {:ok, reset_tenant_state(assign(socket, flags: FeatureFlags.list_flags()))}
+  end
+
+  @impl true
+  def handle_event("toggle", %{"id" => id}, socket) do
+    flag = Enum.find(socket.assigns.flags, &(&1.id == id))
+
+    case FeatureFlags.upsert_flag(%{name: flag.name, enabled: !flag.enabled}) do
+      {:ok, updated} ->
+        Cache.global_revalidate(updated)
+        flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
+        {:noreply, assign(socket, flags: flags)}
+
+      {:error, _} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("create", %{"name" => name}, socket) when name != "" do
+    case FeatureFlags.upsert_flag(%{name: String.trim(name), enabled: false}) do
+      {:ok, flag} ->
+        Cache.global_revalidate(flag)
+        flags = Enum.sort_by([flag | socket.assigns.flags], & &1.name)
+        {:noreply, assign(socket, flags: flags)}
+
+      {:error, _} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("create", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    flag = Enum.find(socket.assigns.flags, &(&1.id == id))
+
+    case FeatureFlags.delete_flag(flag) do
+      {:ok, _} ->
+        Cache.distributed_invalidate_cache(flag.name)
+        {:noreply, assign(socket, flags: Enum.reject(socket.assigns.flags, &(&1.id == id)))}
+
+      {:error, _} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("open_tenant_manager", %{"id" => id}, socket) do
+    {:noreply, reset_tenant_state(socket, managing_id: id)}
+  end
+
+  @impl true
+  def handle_event("close_tenant_manager", _params, socket) do
+    {:noreply, reset_tenant_state(socket)}
+  end
+
+  @impl true
+  def handle_event("search_tenant", %{"tenant_id" => tenant_id}, socket) do
+    case TenantsCache.get_tenant_by_external_id(String.trim(tenant_id)) do
+      nil ->
+        {:noreply, assign(socket, found_tenant: nil, tenant_error: "Tenant not found", tenant_search: tenant_id)}
+
+      tenant ->
+        {:noreply, assign(socket, found_tenant: tenant, tenant_error: nil, tenant_search: tenant_id)}
+    end
+  end
+
+  @impl true
+  def handle_event("set_tenant_flag", %{"flag_name" => flag_name, "enabled" => enabled}, socket) do
+    tenant = socket.assigns.found_tenant
+
+    case FeatureFlags.set_tenant_flag(flag_name, tenant.external_id, enabled == "true") do
+      {:ok, updated_tenant} ->
+        {:noreply, assign(socket, found_tenant: updated_tenant)}
+
+      {:error, _} ->
+        {:noreply, assign(socket, tenant_error: "Failed to update tenant flag")}
+    end
+  end
+
+  defp reset_tenant_state(socket, extra \\ []) do
+    assign(socket, [managing_id: nil, tenant_search: "", found_tenant: nil, tenant_error: nil] ++ extra)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="phx-dashboard-section">
+      <h5 class="card-title">Feature Flags</h5>
+
+      <form phx-submit="create" class="mb-4 d-flex gap-2">
+        <input
+          type="text"
+          name="name"
+          placeholder="New flag name"
+          class="form-control w-auto"
+          autocomplete="off"
+        />
+        <button type="submit" class="btn btn-primary">Add</button>
+      </form>
+
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th style="width: 60%">Name</th>
+            <th style="width: 15%">Status</th>
+            <th style="width: 25%">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= for flag <- @flags do %>
+            <tr>
+              <td class="font-monospace align-middle"><%= flag.name %></td>
+              <td class="align-middle">
+                <div style="display: flex; align-items: center; gap: 0.5rem;">
+                  <button
+                    type="button"
+                    phx-click="toggle"
+                    phx-value-id={flag.id}
+                    role="switch"
+                    aria-checked={to_string(flag.enabled)}
+                    style={"position: relative; display: inline-flex; align-items: center; width: 44px; height: 24px; border-radius: 9999px; border: none; outline: none; cursor: pointer; padding: 0; transition: background-color 0.2s ease; background-color: #{if flag.enabled, do: "#22c55e", else: "#9ca3af"};"}
+                  >
+                    <span style={"display: block; width: 18px; height: 18px; border-radius: 50%; background: white; box-shadow: 0 1px 3px rgba(0,0,0,0.2); transition: transform 0.2s ease; transform: translateX(#{if flag.enabled, do: "23px", else: "3px"});"} />
+                  </button>
+                  <span style={"font-size: 0.8125rem; font-weight: 500; color: #{if flag.enabled, do: "#16a34a", else: "#6b7280"};"}>
+                    <%= if flag.enabled, do: "Enabled", else: "Disabled" %>
+                  </span>
+                </div>
+              </td>
+              <td class="align-middle">
+                <div style="display: flex; gap: 0.5rem;">
+                  <button phx-click="open_tenant_manager" phx-value-id={flag.id} class="btn btn-sm btn-outline-primary">
+                    Tenants
+                  </button>
+                  <button
+                    phx-click="delete"
+                    phx-value-id={flag.id}
+                    data-confirm={"Delete flag #{flag.name}?"}
+                    class="btn btn-sm btn-outline-danger"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <%= if @managing_id == flag.id do %>
+              <tr>
+                <td colspan="3" style="background: #f8f9fa; padding: 1rem 1.25rem;">
+                  <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75rem;">
+                    <strong>Tenant flag: <%= flag.name %></strong>
+                    <button phx-click="close_tenant_manager" class="btn btn-sm btn-secondary">Close</button>
+                  </div>
+
+                  <form phx-submit="search_tenant" class="d-flex gap-2 mb-3">
+                    <input
+                      type="text"
+                      name="tenant_id"
+                      value={@tenant_search}
+                      placeholder="Enter tenant external_id"
+                      class="form-control form-control-sm w-auto"
+                      autocomplete="off"
+                    />
+                    <button type="submit" class="btn btn-sm btn-primary">Search</button>
+                  </form>
+
+                  <%= if @tenant_error do %>
+                    <p class="text-danger mb-2"><%= @tenant_error %></p>
+                  <% end %>
+
+                  <%= if @found_tenant do %>
+                    <% flag_enabled = Map.get(@found_tenant.feature_flags, flag.name, flag.enabled) %>
+                    <div style="display: flex; align-items: center; gap: 1rem; padding: 0.5rem 0.75rem; background: white; border-radius: 4px; border: 1px solid #dee2e6;">
+                      <code><%= @found_tenant.external_id %></code>
+                      <span class="text-muted">—</span>
+                      <div style="display: flex; align-items: center; gap: 0.5rem;">
+                        <button
+                          type="button"
+                          phx-click="set_tenant_flag"
+                          phx-value-flag_name={flag.name}
+                          phx-value-enabled={to_string(!flag_enabled)}
+                          role="switch"
+                          aria-checked={to_string(flag_enabled)}
+                          style={"position: relative; display: inline-flex; align-items: center; width: 44px; height: 24px; border-radius: 9999px; border: none; outline: none; cursor: pointer; padding: 0; transition: background-color 0.2s ease; background-color: #{if flag_enabled, do: "#22c55e", else: "#9ca3af"};"}
+                        >
+                          <span style={"display: block; width: 18px; height: 18px; border-radius: 50%; background: white; box-shadow: 0 1px 3px rgba(0,0,0,0.2); transition: transform 0.2s ease; transform: translateX(#{if flag_enabled, do: "23px", else: "3px"});"} />
+                        </button>
+                        <span style={"font-size: 0.8125rem; font-weight: 500; color: #{if flag_enabled, do: "#16a34a", else: "#6b7280"};"}>
+                          <%= if flag_enabled, do: "Enabled", else: "Disabled" %>
+                        </span>
+                      </div>
+                    </div>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+end

--- a/lib/realtime_web/live/feature_flags_live/index.ex
+++ b/lib/realtime_web/live/feature_flags_live/index.ex
@@ -23,7 +23,7 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
 
     case FeatureFlags.upsert_flag(%{name: flag.name, enabled: !flag.enabled}) do
       {:ok, updated} ->
-        Cache.global_revalidate(updated)
+        Cache.global_update_cache(updated)
         Endpoint.broadcast_from(self(), "feature_flags", "updated", updated)
         flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
         {:noreply, assign(socket, flags: flags)}
@@ -37,7 +37,7 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
   def handle_event("create", %{"name" => name}, socket) when name != "" do
     case FeatureFlags.upsert_flag(%{name: String.trim(name), enabled: false}) do
       {:ok, flag} ->
-        Cache.global_revalidate(flag)
+        Cache.global_update_cache(flag)
         Endpoint.broadcast_from(self(), "feature_flags", "updated", flag)
         flags = Enum.sort_by([flag | socket.assigns.flags], & &1.name)
         {:noreply, assign(socket, flags: flags, new_name: "")}
@@ -56,7 +56,7 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
 
     case FeatureFlags.delete_flag(flag) do
       {:ok, _} ->
-        Cache.distributed_invalidate_cache(flag.name)
+        Cache.global_invalidate_cache(flag)
         Endpoint.broadcast_from(self(), "feature_flags", "deleted", %{name: flag.name})
         {:noreply, assign(socket, flags: Enum.reject(socket.assigns.flags, &(&1.id == id)))}
 

--- a/lib/realtime_web/live/feature_flags_live/index.ex
+++ b/lib/realtime_web/live/feature_flags_live/index.ex
@@ -1,0 +1,85 @@
+defmodule RealtimeWeb.FeatureFlagsLive.Index do
+  use RealtimeWeb, :live_view
+
+  alias Realtime.FeatureFlags
+  alias Realtime.FeatureFlags.Cache
+  alias RealtimeWeb.Endpoint
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Endpoint.subscribe("feature_flags")
+
+    {:ok, assign(socket, flags: FeatureFlags.list_flags(), new_name: "")}
+  end
+
+  @impl true
+  def handle_params(_params, _url, socket) do
+    {:noreply, assign(socket, :page_title, "Feature Flags")}
+  end
+
+  @impl true
+  def handle_event("toggle", %{"id" => id}, socket) do
+    flag = Enum.find(socket.assigns.flags, &(&1.id == id))
+
+    case FeatureFlags.upsert_flag(%{name: flag.name, enabled: !flag.enabled}) do
+      {:ok, updated} ->
+        Cache.global_revalidate(updated)
+        Endpoint.broadcast_from(self(), "feature_flags", "updated", updated)
+        flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
+        {:noreply, assign(socket, flags: flags)}
+
+      {:error, _} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("create", %{"name" => name}, socket) when name != "" do
+    case FeatureFlags.upsert_flag(%{name: String.trim(name), enabled: false}) do
+      {:ok, flag} ->
+        Cache.global_revalidate(flag)
+        Endpoint.broadcast_from(self(), "feature_flags", "updated", flag)
+        flags = Enum.sort_by([flag | socket.assigns.flags], & &1.name)
+        {:noreply, assign(socket, flags: flags, new_name: "")}
+
+      {:error, _changeset} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("create", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    flag = Enum.find(socket.assigns.flags, &(&1.id == id))
+
+    case FeatureFlags.delete_flag(flag) do
+      {:ok, _} ->
+        Cache.distributed_invalidate_cache(flag.name)
+        Endpoint.broadcast_from(self(), "feature_flags", "deleted", %{name: flag.name})
+        {:noreply, assign(socket, flags: Enum.reject(socket.assigns.flags, &(&1.id == id)))}
+
+      {:error, _} ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{event: "updated", payload: updated}, socket) do
+    flags =
+      if Enum.any?(socket.assigns.flags, &(&1.id == updated.id)) do
+        Enum.map(socket.assigns.flags, fn f -> if f.id == updated.id, do: updated, else: f end)
+      else
+        Enum.sort_by([updated | socket.assigns.flags], & &1.name)
+      end
+
+    {:noreply, assign(socket, flags: flags)}
+  end
+
+  @impl true
+  def handle_info(%Phoenix.Socket.Broadcast{event: "deleted", payload: %{name: name}}, socket) do
+    flags = Enum.reject(socket.assigns.flags, &(&1.name == name))
+    {:noreply, assign(socket, flags: flags)}
+  end
+end

--- a/lib/realtime_web/live/feature_flags_live/index.html.heex
+++ b/lib/realtime_web/live/feature_flags_live/index.html.heex
@@ -1,0 +1,66 @@
+<.h1>Feature Flags</.h1>
+
+<div class="my-5">
+  <form phx-submit="create" class="flex flex-row gap-2 mb-6">
+    <input
+      type="text"
+      name="name"
+      value={@new_name}
+      placeholder="New flag name"
+      class="border border-gray-300 rounded px-3 py-2 text-sm w-64"
+    />
+    <button type="submit" class="bg-green-600 hover:bg-green-700 text-white text-sm px-4 py-2 rounded">
+      Add
+    </button>
+  </form>
+
+  <table class="w-full text-sm text-left border-collapse">
+    <thead>
+      <tr class="border-b border-gray-200">
+        <th class="py-2 pr-4 font-semibold text-gray-700">Name</th>
+        <th class="py-2 pr-4 font-semibold text-gray-700">Status</th>
+        <th class="py-2 font-semibold text-gray-700">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= for flag <- @flags do %>
+        <tr class="border-b border-gray-100">
+          <td class="py-3 pr-4 font-mono"><%= flag.name %></td>
+          <td class="py-3 pr-4">
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                phx-click="toggle"
+                phx-value-id={flag.id}
+                role="switch"
+                aria-checked={to_string(flag.enabled)}
+                class={[
+                  "relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full transition-colors duration-200 ease-in-out focus:outline-none",
+                  if(flag.enabled, do: "bg-green-500", else: "bg-gray-300")
+                ]}
+              >
+                <span class={[
+                  "absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200 ease-in-out",
+                  if(flag.enabled, do: "translate-x-4", else: "translate-x-0")
+                ]} />
+              </button>
+              <span class={["text-xs font-medium", if(flag.enabled, do: "text-green-600", else: "text-gray-400")]}>
+                <%= if flag.enabled, do: "Enabled", else: "Disabled" %>
+              </span>
+            </div>
+          </td>
+          <td class="py-3">
+            <button
+              phx-click="delete"
+              phx-value-id={flag.id}
+              data-confirm={"Delete flag #{flag.name}?"}
+              class="bg-red-100 hover:bg-red-200 text-red-800 text-xs px-3 py-1 rounded"
+            >
+              Delete
+            </button>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -69,6 +69,7 @@ defmodule RealtimeWeb.Router do
   scope "/admin", RealtimeWeb do
     pipe_through [:browser, :dashboard_admin]
     live("/tenants", TenantsLive.Index, :index)
+    live("/feature-flags", FeatureFlagsLive.Index, :index)
   end
 
   scope "/metrics", RealtimeWeb do
@@ -130,7 +131,8 @@ defmodule RealtimeWeb.Router do
         tenant_info: RealtimeWeb.Dashboard.TenantInfo,
         recon_trace: RealtimeWeb.Dashboard.ReconTrace,
         node_info: RealtimeWeb.Dashboard.NodeInfo,
-        sql_inspector: RealtimeWeb.Dashboard.SqlInspector
+        sql_inspector: RealtimeWeb.Dashboard.SqlInspector,
+        feature_flags: RealtimeWeb.Dashboard.FeatureFlags
       ]
     )
   end

--- a/mise.toml
+++ b/mise.toml
@@ -4,8 +4,11 @@ erlang = "27"
 node = "24"
 
 [env]
+API_JWT_SECRET = "dev"
 DB_ENC_KEY = "1234567890123456"
 METRICS_JWT_SECRET = "dev"
+DASHBOARD_USER = "admin"
+DASHBOARD_PASSWORD = "admin"
 
 [tasks.dev]
 description = "Start the dev server"

--- a/priv/repo/migrations/20260422000000_create_feature_flags.exs
+++ b/priv/repo/migrations/20260422000000_create_feature_flags.exs
@@ -1,0 +1,18 @@
+defmodule Realtime.Repo.Migrations.CreateFeatureFlags do
+  use Ecto.Migration
+
+  def change do
+    create table(:feature_flags, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+      add :enabled, :boolean, null: false, default: false
+      timestamps()
+    end
+
+    create unique_index(:feature_flags, [:name])
+
+    alter table(:tenants) do
+      add :feature_flags, :map, null: false, default: %{}
+    end
+  end
+end

--- a/test/realtime/feature_flags_test.exs
+++ b/test/realtime/feature_flags_test.exs
@@ -1,0 +1,124 @@
+defmodule Realtime.FeatureFlagsTest do
+  use Realtime.DataCase, async: false
+
+  alias Realtime.Api.FeatureFlag
+  alias Realtime.FeatureFlags
+  alias Realtime.FeatureFlags.Cache
+  alias Realtime.Tenants.Cache, as: TenantsCache
+
+  setup do
+    Cachex.clear(Cache)
+    Cachex.clear(TenantsCache)
+    :ok
+  end
+
+  describe "list_flags/0" do
+    test "returns all flags ordered by name" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "zebra_flag", enabled: false})
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "alpha_flag", enabled: true})
+
+      names = FeatureFlags.list_flags() |> Enum.map(& &1.name)
+      assert names == Enum.sort(names)
+      assert "alpha_flag" in names
+      assert "zebra_flag" in names
+    end
+  end
+
+  describe "get_flag/1" do
+    test "returns the flag when it exists" do
+      {:ok, flag} = FeatureFlags.upsert_flag(%{name: "my_flag", enabled: true})
+      assert %FeatureFlag{name: "my_flag"} = FeatureFlags.get_flag("my_flag")
+      assert FeatureFlags.get_flag("my_flag").id == flag.id
+    end
+
+    test "returns nil when flag does not exist" do
+      assert FeatureFlags.get_flag("nonexistent") == nil
+    end
+  end
+
+  describe "upsert_flag/1" do
+    test "inserts a new flag" do
+      assert {:ok, %FeatureFlag{name: "new_flag", enabled: false}} =
+               FeatureFlags.upsert_flag(%{name: "new_flag", enabled: false})
+    end
+
+    test "updates an existing flag" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "existing", enabled: false})
+
+      assert {:ok, %FeatureFlag{name: "existing", enabled: true}} =
+               FeatureFlags.upsert_flag(%{name: "existing", enabled: true})
+
+      assert FeatureFlags.list_flags() |> Enum.count(&(&1.name == "existing")) == 1
+    end
+
+    test "returns error changeset when name is missing" do
+      assert {:error, changeset} = FeatureFlags.upsert_flag(%{enabled: false})
+      assert "can't be blank" in errors_on(changeset).name
+    end
+  end
+
+  describe "delete_flag/1" do
+    test "removes the flag" do
+      {:ok, flag} = FeatureFlags.upsert_flag(%{name: "to_delete", enabled: false})
+      assert {:ok, _} = FeatureFlags.delete_flag(flag)
+      assert FeatureFlags.get_flag("to_delete") == nil
+    end
+  end
+
+  describe "enabled?/1" do
+    test "returns false when flag does not exist" do
+      refute FeatureFlags.enabled?("missing_flag")
+    end
+
+    test "returns false when flag is disabled" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "off_flag", enabled: false})
+      refute FeatureFlags.enabled?("off_flag")
+    end
+
+    test "returns true when flag is enabled" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "on_flag", enabled: true})
+      assert FeatureFlags.enabled?("on_flag")
+    end
+  end
+
+  describe "enabled?/2" do
+    test "returns false when flag does not exist" do
+      refute FeatureFlags.enabled?("missing_flag", "tenant_1")
+    end
+
+    test "returns false when flag is disabled and tenant has no entry (follows global)" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "off_flag", enabled: false})
+      tenant = tenant_fixture(%{feature_flags: %{}})
+      refute FeatureFlags.enabled?("off_flag", tenant.external_id)
+    end
+
+    test "returns true when flag is disabled globally but tenant has it explicitly enabled" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "tenant_override_flag", enabled: false})
+      tenant = tenant_fixture(%{feature_flags: %{"tenant_override_flag" => true}})
+      assert FeatureFlags.enabled?("tenant_override_flag", tenant.external_id)
+    end
+
+    test "returns global value when flag is enabled but tenant does not exist" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "enabled_flag", enabled: true})
+      assert FeatureFlags.enabled?("enabled_flag", "nonexistent_tenant")
+    end
+
+    test "returns true when flag is enabled and tenant has no entry (follows global)" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "partial_flag", enabled: true})
+      tenant = tenant_fixture(%{feature_flags: %{}})
+      assert FeatureFlags.enabled?("partial_flag", tenant.external_id)
+    end
+
+    test "returns true when flag is enabled and tenant has it explicitly enabled" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "tenant_flag", enabled: true})
+      tenant = tenant_fixture(%{feature_flags: %{"tenant_flag" => true}})
+      assert FeatureFlags.enabled?("tenant_flag", tenant.external_id)
+    end
+
+    test "returns false when flag is enabled but tenant has it explicitly disabled" do
+      {:ok, _} = FeatureFlags.upsert_flag(%{name: "disabled_for_tenant", enabled: true})
+      tenant = tenant_fixture(%{feature_flags: %{"disabled_for_tenant" => false}})
+      refute FeatureFlags.enabled?("disabled_for_tenant", tenant.external_id)
+    end
+  end
+end

--- a/test/realtime/feature_flags_test.exs
+++ b/test/realtime/feature_flags_test.exs
@@ -17,10 +17,7 @@ defmodule Realtime.FeatureFlagsTest do
       {:ok, _} = FeatureFlags.upsert_flag(%{name: "zebra_flag", enabled: false})
       {:ok, _} = FeatureFlags.upsert_flag(%{name: "alpha_flag", enabled: true})
 
-      names = FeatureFlags.list_flags() |> Enum.map(& &1.name)
-      assert names == Enum.sort(names)
-      assert "alpha_flag" in names
-      assert "zebra_flag" in names
+      assert FeatureFlags.list_flags() |> Enum.map(& &1.name) |> Enum.sort() == ["alpha_flag", "zebra_flag"]
     end
   end
 
@@ -32,7 +29,7 @@ defmodule Realtime.FeatureFlagsTest do
     end
 
     test "returns nil when flag does not exist" do
-      assert FeatureFlags.get_flag("nonexistent") == nil
+      refute FeatureFlags.get_flag("nonexistent")
     end
   end
 
@@ -61,7 +58,7 @@ defmodule Realtime.FeatureFlagsTest do
     test "removes the flag" do
       {:ok, flag} = FeatureFlags.upsert_flag(%{name: "to_delete", enabled: false})
       assert {:ok, _} = FeatureFlags.delete_flag(flag)
-      assert FeatureFlags.get_flag("to_delete") == nil
+      refute FeatureFlags.get_flag("to_delete")
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds Feature Flags to Realtime

Resolution order:
1. Tenant specific override (stored as a JSONB map on the tenant record)
2. Global flag value
3. false 

Flags are cached per node via FeatureFlags.Cache (backed by Cachex). On mutation, global_revalidate/1 multicasts the updated struct to all cluster nodes via GenRpc. Deletes use distributed_invalidate_cache/1. Cache misses fall through to the DB automatically; nil results are intentionally not cached so new flags are visible immediately
```elixir
# Global flag — no tenant context needed (e.g. a cluster-wide behaviour toggle)
defmodule Realtime.Broadcast do
  import Realtime.FeatureFlags, only: [enabled?: 1]

  def dispatch(message) do
    if enabled?("new_broadcast_engine"), 
      do: NewEngine.dispatch(message), 
      else: LegacyEngine.dispatch(message)
  end
end

# Per-tenant flag — behaviour differs per tenant (e.g. a beta feature rollout)
defmodule Realtime.Presence do
  import Realtime.FeatureFlags, only: [enabled?: 2]

  def track(tenant, payload) do
    if enabled?("enhanced_presence", tenant.external_id), 
      do: EnhancedPresence.track(payload), 
      else: BasicPresence.track(payload)
  end
end
```
<img width="1173" height="602" alt="image" src="https://github.com/user-attachments/assets/d2a25049-fea5-4e8a-92ef-073c84b254a4" />
