### PR TITLE
feat(observability): expose tenant migration metrics

### DIFF
--- a/OBSERVABILITY_METRICS.md
+++ b/OBSERVABILITY_METRICS.md
@@ -9,6 +9,7 @@
 - [Payload & Traffic Metrics](#payload--traffic-metrics)
 - [Latency & Performance Metrics](#latency--performance-metrics)
 - [Authorization & Error Metrics](#authorization--error-metrics)
+- [Tenant Migration Metrics](#tenant-migration-metrics)
 - [BEAM/Erlang VM Metrics](#beamerlang-vm-metrics)
   - [Memory Metrics](#memory-metrics)
   - [Process & Resource Metrics](#process--resource-metrics)
@@ -132,6 +133,21 @@ These metrics track security policy enforcement and error rates.
 | `realtime_channel_error`        | Counter | Unhandled channel errors per tenant. Any non-zero value warrants investigation.                                                                 | **Per-Tenant**   | `/tenant-metrics` |
 | `realtime_channel_global_error` | Counter | Global unhandled channel error count across all tenants, tagged by error code.                                                                  | Global Aggregate | `/metrics`        |
 | `phoenix_channel_joined_total`  | Counter | WebSocket channel join attempts tagged by `result` (`ok`/`error`) and `transport`. Use `result="error"` rate to detect client or policy issues. | Per-Node         | `/metrics`        |
+
+## Tenant Migration Metrics
+
+These metrics track tenants migration execution and reconciliations.
+
+| Metric                                                     | Type      | Description                                                                                                  | Scope            | Endpoint   |
+| ---------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------ | ---------------- | ---------- |
+| `realtime_tenants_migrations_duration_milliseconds_bucket` | Histogram | Tenant migration duration in milliseconds.                                                                   | Global Aggregate | `/metrics` |
+| `realtime_tenants_migrations_duration_milliseconds_count`  | Counter   | Completed tenant migration runs.                                                                             | Global Aggregate | `/metrics` |
+| `realtime_tenants_migrations_duration_milliseconds_sum`    | Counter   | Cumulative tenant migration time in milliseconds.                                                            | Global Aggregate | `/metrics` |
+| `realtime_tenants_migrations_exceptions_total`             | Counter   | Failed tenant migration runs, tagged by `error_code`.                                                        | Global Aggregate | `/metrics` |
+| `realtime_tenants_migrations_reconcile_total`              | Counter   | Tenants whose cached `migrations_ran` was reconciled against the database on connect.                        | Global Aggregate | `/metrics` |
+| `realtime_tenants_migrations_reconcile_exceptions_total`   | Counter   | Failed reconciliations.                                                                                      | Global Aggregate | `/metrics` |
+
+Per-tenant attribution lives on the log path — see [TELEMETRY.md](./TELEMETRY.md) for the alert query foundation.
 
 ## BEAM/Erlang VM Metrics
 

--- a/lib/realtime/monitoring/prom_ex.ex
+++ b/lib/realtime/monitoring/prom_ex.ex
@@ -1,6 +1,7 @@
 defmodule Realtime.PromEx do
   alias Realtime.PromEx.Plugins.Distributed
   alias Realtime.PromEx.Plugins.GenRpc
+  alias Realtime.PromEx.Plugins.Migrations
   alias Realtime.PromEx.Plugins.OsMon
   alias Realtime.PromEx.Plugins.Phoenix
   alias Realtime.PromEx.Plugins.TenantGlobal
@@ -101,6 +102,7 @@ defmodule Realtime.PromEx do
       {Plugins.Beam, poll_rate: poll_rate, metric_prefix: [:beam]},
       {Phoenix, router: RealtimeWeb.Router, poll_rate: poll_rate, metric_prefix: [:phoenix]},
       {OsMon, poll_rate: poll_rate},
+      {Migrations, poll_rate: poll_rate},
       {Tenants, poll_rate: poll_rate},
       {TenantGlobal, poll_rate: poll_rate},
       {Distributed, poll_rate: poll_rate},

--- a/lib/realtime/monitoring/prom_ex/plugins/migrations.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/migrations.ex
@@ -1,0 +1,43 @@
+defmodule Realtime.PromEx.Plugins.Migrations do
+  @moduledoc """
+  Tenant migration metrics.
+  """
+
+  use PromEx.Plugin
+
+  defmodule Buckets do
+    @moduledoc false
+    use Peep.Buckets.Custom,
+      buckets: [100, 250, 500, 1_000, 2_000, 5_000, 10_000, 20_000, 30_000, 45_000, 60_000, 90_000, 120_000]
+  end
+
+  @impl true
+  def event_metrics(_opts) do
+    Event.build(:realtime_tenants_migrations, [
+      distribution(
+        [:realtime, :tenants, :migrations, :duration, :milliseconds],
+        event_name: [:realtime, :tenants, :migrations, :stop],
+        measurement: :duration,
+        unit: {:native, :millisecond},
+        description: "Tenant migrations duration",
+        reporter_options: [peep_bucket_calculator: Buckets]
+      ),
+      counter(
+        [:realtime, :tenants, :migrations, :exceptions, :total],
+        event_name: [:realtime, :tenants, :migrations, :exception],
+        tags: [:error_code],
+        description: "Count of failed tenant migrations"
+      ),
+      counter(
+        [:realtime, :tenants, :migrations, :reconcile, :total],
+        event_name: [:realtime, :tenants, :migrations, :reconcile, :stop],
+        description: "Count of reconciled tenant migrations"
+      ),
+      counter(
+        [:realtime, :tenants, :migrations, :reconcile, :exceptions, :total],
+        event_name: [:realtime, :tenants, :migrations, :reconcile, :exception],
+        description: "Count of failed migrations_ran reconciliations"
+      )
+    ])
+  end
+end

--- a/lib/realtime/telemetry/logger.ex
+++ b/lib/realtime/telemetry/logger.ex
@@ -4,6 +4,7 @@ defmodule Realtime.Telemetry.Logger do
   """
 
   require Logger
+  use Realtime.Logs
 
   use GenServer
 
@@ -11,7 +12,12 @@ defmodule Realtime.Telemetry.Logger do
     [:realtime, :connections],
     [:realtime, :rate_counter, :channel, :events],
     [:realtime, :rate_counter, :channel, :db_events],
-    [:realtime, :rate_counter, :channel, :presence_events]
+    [:realtime, :rate_counter, :channel, :presence_events],
+    [:realtime, :tenants, :migrations, :start],
+    [:realtime, :tenants, :migrations, :stop],
+    [:realtime, :tenants, :migrations, :exception],
+    [:realtime, :tenants, :migrations, :reconcile, :stop],
+    [:realtime, :tenants, :migrations, :reconcile, :exception]
   ]
 
   def start_link(args) do
@@ -31,6 +37,47 @@ defmodule Realtime.Telemetry.Logger do
     meta = %{project: tenant, measurements: measurements}
     Logger.info(["Billing metrics: ", inspect(event)], meta)
     :ok
+  end
+
+  def handle_event([:realtime, :tenants, :migrations, :start], _measurements, metadata, _config) do
+    Logger.info(
+      "Applying migrations to #{metadata.hostname}",
+      project: metadata.external_id
+    )
+  end
+
+  def handle_event([:realtime, :tenants, :migrations, :stop], measurements, metadata, _config) do
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+
+    Logger.info(
+      "Finished applying #{metadata.migrations_executed} migrations for tenant #{metadata.external_id} in #{duration_ms}ms",
+      project: metadata.external_id
+    )
+  end
+
+  def handle_event([:realtime, :tenants, :migrations, :exception], _measurements, metadata, _config) do
+    log_error(
+      "MigrationsFailedToRun",
+      metadata.reason,
+      project: metadata.external_id,
+      error_code: metadata.error_code
+    )
+  end
+
+  def handle_event([:realtime, :tenants, :migrations, :reconcile, :stop], _measurements, metadata, _config) do
+    log_warning(
+      "MigrationCountMismatch",
+      "Reconciling migrations_ran for tenant #{metadata.external_id} cached=#{metadata.cached_migrations_ran} database=#{metadata.database_migrations_ran}",
+      project: metadata.external_id
+    )
+  end
+
+  def handle_event([:realtime, :tenants, :migrations, :reconcile, :exception], _measurements, metadata, _config) do
+    log_error(
+      "MigrationCountMismatchReconcileFailed",
+      metadata.reason,
+      project: metadata.external_id
+    )
   end
 
   def handle_event(_event, _measurements, _metadata, _config) do

--- a/lib/realtime/telemetry/telemetry.ex
+++ b/lib/realtime/telemetry/telemetry.ex
@@ -1,14 +1,38 @@
 defmodule Realtime.Telemetry do
   @moduledoc """
-  Telemetry wrapper
+  Telemetry integration.
   """
 
   @doc """
   Dispatches Telemetry events.
   """
-
   @spec execute([atom, ...], map, map) :: :ok
   def execute(event, measurements, metadata \\ %{}) do
     :telemetry.execute(event, measurements, metadata)
+  end
+
+  @spec start([atom, ...], map, map) :: integer()
+  def start(event, metadata \\ %{}, measurements \\ %{}) do
+    start_time = System.monotonic_time()
+    measurements = Map.merge(measurements, %{system_time: System.system_time()})
+
+    execute(event ++ [:start], measurements, metadata)
+
+    start_time
+  end
+
+  @spec stop([atom, ...], integer(), map, map) :: :ok
+  def stop(event, start_time, metadata \\ %{}, measurements \\ %{}) do
+    end_time = System.monotonic_time()
+    measurements = Map.merge(measurements, %{duration: end_time - start_time})
+    execute(event ++ [:stop], measurements, metadata)
+  end
+
+  @spec exception([atom, ...], integer(), atom(), any(), list(), map, map) :: :ok
+  def exception(event, start_time, kind, reason, stacktrace, metadata \\ %{}, measurements \\ %{}) do
+    end_time = System.monotonic_time()
+    measurements = Map.merge(measurements, %{duration: end_time - start_time})
+    metadata = Map.merge(metadata, %{kind: kind, reason: reason, stacktrace: stacktrace})
+    execute(event ++ [:exception], measurements, metadata)
   end
 end

--- a/lib/realtime/tenants/connect/reconcile_migrations.ex
+++ b/lib/realtime/tenants/connect/reconcile_migrations.ex
@@ -7,26 +7,34 @@ defmodule Realtime.Tenants.Connect.ReconcileMigrations do
   to revert while the migrations_ran counter remains at the latest value.
   """
 
-  use Realtime.Logs
-
   alias Realtime.Api
+  alias Realtime.Telemetry
 
   @behaviour Realtime.Tenants.Connect.Piper
 
-  @impl true
-  def run(%{tenant: tenant, migrations_ran_on_database: migrations_ran_on_database} = acc) do
-    if tenant.migrations_ran != migrations_ran_on_database do
-      log_warning(
-        "MigrationCountMismatch",
-        "cached=#{tenant.migrations_ran} database=#{migrations_ran_on_database}"
-      )
+  @event [:realtime, :tenants, :migrations, :reconcile]
 
-      case Api.update_migrations_ran(tenant.external_id, migrations_ran_on_database) do
-        {:ok, updated_tenant} -> {:ok, %{acc | tenant: updated_tenant}}
-        {:error, error} -> {:error, error}
-      end
-    else
-      {:ok, acc}
+  @impl true
+  def run(%{tenant: %{migrations_ran: migrations_ran}, migrations_ran_on_database: migrations_ran} = acc),
+    do: {:ok, acc}
+
+  def run(%{tenant: tenant, migrations_ran_on_database: migrations_ran_on_database} = acc) do
+    metadata = %{
+      external_id: tenant.external_id,
+      cached_migrations_ran: tenant.migrations_ran,
+      database_migrations_ran: migrations_ran_on_database
+    }
+
+    start_time = Telemetry.start(@event, metadata)
+
+    case Api.update_migrations_ran(tenant.external_id, migrations_ran_on_database) do
+      {:ok, updated_tenant} ->
+        Telemetry.stop(@event, start_time, metadata)
+        {:ok, %{acc | tenant: updated_tenant}}
+
+      {:error, error} ->
+        Telemetry.exception(@event, start_time, :error, error, [], metadata)
+        {:error, error}
     end
   end
 end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -13,6 +13,7 @@ defmodule Realtime.Tenants.Migrations do
   alias Realtime.Api
   alias Realtime.Nodes
   alias Realtime.GenRpc
+  alias Realtime.Telemetry
 
   alias Realtime.Tenants.Migrations.{
     CreateRealtimeSubscriptionTable,
@@ -211,7 +212,7 @@ defmodule Realtime.Tenants.Migrations do
   def init(%__MODULE__{tenant_external_id: tenant_external_id, settings: settings}) do
     Logger.metadata(external_id: tenant_external_id, project: tenant_external_id)
 
-    case migrate(settings) do
+    case migrate(tenant_external_id, settings) do
       :ok ->
         Task.Supervisor.async_nolink(__MODULE__.TaskSupervisor, Api, :update_migrations_ran, [
           tenant_external_id,
@@ -225,7 +226,7 @@ defmodule Realtime.Tenants.Migrations do
     end
   end
 
-  defp migrate(settings) do
+  defp migrate(tenant_external_id, settings) do
     with {:ok, settings} <- Database.from_settings(settings, "realtime_migrations", :stop) do
       [
         hostname: settings.hostname,
@@ -240,31 +241,36 @@ defmodule Realtime.Tenants.Migrations do
         ssl: settings.ssl
       ]
       |> Repo.with_dynamic_repo(fn repo ->
-        Logger.info("Applying migrations to #{settings.hostname}")
+        event = [:realtime, :tenants, :migrations]
+        metadata = %{external_id: tenant_external_id, hostname: settings.hostname}
+        start_time = Telemetry.start(event, metadata)
 
         try do
           opts = [all: true, prefix: "realtime", dynamic_repo: repo]
-          {time, _} = :timer.tc(fn -> Ecto.Migrator.run(Repo, @migrations, :up, opts) end)
-          Logger.info("Finished applying tenant migrations in #{div(time, 1000)}ms")
-
-          :ok
+          result = Ecto.Migrator.run(Repo, @migrations, :up, opts)
+          Telemetry.stop(event, start_time, Map.put(metadata, :migrations_executed, length(result)))
         rescue
           error ->
-            log_error("MigrationsFailedToRun", error, migration_error_metadata(error))
+            metadata = Map.put(metadata, :error_code, error_code(error))
+
+            Telemetry.exception(
+              event,
+              start_time,
+              :error,
+              error,
+              __STACKTRACE__,
+              metadata
+            )
+
             {:error, error}
         end
       end)
     end
   end
 
-  defp migration_error_metadata(%Postgrex.Error{postgres: postgres}) when is_map(postgres) do
-    [
-      pg_code: postgres[:pg_code],
-      pg_routine: postgres[:routine]
-    ]
-  end
-
-  defp migration_error_metadata(_), do: []
+  defp error_code(%Postgrex.Error{postgres: %{code: code}}), do: code
+  defp error_code(%DBConnection.ConnectionError{}), do: :connection_error
+  defp error_code(_), do: :other
 
   @doc """
   Create partitions against tenant db connection

--- a/priv/repo/dev_seeds.exs
+++ b/priv/repo/dev_seeds.exs
@@ -43,7 +43,7 @@ default_db_host = "127.0.0.1"
   end)
 
 # Reset Tenant DB
-settings = Database.from_tenant(tenant, "realtime_migrations", :stop)
+{:ok, settings} = Database.from_tenant(tenant, "realtime_migrations", :stop)
 settings = %{settings | max_restarts: 0, ssl: false}
 {:ok, tenant_conn} = Database.connect_db(settings)
 publication = "supabase_realtime"

--- a/test/realtime/monitoring/prom_ex/plugins/migrations_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/migrations_test.exs
@@ -1,0 +1,96 @@
+defmodule Realtime.PromEx.Plugins.MigrationsTest do
+  use Realtime.DataCase, async: false
+
+  alias Realtime.PromEx.Plugins.Migrations
+  alias Realtime.Telemetry
+
+  defmodule MetricsTest do
+    use PromEx, otp_app: :realtime_test_migrations
+
+    @impl true
+    def plugins, do: [Migrations]
+  end
+
+  setup_all do
+    start_supervised!(MetricsTest)
+    :ok
+  end
+
+  defp metric_value(metric, expected_tags \\ nil) do
+    MetricsTest
+    |> PromEx.get_metrics()
+    |> MetricsHelper.search(metric, expected_tags)
+  end
+
+  test "records migration duration histogram on stop" do
+    start_time = Telemetry.start([:realtime, :tenants, :migrations], %{external_id: "tenant", hostname: "localhost"})
+
+    Telemetry.stop(
+      [:realtime, :tenants, :migrations],
+      start_time,
+      %{external_id: "tenant", hostname: "localhost", migrations_executed: 3}
+    )
+
+    assert metric_value("realtime_tenants_migrations_duration_milliseconds_count") == 1
+    assert metric_value("realtime_tenants_migrations_duration_milliseconds_bucket", le: "100.0") > 0
+  end
+
+  test "tags Postgrex errors with the SQLSTATE atom" do
+    metric = "realtime_tenants_migrations_exceptions_total"
+    start_time = Telemetry.start([:realtime, :tenants, :migrations], %{external_id: "tenant", hostname: "localhost"})
+
+    Telemetry.exception(
+      [:realtime, :tenants, :migrations],
+      start_time,
+      :error,
+      %Postgrex.Error{postgres: %{code: :undefined_column}},
+      [],
+      %{external_id: "tenant", error_code: :undefined_column}
+    )
+
+    assert metric_value(metric, error_code: "undefined_column") == 1
+  end
+
+  test "tags connection errors with error_code=connection_error" do
+    metric = "realtime_tenants_migrations_exceptions_total"
+    start_time = Telemetry.start([:realtime, :tenants, :migrations], %{external_id: "tenant", hostname: "localhost"})
+
+    Telemetry.exception(
+      [:realtime, :tenants, :migrations],
+      start_time,
+      :error,
+      %DBConnection.ConnectionError{message: "ssl send: closed"},
+      [],
+      %{external_id: "tenant", error_code: :connection_error}
+    )
+
+    assert metric_value(metric, error_code: "connection_error") == 1
+  end
+
+  test "counts reconciliations" do
+    start_time = Telemetry.start([:realtime, :tenants, :migrations, :reconcile], %{external_id: "tenant"})
+
+    Telemetry.stop(
+      [:realtime, :tenants, :migrations, :reconcile],
+      start_time,
+      %{external_id: "tenant", cached_migrations_ran: 60, database_migrations_ran: 65}
+    )
+
+    assert metric_value("realtime_tenants_migrations_reconcile_total") == 1
+  end
+
+  test "counts reconcile exceptions" do
+    start_time = Telemetry.start([:realtime, :tenants, :migrations, :reconcile], %{external_id: "tenant"})
+
+    Telemetry.exception(
+      [:realtime, :tenants, :migrations, :reconcile],
+      start_time,
+      :error,
+      %RuntimeError{message: "boom"},
+      [],
+      %{external_id: "tenant"}
+    )
+
+    assert metric_value("realtime_tenants_migrations_reconcile_exceptions_total") == 1
+  end
+end


### PR DESCRIPTION
1. Add telemetry events for migrations and reconciliations:

```
[:realtime, :tenants, :migrations, :start | :stop | :exception]
[:realtime, :tenants, :migrations, :reconcile, :start | :stop | :exception]
```

2. Move logs into a Telemetry -> Logger pattern

Leverage the existing `Realtime.Telemetry.Logger` log telemetry events

---

Close REAL-776
Close REAL-777
