### PR TITLE
fix(monitoring): only keep migration events when executed>0

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/migrations.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/migrations.ex
@@ -20,6 +20,7 @@ defmodule Realtime.PromEx.Plugins.Migrations do
         measurement: :duration,
         unit: {:native, :millisecond},
         description: "Tenant migrations duration",
+        keep: &__MODULE__.migrations_executed/1,
         reporter_options: [peep_bucket_calculator: Buckets]
       ),
       counter(
@@ -40,4 +41,7 @@ defmodule Realtime.PromEx.Plugins.Migrations do
       )
     ])
   end
+
+  def migrations_executed(%{migrations_executed: n}) when is_integer(n) and n > 0, do: true
+  def migrations_executed(_), do: false
 end

--- a/test/realtime/monitoring/prom_ex/plugins/migrations_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/migrations_test.exs
@@ -35,6 +35,20 @@ defmodule Realtime.PromEx.Plugins.MigrationsTest do
     assert metric_value("realtime_tenants_migrations_duration_milliseconds_bucket", le: "100.0") > 0
   end
 
+  test "skips duration histogram when migrations_executed is 0" do
+    before = metric_value("realtime_tenants_migrations_duration_milliseconds_count")
+
+    start_time = Telemetry.start([:realtime, :tenants, :migrations], %{external_id: "tenant", hostname: "localhost"})
+
+    Telemetry.stop(
+      [:realtime, :tenants, :migrations],
+      start_time,
+      %{external_id: "tenant", hostname: "localhost", migrations_executed: 0}
+    )
+
+    assert metric_value("realtime_tenants_migrations_duration_milliseconds_count") == before
+  end
+
   test "tags Postgrex errors with the SQLSTATE atom" do
     metric = "realtime_tenants_migrations_exceptions_total"
     start_time = Telemetry.start([:realtime, :tenants, :migrations], %{external_id: "tenant", hostname: "localhost"})


### PR DESCRIPTION
With concurrent nodes health checking and connecting we have partially consistent migrations_ran firing the migrator even when another node is already running tenant migrations with a DB lock causing telemetry to emit migration execution events with 0 migrations executed. Discard those to not pollute metrics, but we still keep the logs for debugging purposes.