### PR TITLE
fix: account for replica and repo usage on FeatureFlag management

### DIFF
--- a/lib/realtime/api.ex
+++ b/lib/realtime/api.ex
@@ -9,7 +9,9 @@ defmodule Realtime.Api do
   alias Ecto.Changeset
   alias Extensions.PostgresCdcRls
   alias Realtime.Api.Extensions
+  alias Realtime.Api.FeatureFlag
   alias Realtime.Api.Tenant
+  alias Realtime.FeatureFlags
   alias Realtime.GenCounter
   alias Realtime.GenRpc
   alias Realtime.Nodes
@@ -129,7 +131,7 @@ defmodule Realtime.Api do
           error
       end
     else
-      call(:create_tenant, [attrs], tenant_id)
+      call(:create_tenant, [attrs], tenant_id: tenant_id)
     end
   end
 
@@ -143,7 +145,7 @@ defmodule Realtime.Api do
       |> get_tenant_by_external_id(use_replica?: false)
       |> update_tenant(attrs)
     else
-      call(:update_tenant_by_external_id, [tenant_id, attrs], tenant_id)
+      call(:update_tenant_by_external_id, [tenant_id, attrs], tenant_id: tenant_id)
     end
   end
 
@@ -173,7 +175,7 @@ defmodule Realtime.Api do
       {num, _} = Repo.delete_all(query)
       num > 0
     else
-      call(:delete_tenant_by_external_id, [id], id)
+      call(:delete_tenant_by_external_id, [id], tenant_id: id)
     end
   end
 
@@ -189,7 +191,45 @@ defmodule Realtime.Api do
         Repo.get_by(Tenant, external_id: external_id) |> Repo.preload(:extensions)
 
       true ->
-        call(:get_tenant_by_external_id, [external_id, opts], external_id)
+        call(:get_tenant_by_external_id, [external_id, opts], tenant_id: external_id)
+    end
+  end
+
+  @spec list_feature_flags() :: [FeatureFlag.t()]
+  def list_feature_flags do
+    Replica.replica().all(from f in FeatureFlag, order_by: [asc: f.name])
+  end
+
+  @spec get_feature_flag(String.t()) :: FeatureFlag.t() | nil
+  def get_feature_flag(name) when is_binary(name),
+    do: Replica.replica().get_by(FeatureFlag, name: name)
+
+  @spec upsert_feature_flag(map()) :: {:ok, FeatureFlag.t()} | {:error, Ecto.Changeset.t()}
+  def upsert_feature_flag(attrs) do
+    if master_region?() do
+      %FeatureFlag{}
+      |> FeatureFlag.changeset(attrs)
+      |> Repo.insert(on_conflict: {:replace, [:enabled, :updated_at]}, conflict_target: :name, returning: true)
+      |> tap(fn
+        {:ok, flag} -> FeatureFlags.Cache.global_update_cache(flag)
+        _ -> :ok
+      end)
+    else
+      call(:upsert_feature_flag, [attrs])
+    end
+  end
+
+  @spec delete_feature_flag(FeatureFlag.t()) :: {:ok, FeatureFlag.t()} | {:error, Ecto.Changeset.t()}
+  def delete_feature_flag(%FeatureFlag{} = flag) do
+    if master_region?() do
+      flag
+      |> Repo.delete()
+      |> tap(fn
+        {:ok, deleted} -> FeatureFlags.Cache.global_invalidate_cache(deleted)
+        _ -> :ok
+      end)
+    else
+      call(:delete_feature_flag, [flag])
     end
   end
 
@@ -210,7 +250,7 @@ defmodule Realtime.Api do
         |> Repo.update()
       end
     else
-      call(:rename_settings_field, [from, to], from)
+      call(:rename_settings_field, [from, to])
     end
   end
 
@@ -233,7 +273,7 @@ defmodule Realtime.Api do
         end
       end)
     else
-      call(:update_migrations_ran, [external_id, count], external_id)
+      call(:update_migrations_ran, [external_id, count], tenant_id: external_id)
     end
   end
 
@@ -323,17 +363,17 @@ defmodule Realtime.Api do
     region == master_region
   end
 
-  defp call(operation, args, tenant_id) do
+  defp call(operation, args, opts \\ []) do
     master_region = Application.get_env(:realtime, :master_region)
 
     with {:ok, master_node} <- Nodes.node_from_region(master_region, self()),
-         {:ok, result} <- wrapped_call(master_node, operation, args, tenant_id) do
+         {:ok, result} <- wrapped_call(master_node, operation, args, opts) do
       result
     end
   end
 
-  defp wrapped_call(master_node, operation, args, tenant_id) do
-    case GenRpc.call(master_node, __MODULE__, operation, args, tenant_id: tenant_id) do
+  defp wrapped_call(master_node, operation, args, opts) do
+    case GenRpc.call(master_node, __MODULE__, operation, args, opts) do
       {:error, :rpc_error, reason} -> {:error, reason}
       {:error, reason} -> {:error, reason}
       result -> {:ok, result}

--- a/lib/realtime/feature_flags.ex
+++ b/lib/realtime/feature_flags.ex
@@ -12,28 +12,10 @@ defmodule Realtime.FeatureFlags do
     3. `false` when the flag does not exist
   """
 
-  import Ecto.Query
   alias Realtime.Api
-  alias Realtime.FeatureFlags.Cache
-  alias Realtime.Repo
   alias Realtime.Api.FeatureFlag
+  alias Realtime.FeatureFlags.Cache
   alias Realtime.Tenants.Cache, as: TenantsCache
-
-  @spec list_flags() :: [FeatureFlag.t()]
-  def list_flags, do: Repo.all(from f in FeatureFlag, order_by: [asc: f.name])
-
-  @spec get_flag(String.t()) :: FeatureFlag.t() | nil
-  def get_flag(name) when is_binary(name), do: Repo.get_by(FeatureFlag, name: name)
-
-  @spec upsert_flag(map()) :: {:ok, FeatureFlag.t()} | {:error, Ecto.Changeset.t()}
-  def upsert_flag(attrs) do
-    %FeatureFlag{}
-    |> FeatureFlag.changeset(attrs)
-    |> Repo.insert(on_conflict: {:replace, [:enabled, :updated_at]}, conflict_target: :name, returning: true)
-  end
-
-  @spec delete_flag(FeatureFlag.t()) :: {:ok, FeatureFlag.t()} | {:error, Ecto.Changeset.t()}
-  def delete_flag(%FeatureFlag{} = flag), do: Repo.delete(flag)
 
   @spec set_tenant_flag(String.t(), String.t(), boolean()) ::
           {:ok, Realtime.Api.Tenant.t()} | {:error, :not_found | Ecto.Changeset.t()}

--- a/lib/realtime/feature_flags/cache.ex
+++ b/lib/realtime/feature_flags/cache.ex
@@ -11,9 +11,9 @@ defmodule Realtime.FeatureFlags.Cache do
   """
 
   require Cachex.Spec
+  alias Realtime.Api
   alias Realtime.Api.FeatureFlag
   alias Realtime.GenRpc
-  alias Realtime.FeatureFlags
 
   def child_spec(_) do
     tenant_cache_expiration = Application.get_env(:realtime, :tenant_cache_expiration)
@@ -28,7 +28,7 @@ defmodule Realtime.FeatureFlags.Cache do
   def get_flag(name) do
     with {_, value} <-
            Cachex.fetch(__MODULE__, cache_key(name), fn _key ->
-             with %FeatureFlag{} = flag <- FeatureFlags.get_flag(name),
+             with %FeatureFlag{} = flag <- Api.get_feature_flag(name),
                   do: {:commit, flag},
                   else: (_ -> {:ignore, nil})
            end) do

--- a/lib/realtime_web/dashboard/feature_flags.ex
+++ b/lib/realtime_web/dashboard/feature_flags.ex
@@ -8,8 +8,8 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
 
   use Phoenix.LiveDashboard.PageBuilder
 
+  alias Realtime.Api
   alias Realtime.FeatureFlags
-  alias Realtime.FeatureFlags.Cache
   alias Realtime.Tenants.Cache, as: TenantsCache
 
   @impl true
@@ -17,16 +17,15 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
 
   @impl true
   def mount(_params, _, socket) do
-    {:ok, reset_tenant_state(assign(socket, flags: FeatureFlags.list_flags()))}
+    {:ok, reset_tenant_state(assign(socket, flags: Api.list_feature_flags()))}
   end
 
   @impl true
   def handle_event("toggle", %{"id" => id}, socket) do
     flag = Enum.find(socket.assigns.flags, &(&1.id == id))
 
-    case FeatureFlags.upsert_flag(%{name: flag.name, enabled: !flag.enabled}) do
+    case Api.upsert_feature_flag(%{name: flag.name, enabled: !flag.enabled}) do
       {:ok, updated} ->
-        Cache.global_update_cache(updated)
         flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
         {:noreply, assign(socket, flags: flags)}
 
@@ -37,9 +36,8 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
 
   @impl true
   def handle_event("create", %{"name" => name}, socket) when name != "" do
-    case FeatureFlags.upsert_flag(%{name: String.trim(name), enabled: false}) do
+    case Api.upsert_feature_flag(%{name: String.trim(name), enabled: false}) do
       {:ok, flag} ->
-        Cache.global_update_cache(flag)
         flags = Enum.sort_by([flag | socket.assigns.flags], & &1.name)
         {:noreply, assign(socket, flags: flags)}
 
@@ -55,9 +53,8 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
   def handle_event("delete", %{"id" => id}, socket) do
     flag = Enum.find(socket.assigns.flags, &(&1.id == id))
 
-    case FeatureFlags.delete_flag(flag) do
+    case Api.delete_feature_flag(flag) do
       {:ok, _} ->
-        Cache.global_invalidate_cache(flag)
         {:noreply, assign(socket, flags: Enum.reject(socket.assigns.flags, &(&1.id == id)))}
 
       {:error, _} ->

--- a/lib/realtime_web/live/feature_flags_live/index.ex
+++ b/lib/realtime_web/live/feature_flags_live/index.ex
@@ -1,15 +1,14 @@
 defmodule RealtimeWeb.FeatureFlagsLive.Index do
   use RealtimeWeb, :live_view
 
-  alias Realtime.FeatureFlags
-  alias Realtime.FeatureFlags.Cache
+  alias Realtime.Api
   alias RealtimeWeb.Endpoint
 
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket), do: Endpoint.subscribe("feature_flags")
 
-    {:ok, assign(socket, flags: FeatureFlags.list_flags(), new_name: "")}
+    {:ok, assign(socket, flags: Api.list_feature_flags(), new_name: "")}
   end
 
   @impl true
@@ -21,9 +20,8 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
   def handle_event("toggle", %{"id" => id}, socket) do
     flag = Enum.find(socket.assigns.flags, &(&1.id == id))
 
-    case FeatureFlags.upsert_flag(%{name: flag.name, enabled: !flag.enabled}) do
+    case Api.upsert_feature_flag(%{name: flag.name, enabled: !flag.enabled}) do
       {:ok, updated} ->
-        Cache.global_update_cache(updated)
         Endpoint.broadcast_from(self(), "feature_flags", "updated", updated)
         flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
         {:noreply, assign(socket, flags: flags)}
@@ -35,9 +33,8 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
 
   @impl true
   def handle_event("create", %{"name" => name}, socket) when name != "" do
-    case FeatureFlags.upsert_flag(%{name: String.trim(name), enabled: false}) do
+    case Api.upsert_feature_flag(%{name: String.trim(name), enabled: false}) do
       {:ok, flag} ->
-        Cache.global_update_cache(flag)
         Endpoint.broadcast_from(self(), "feature_flags", "updated", flag)
         flags = Enum.sort_by([flag | socket.assigns.flags], & &1.name)
         {:noreply, assign(socket, flags: flags, new_name: "")}
@@ -54,9 +51,8 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
   def handle_event("delete", %{"id" => id}, socket) do
     flag = Enum.find(socket.assigns.flags, &(&1.id == id))
 
-    case FeatureFlags.delete_flag(flag) do
+    case Api.delete_feature_flag(flag) do
       {:ok, _} ->
-        Cache.global_invalidate_cache(flag)
         Endpoint.broadcast_from(self(), "feature_flags", "deleted", %{name: flag.name})
         {:noreply, assign(socket, flags: Enum.reject(socket.assigns.flags, &(&1.id == id)))}
 

--- a/test/integration/region_aware_routing_test.exs
+++ b/test/integration/region_aware_routing_test.exs
@@ -248,6 +248,24 @@ defmodule Realtime.Integration.RegionAwareRoutingTest do
     assert Realtime.Repo.get_by(FeatureFlag, name: flag_name)
   end
 
+  test "upsert_feature_flag surfaces error", %{master_node: master_node} do
+    # validation will fail
+    flag_name = ""
+    on_exit(fn -> Realtime.Repo.delete_all(from f in FeatureFlag, where: f.name == ^flag_name) end)
+
+    Mimic.expect(GenRpc, :call, fn node, mod, func, args, opts ->
+      assert node == master_node
+      assert mod == Realtime.Api
+      assert func == :upsert_feature_flag
+      assert opts == []
+
+      call_original(GenRpc, :call, [node, mod, func, args, opts])
+    end)
+
+    assert {:error, %Ecto.Changeset{errors: [name: {"can't be blank", [validation: :required]}]}} =
+             Api.upsert_feature_flag(%{name: flag_name, enabled: true})
+  end
+
   test "delete_feature_flag automatically routes to master region", %{master_node: master_node} do
     flag_name = "test_routing_delete_#{System.unique_integer([:positive])}"
 

--- a/test/integration/region_aware_routing_test.exs
+++ b/test/integration/region_aware_routing_test.exs
@@ -2,7 +2,10 @@ defmodule Realtime.Integration.RegionAwareRoutingTest do
   use Realtime.DataCase, async: false
   use Mimic
 
+  import Ecto.Query
+
   alias Realtime.Api
+  alias Realtime.Api.FeatureFlag
   alias Realtime.Api.Tenant
   alias Realtime.GenRpc
   alias Realtime.Nodes
@@ -224,5 +227,45 @@ defmodule Realtime.Integration.RegionAwareRoutingTest do
     Mimic.expect(GenRpc, :call, fn _node, _mod, _func, _args, _opts -> {:error, :rpc_error, rpc_error_reason} end)
     result = Api.create_tenant(attrs)
     assert {:error, ^rpc_error_reason} = result
+  end
+
+  test "upsert_feature_flag automatically routes to master region", %{master_node: master_node} do
+    flag_name = "test_routing_flag_#{System.unique_integer([:positive])}"
+    on_exit(fn -> Realtime.Repo.delete_all(from f in FeatureFlag, where: f.name == ^flag_name) end)
+
+    Mimic.expect(GenRpc, :call, fn node, mod, func, args, opts ->
+      assert node == master_node
+      assert mod == Realtime.Api
+      assert func == :upsert_feature_flag
+      assert opts == []
+
+      call_original(GenRpc, :call, [node, mod, func, args, opts])
+    end)
+
+    assert {:ok, %FeatureFlag{name: ^flag_name, enabled: true}} =
+             Api.upsert_feature_flag(%{name: flag_name, enabled: true})
+
+    assert Realtime.Repo.get_by(FeatureFlag, name: flag_name)
+  end
+
+  test "delete_feature_flag automatically routes to master region", %{master_node: master_node} do
+    flag_name = "test_routing_delete_#{System.unique_integer([:positive])}"
+
+    GenRpc
+    |> Mimic.expect(:call, fn node, mod, func, args, opts ->
+      assert node == master_node
+      assert func == :upsert_feature_flag
+      call_original(GenRpc, :call, [node, mod, func, args, opts])
+    end)
+    |> Mimic.expect(:call, fn node, mod, func, args, opts ->
+      assert node == master_node
+      assert func == :delete_feature_flag
+      assert opts == []
+      call_original(GenRpc, :call, [node, mod, func, args, opts])
+    end)
+
+    {:ok, flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: true})
+    assert {:ok, _} = Api.delete_feature_flag(flag)
+    refute Realtime.Repo.get_by(FeatureFlag, name: flag_name)
   end
 end

--- a/test/realtime/api_test.exs
+++ b/test/realtime/api_test.exs
@@ -28,7 +28,11 @@ defmodule Realtime.ApiTest do
     setup [:create_tenants]
 
     test "returns all tenants", %{tenants: tenants} do
-      assert Enum.sort(Api.list_tenants()) == Enum.sort(tenants)
+      assert Api.list_tenants()
+
+      Enum.each(tenants, fn tenant ->
+        assert tenant in Api.list_tenants()
+      end)
     end
   end
 

--- a/test/realtime/api_test.exs
+++ b/test/realtime/api_test.exs
@@ -1,13 +1,16 @@
 defmodule Realtime.ApiTest do
-  use Realtime.DataCase, async: true
+  use Realtime.DataCase, async: false
 
   use Mimic
 
   alias Realtime.Api
   alias Realtime.Api.Extensions, as: ApiExtensions
+  alias Realtime.Api.FeatureFlag
   alias Realtime.Api.Tenant
   alias Realtime.Crypto
   alias Realtime.GenCounter
+  alias Realtime.GenRpc
+  alias Realtime.Nodes
   alias Realtime.RateCounter
   alias Realtime.Tenants.Connect
   alias Extensions.PostgresCdcRls
@@ -508,6 +511,114 @@ defmodule Realtime.ApiTest do
 
       assert {:ok, tenant} = Api.update_migrations_ran(tenant.external_id, 1)
       assert tenant.migrations_ran == 1
+    end
+  end
+
+  describe "list_feature_flags/0" do
+    test "returns all flags ordered by name" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "zebra_flag", enabled: false})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "alpha_flag", enabled: true})
+
+      names = Api.list_feature_flags() |> Enum.map(& &1.name)
+      assert "alpha_flag" in names
+      assert "zebra_flag" in names
+      assert Enum.find_index(names, &(&1 == "alpha_flag")) < Enum.find_index(names, &(&1 == "zebra_flag"))
+    end
+  end
+
+  describe "get_feature_flag/1" do
+    test "returns the flag when it exists" do
+      {:ok, flag} = Api.upsert_feature_flag(%{name: "my_flag", enabled: true})
+      assert %FeatureFlag{name: "my_flag"} = Api.get_feature_flag("my_flag")
+      assert Api.get_feature_flag("my_flag").id == flag.id
+    end
+
+    test "returns nil when flag does not exist" do
+      refute Api.get_feature_flag("nonexistent")
+    end
+  end
+
+  describe "upsert_feature_flag/1" do
+    test "inserts a new flag" do
+      assert {:ok, %FeatureFlag{name: "new_flag", enabled: false}} =
+               Api.upsert_feature_flag(%{name: "new_flag", enabled: false})
+    end
+
+    test "updates an existing flag" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "existing", enabled: false})
+
+      assert {:ok, %FeatureFlag{name: "existing", enabled: true}} =
+               Api.upsert_feature_flag(%{name: "existing", enabled: true})
+
+      assert Api.list_feature_flags() |> Enum.count(&(&1.name == "existing")) == 1
+    end
+
+    test "returns error changeset when name is missing" do
+      assert {:error, changeset} = Api.upsert_feature_flag(%{enabled: false})
+      assert "can't be blank" in errors_on(changeset).name
+    end
+  end
+
+  describe "delete_feature_flag/1" do
+    test "removes the flag" do
+      {:ok, flag} = Api.upsert_feature_flag(%{name: "to_delete", enabled: false})
+      assert {:ok, _} = Api.delete_feature_flag(flag)
+      refute Api.get_feature_flag("to_delete")
+    end
+  end
+
+  describe "non-master region routing" do
+    setup do
+      previous_region = Application.get_env(:realtime, :region)
+      previous_master_region = Application.get_env(:realtime, :master_region)
+
+      Application.put_env(:realtime, :region, "ap-southeast-2")
+      Application.put_env(:realtime, :master_region, "us-east-1")
+
+      on_exit(fn ->
+        Application.put_env(:realtime, :region, previous_region)
+        Application.put_env(:realtime, :master_region, previous_master_region)
+      end)
+
+      fake_master = :"master@127.0.0.1"
+      Mimic.stub(Nodes, :node_from_region, fn "us-east-1", _key -> {:ok, fake_master} end)
+
+      %{master_node: fake_master}
+    end
+
+    test "upsert_feature_flag dispatches to master with empty opts", %{master_node: master_node} do
+      Mimic.expect(GenRpc, :call, fn ^master_node, Api, :upsert_feature_flag, args, opts ->
+        assert args == [%{name: "rpc_flag", enabled: true}]
+        assert opts == []
+        {:ok, %FeatureFlag{name: "rpc_flag", enabled: true}}
+      end)
+
+      assert {:ok, %FeatureFlag{name: "rpc_flag", enabled: true}} =
+               Api.upsert_feature_flag(%{name: "rpc_flag", enabled: true})
+    end
+
+    test "delete_feature_flag dispatches to master with empty opts", %{master_node: master_node} do
+      flag = %FeatureFlag{id: Ecto.UUID.generate(), name: "rpc_delete", enabled: false}
+
+      Mimic.expect(GenRpc, :call, fn ^master_node, Api, :delete_feature_flag, args, opts ->
+        assert args == [flag]
+        assert opts == []
+        {:ok, flag}
+      end)
+
+      assert {:ok, ^flag} = Api.delete_feature_flag(flag)
+    end
+
+    test "create_tenant dispatches to master with tenant_id opt", %{master_node: master_node} do
+      external_id = "rpc_tenant_#{System.unique_integer([:positive])}"
+      attrs = %{"external_id" => external_id, "name" => external_id}
+
+      Mimic.expect(GenRpc, :call, fn ^master_node, Api, :create_tenant, _args, opts ->
+        assert opts == [tenant_id: external_id]
+        {:ok, %Tenant{external_id: external_id}}
+      end)
+
+      assert {:ok, %Tenant{external_id: ^external_id}} = Api.create_tenant(attrs)
     end
   end
 end

--- a/test/realtime/feature_flags_test.exs
+++ b/test/realtime/feature_flags_test.exs
@@ -1,7 +1,7 @@
 defmodule Realtime.FeatureFlagsTest do
   use Realtime.DataCase, async: false
 
-  alias Realtime.Api.FeatureFlag
+  alias Realtime.Api
   alias Realtime.FeatureFlags
   alias Realtime.FeatureFlags.Cache
   alias Realtime.Tenants.Cache, as: TenantsCache
@@ -12,68 +12,18 @@ defmodule Realtime.FeatureFlagsTest do
     :ok
   end
 
-  describe "list_flags/0" do
-    test "returns all flags ordered by name" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "zebra_flag", enabled: false})
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "alpha_flag", enabled: true})
-
-      assert FeatureFlags.list_flags() |> Enum.map(& &1.name) |> Enum.sort() == ["alpha_flag", "zebra_flag"]
-    end
-  end
-
-  describe "get_flag/1" do
-    test "returns the flag when it exists" do
-      {:ok, flag} = FeatureFlags.upsert_flag(%{name: "my_flag", enabled: true})
-      assert %FeatureFlag{name: "my_flag"} = FeatureFlags.get_flag("my_flag")
-      assert FeatureFlags.get_flag("my_flag").id == flag.id
-    end
-
-    test "returns nil when flag does not exist" do
-      refute FeatureFlags.get_flag("nonexistent")
-    end
-  end
-
-  describe "upsert_flag/1" do
-    test "inserts a new flag" do
-      assert {:ok, %FeatureFlag{name: "new_flag", enabled: false}} =
-               FeatureFlags.upsert_flag(%{name: "new_flag", enabled: false})
-    end
-
-    test "updates an existing flag" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "existing", enabled: false})
-
-      assert {:ok, %FeatureFlag{name: "existing", enabled: true}} =
-               FeatureFlags.upsert_flag(%{name: "existing", enabled: true})
-
-      assert FeatureFlags.list_flags() |> Enum.count(&(&1.name == "existing")) == 1
-    end
-
-    test "returns error changeset when name is missing" do
-      assert {:error, changeset} = FeatureFlags.upsert_flag(%{enabled: false})
-      assert "can't be blank" in errors_on(changeset).name
-    end
-  end
-
-  describe "delete_flag/1" do
-    test "removes the flag" do
-      {:ok, flag} = FeatureFlags.upsert_flag(%{name: "to_delete", enabled: false})
-      assert {:ok, _} = FeatureFlags.delete_flag(flag)
-      refute FeatureFlags.get_flag("to_delete")
-    end
-  end
-
   describe "enabled?/1" do
     test "returns false when flag does not exist" do
       refute FeatureFlags.enabled?("missing_flag")
     end
 
     test "returns false when flag is disabled" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "off_flag", enabled: false})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "off_flag", enabled: false})
       refute FeatureFlags.enabled?("off_flag")
     end
 
     test "returns true when flag is enabled" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "on_flag", enabled: true})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "on_flag", enabled: true})
       assert FeatureFlags.enabled?("on_flag")
     end
   end
@@ -84,36 +34,36 @@ defmodule Realtime.FeatureFlagsTest do
     end
 
     test "returns false when flag is disabled and tenant has no entry (follows global)" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "off_flag", enabled: false})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "off_flag", enabled: false})
       tenant = tenant_fixture(%{feature_flags: %{}})
       refute FeatureFlags.enabled?("off_flag", tenant.external_id)
     end
 
     test "returns true when flag is disabled globally but tenant has it explicitly enabled" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "tenant_override_flag", enabled: false})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "tenant_override_flag", enabled: false})
       tenant = tenant_fixture(%{feature_flags: %{"tenant_override_flag" => true}})
       assert FeatureFlags.enabled?("tenant_override_flag", tenant.external_id)
     end
 
     test "returns global value when flag is enabled but tenant does not exist" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "enabled_flag", enabled: true})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "enabled_flag", enabled: true})
       assert FeatureFlags.enabled?("enabled_flag", "nonexistent_tenant")
     end
 
     test "returns true when flag is enabled and tenant has no entry (follows global)" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "partial_flag", enabled: true})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "partial_flag", enabled: true})
       tenant = tenant_fixture(%{feature_flags: %{}})
       assert FeatureFlags.enabled?("partial_flag", tenant.external_id)
     end
 
     test "returns true when flag is enabled and tenant has it explicitly enabled" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "tenant_flag", enabled: true})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "tenant_flag", enabled: true})
       tenant = tenant_fixture(%{feature_flags: %{"tenant_flag" => true}})
       assert FeatureFlags.enabled?("tenant_flag", tenant.external_id)
     end
 
     test "returns false when flag is enabled but tenant has it explicitly disabled" do
-      {:ok, _} = FeatureFlags.upsert_flag(%{name: "disabled_for_tenant", enabled: true})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "disabled_for_tenant", enabled: true})
       tenant = tenant_fixture(%{feature_flags: %{"disabled_for_tenant" => false}})
       refute FeatureFlags.enabled?("disabled_for_tenant", tenant.external_id)
     end

--- a/test/realtime_web/live/feature_flags_live/index_test.exs
+++ b/test/realtime_web/live/feature_flags_live/index_test.exs
@@ -1,0 +1,160 @@
+defmodule RealtimeWeb.FeatureFlagsLive.IndexTest do
+  use RealtimeWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Realtime.Api
+  alias Realtime.Api.FeatureFlag
+  alias Realtime.FeatureFlags.Cache
+  alias RealtimeWeb.Endpoint
+
+  setup do
+    user = random_string()
+    password = random_string()
+
+    Application.put_env(:realtime, :dashboard_auth, :basic_auth)
+    Application.put_env(:realtime, :dashboard_credentials, {user, password})
+
+    on_exit(fn ->
+      Application.delete_env(:realtime, :dashboard_auth)
+      Application.delete_env(:realtime, :dashboard_credentials)
+      Cachex.clear(Cache)
+    end)
+
+    Cachex.clear(Cache)
+
+    %{user: user, password: password}
+  end
+
+  describe "auth" do
+    test "renders feature flags page with valid credentials", %{conn: conn, user: user, password: password} do
+      {:ok, _view, html} =
+        conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      assert html =~ "Feature Flags"
+    end
+
+    test "returns 401 without credentials", %{conn: conn} do
+      assert conn |> get(~p"/admin/feature-flags") |> response(401)
+    end
+
+    test "returns 401 with wrong credentials", %{conn: conn} do
+      assert conn |> using_basic_auth("wrong", "wrong") |> get(~p"/admin/feature-flags") |> response(401)
+    end
+  end
+
+  describe "mount" do
+    test "lists existing flags ordered by name", %{conn: conn, user: user, password: password} do
+      {:ok, _alpha} = Api.upsert_feature_flag(%{name: "alpha_flag", enabled: true})
+      {:ok, _zeta} = Api.upsert_feature_flag(%{name: "zeta_flag", enabled: false})
+
+      {:ok, _view, html} =
+        conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      assert html =~ "alpha_flag"
+      assert html =~ "zeta_flag"
+    end
+  end
+
+  describe "create event" do
+    test "adds a new flag to the list and persists it", %{conn: conn, user: user, password: password} do
+      flag_name = "created_#{random_string()}"
+
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      html = view |> form("form[phx-submit=create]", name: flag_name) |> render_submit()
+
+      assert html =~ flag_name
+      assert %FeatureFlag{enabled: false} = Api.get_feature_flag(flag_name)
+    end
+
+    test "trims whitespace from the new flag name", %{conn: conn, user: user, password: password} do
+      flag_name = "trim_#{random_string()}"
+
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      _ = view |> form("form[phx-submit=create]", name: "  #{flag_name}  ") |> render_submit()
+
+      assert %FeatureFlag{name: ^flag_name} = Api.get_feature_flag(flag_name)
+    end
+
+    test "does not create a flag when name is empty", %{conn: conn, user: user, password: password} do
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      flags_before = Api.list_feature_flags() |> length()
+
+      _ = view |> form("form[phx-submit=create]", name: "") |> render_submit()
+
+      assert Api.list_feature_flags() |> length() == flags_before
+    end
+  end
+
+  describe "toggle event" do
+    test "flips the enabled state and persists", %{conn: conn, user: user, password: password} do
+      flag_name = "toggle_#{random_string()}"
+      {:ok, flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: false})
+
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      view |> element("button[phx-click=toggle][phx-value-id='#{flag.id}']") |> render_click()
+
+      assert %FeatureFlag{enabled: true} = Api.get_feature_flag(flag_name)
+    end
+  end
+
+  describe "delete event" do
+    test "removes the flag from the list and DB", %{conn: conn, user: user, password: password} do
+      flag_name = "delete_#{random_string()}"
+      {:ok, flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: false})
+
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      html = view |> element("button[phx-click=delete][phx-value-id='#{flag.id}']") |> render_click()
+
+      refute html =~ flag_name
+      refute Api.get_feature_flag(flag_name)
+    end
+  end
+
+  describe "broadcasts" do
+    test "adds a new flag when an 'updated' broadcast arrives for an unseen flag",
+         %{conn: conn, user: user, password: password} do
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      remote = %FeatureFlag{id: Ecto.UUID.generate(), name: "remote_#{random_string()}", enabled: true}
+      Endpoint.broadcast("feature_flags", "updated", remote)
+
+      assert render(view) =~ remote.name
+    end
+
+    test "updates an existing flag when an 'updated' broadcast arrives",
+         %{conn: conn, user: user, password: password} do
+      flag_name = "broadcast_#{random_string()}"
+      {:ok, flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: false})
+
+      {:ok, view, html} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+      assert html =~ "Disabled"
+
+      Endpoint.broadcast("feature_flags", "updated", %{flag | enabled: true})
+
+      assert render(view) =~ "Enabled"
+    end
+
+    test "removes a flag when a 'deleted' broadcast arrives",
+         %{conn: conn, user: user, password: password} do
+      flag_name = "broadcast_delete_#{random_string()}"
+      {:ok, _flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: false})
+
+      {:ok, view, html} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+      assert html =~ flag_name
+
+      Endpoint.broadcast("feature_flags", "deleted", %{name: flag_name})
+
+      refute render(view) =~ flag_name
+    end
+  end
+
+  defp using_basic_auth(conn, username, password) do
+    header_content = "Basic " <> Base.encode64("#{username}:#{password}")
+    put_req_header(conn, "authorization", header_content)
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ensure we read using `Replica.replica()` and route changes to the master region where `Realtime.Repo` exists.