### PR TITLE
feat: improve observability on tenant migrations

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -245,7 +245,8 @@ defmodule Realtime.Tenants.Migrations do
 
       try do
         opts = [all: true, prefix: "realtime", dynamic_repo: repo]
-        Ecto.Migrator.run(Repo, @migrations, :up, opts)
+        {time, _} = :timer.tc(fn -> Ecto.Migrator.run(Repo, @migrations, :up, opts) end)
+        Logger.info("Finished applying tenant migrations in #{div(time, 1000)}ms")
 
         :ok
       rescue

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -251,11 +251,20 @@ defmodule Realtime.Tenants.Migrations do
         :ok
       rescue
         error ->
-          log_error("MigrationsFailedToRun", error)
+          log_error("MigrationsFailedToRun", error, migration_error_metadata(error))
           {:error, error}
       end
     end)
   end
+
+  defp migration_error_metadata(%Postgrex.Error{postgres: postgres}) when is_map(postgres) do
+    [
+      pg_code: postgres[:pg_code],
+      pg_routine: postgres[:routine]
+    ]
+  end
+
+  defp migration_error_metadata(_), do: []
 
   @doc """
   Create partitions against tenant db connection


### PR DESCRIPTION
Related to REAL-765

**feat: record elapsed time to run tenant migrations**

We need this simple metric to track tenant migrations total execution time. It won't give individual migration timing per tenant but it's enough to signal which tenant need further observation.


**feat: log migration error pg_code and routine**

To facilitate querying and not crash the log server otherwise we need to parse the message at runtime.