### PR TITLE
feat: tag metric pusher errors

### DIFF
--- a/lib/realtime/metrics_pusher.ex
+++ b/lib/realtime/metrics_pusher.ex
@@ -7,6 +7,8 @@ defmodule Realtime.MetricsPusher do
   """
 
   use GenServer
+  use Realtime.Logs
+
   require Logger
 
   defstruct [:push_ref, :interval, :req_options]
@@ -121,10 +123,10 @@ defmodule Realtime.MetricsPusher do
     |> Enum.each(fn
       {task, nil} ->
         Task.shutdown(task, :brutal_kill)
-        Logger.error("MetricsPusher: Task timed out: #{inspect(task)}")
+        log_error("MetricsPusherTimeout", "MetricsPusher: Task timed out: #{inspect(task)}")
 
       {_task, {:exit, reason}} ->
-        Logger.error("MetricsPusher: Task exited with reason: #{inspect(reason)}")
+        log_error("MetricsPusherTaskExited", "MetricsPusher: Task exited with reason: #{inspect(reason)}")
 
       {_task, {:ok, _}} ->
         :ok
@@ -140,12 +142,16 @@ defmodule Realtime.MetricsPusher do
           :ok
 
         {:error, reason} ->
-          Logger.error("MetricsPusher: Failed to push #{label} metrics to #{req_options[:url]}: #{inspect(reason)}")
+          log_error(
+            "MetricsPusherFailed",
+            "MetricsPusher: Failed to push #{label} metrics to #{req_options[:url]}: #{inspect(reason)}"
+          )
+
           :ok
       end
     rescue
       error ->
-        Logger.error("MetricsPusher: Exception during #{label} push: #{inspect(error)}")
+        log_error("MetricsPusherException", "MetricsPusher: Exception during #{label} push: #{inspect(error)}")
         :ok
     end
   end

--- a/test/realtime/metrics_pusher_test.exs
+++ b/test/realtime/metrics_pusher_test.exs
@@ -143,6 +143,7 @@ defmodule Realtime.MetricsPusherTest do
 
       assert log =~ "MetricsPusher: Failed to push"
       assert log =~ "metrics to"
+      assert log =~ "error_code=MetricsPusherFailed"
     end
 
     test "when an error is raised" do
@@ -171,6 +172,7 @@ defmodule Realtime.MetricsPusherTest do
 
       assert log =~ "MetricsPusher: Exception during"
       assert log =~ "push: %RuntimeError{message: \"unexpected error\"}"
+      assert log =~ "error_code=MetricsPusherException"
     end
 
     test "appends extra_label query params to URL" do


### PR DESCRIPTION
Part of REAL-764

To let us query and create alerts for failed metrics.