### PR TITLE
fix: optimise replication poller

### DIFF
--- a/lib/extensions/postgres_cdc_rls/replication_poller.ex
+++ b/lib/extensions/postgres_cdc_rls/replication_poller.ex
@@ -9,6 +9,13 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
 
   @idle_multiplier 5
 
+  # Column order returned by realtime.list_changes/4 (see Replications.list_changes/5
+  # and the SQL function in
+  # lib/realtime/tenants/repo/migrations/20260326120000_list_changes_with_slot_count.ex).
+  # generate_record/1 below pattern-matches positionally on this order; the runtime
+  # check in handle_list_changes_result/4 fails loudly if the SQL ever changes.
+  @expected_columns ~w(type schema table columns record old_record commit_timestamp subscription_ids errors slot_changes_count)
+
   import Realtime.Helpers
 
   alias DBConnection.Backoff
@@ -206,6 +213,9 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
          tenant_id,
          rate_counter_args
        ) do
+    expected_columns = @expected_columns
+    ^expected_columns = columns
+
     # The DB function always returns at least one row (sentinel row with wal=null).
     # All rows carry the same slot_changes_count in the last column.
     slot_changes_count = rows |> List.first() |> List.last()
@@ -223,10 +233,10 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
         :ok
 
       _ ->
-        for row <- real_rows,
-            change <- columns |> Enum.zip(row) |> generate_record() |> List.wrap() do
-          topic = "realtime:postgres:" <> tenant_id
+        topic = "realtime:postgres:" <> tenant_id
 
+        for row <- real_rows,
+            change <- row |> generate_record() |> List.wrap() do
           Realtime.GenCounter.add(rate_counter_args.id, MapSet.size(change.subscription_ids))
 
           payload = Jason.encode!(change)
@@ -265,15 +275,15 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
 
   defp collect_subscription_nodes(subscribers_nodes_table, subscription_ids) do
     Enum.reduce_while(subscription_ids, {:ok, %{}}, fn subscription_id, {:ok, acc} ->
-      case :ets.lookup(subscribers_nodes_table, subscription_id) do
-        [{_, node}] ->
+      case :ets.lookup_element(subscribers_nodes_table, subscription_id, 2, :not_found) do
+        :not_found ->
+          {:halt, {:error, :node_not_found}}
+
+        node ->
           updated_acc =
             Map.update(acc, node, [subscription_id], fn existing_ids -> [subscription_id | existing_ids] end)
 
           {:cont, {:ok, updated_acc}}
-
-        _ ->
-          {:halt, {:error, :node_not_found}}
       end
     end)
   rescue
@@ -281,16 +291,16 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
   end
 
   def generate_record([
-        {"type", "INSERT" = type},
-        {"schema", schema},
-        {"table", table},
-        {"columns", columns},
-        {"record", record},
-        {"old_record", _},
-        {"commit_timestamp", commit_timestamp},
-        {"subscription_ids", subscription_ids},
-        {"errors", errors},
-        {"slot_changes_count", _}
+        "INSERT" = type,
+        schema,
+        table,
+        columns,
+        record,
+        _old_record,
+        commit_timestamp,
+        subscription_ids,
+        errors,
+        _slot_changes_count
       ])
       when is_list(subscription_ids) do
     %NewRecord{
@@ -306,16 +316,16 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
   end
 
   def generate_record([
-        {"type", "UPDATE" = type},
-        {"schema", schema},
-        {"table", table},
-        {"columns", columns},
-        {"record", record},
-        {"old_record", old_record},
-        {"commit_timestamp", commit_timestamp},
-        {"subscription_ids", subscription_ids},
-        {"errors", errors},
-        {"slot_changes_count", _}
+        "UPDATE" = type,
+        schema,
+        table,
+        columns,
+        record,
+        old_record,
+        commit_timestamp,
+        subscription_ids,
+        errors,
+        _slot_changes_count
       ])
       when is_list(subscription_ids) do
     %UpdatedRecord{
@@ -332,16 +342,16 @@ defmodule Extensions.PostgresCdcRls.ReplicationPoller do
   end
 
   def generate_record([
-        {"type", "DELETE" = type},
-        {"schema", schema},
-        {"table", table},
-        {"columns", columns},
-        {"record", _},
-        {"old_record", old_record},
-        {"commit_timestamp", commit_timestamp},
-        {"subscription_ids", subscription_ids},
-        {"errors", errors},
-        {"slot_changes_count", _}
+        "DELETE" = type,
+        schema,
+        table,
+        columns,
+        _record,
+        old_record,
+        commit_timestamp,
+        subscription_ids,
+        errors,
+        _slot_changes_count
       ])
       when is_list(subscription_ids) do
     %DeletedRecord{

--- a/test/realtime/extensions/cdc_rls/replication_poller_test.exs
+++ b/test/realtime/extensions/cdc_rls/replication_poller_test.exs
@@ -410,16 +410,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
   describe "generate_record/1" do
     test "INSERT" do
       wal_record = [
-        {"type", "INSERT"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", Jason.encode!(@record)},
-        {"old_record", nil},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", []},
-        {"slot_changes_count", 1}
+        "INSERT",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        Jason.encode!(@record),
+        nil,
+        @ts,
+        [@subscription_id],
+        [],
+        1
       ]
 
       assert %NewRecord{
@@ -440,16 +440,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "UPDATE" do
       wal_record = [
-        {"type", "UPDATE"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", Jason.encode!(@record)},
-        {"old_record", Jason.encode!(@old_record)},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", []},
-        {"slot_changes_count", 1}
+        "UPDATE",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        Jason.encode!(@record),
+        Jason.encode!(@old_record),
+        @ts,
+        [@subscription_id],
+        [],
+        1
       ]
 
       assert %UpdatedRecord{
@@ -472,16 +472,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "DELETE" do
       wal_record = [
-        {"type", "DELETE"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", nil},
-        {"old_record", Jason.encode!(@old_record)},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", []},
-        {"slot_changes_count", 1}
+        "DELETE",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        nil,
+        Jason.encode!(@old_record),
+        @ts,
+        [@subscription_id],
+        [],
+        1
       ]
 
       assert %DeletedRecord{
@@ -502,16 +502,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "INSERT, large payload error present" do
       wal_record = [
-        {"type", "INSERT"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", Jason.encode!(@record)},
-        {"old_record", nil},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", ["Error 413: Payload Too Large"]},
-        {"slot_changes_count", 1}
+        "INSERT",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        Jason.encode!(@record),
+        nil,
+        @ts,
+        [@subscription_id],
+        ["Error 413: Payload Too Large"],
+        1
       ]
 
       assert %NewRecord{
@@ -532,16 +532,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "INSERT, other errors present" do
       wal_record = [
-        {"type", "INSERT"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", Jason.encode!(@record)},
-        {"old_record", nil},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", ["Error..."]},
-        {"slot_changes_count", 1}
+        "INSERT",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        Jason.encode!(@record),
+        nil,
+        @ts,
+        [@subscription_id],
+        ["Error..."],
+        1
       ]
 
       assert %NewRecord{
@@ -562,16 +562,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "UPDATE, large payload error present" do
       wal_record = [
-        {"type", "UPDATE"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", Jason.encode!(@record)},
-        {"old_record", Jason.encode!(@old_record)},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", ["Error 413: Payload Too Large"]},
-        {"slot_changes_count", 1}
+        "UPDATE",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        Jason.encode!(@record),
+        Jason.encode!(@old_record),
+        @ts,
+        [@subscription_id],
+        ["Error 413: Payload Too Large"],
+        1
       ]
 
       assert %UpdatedRecord{
@@ -594,16 +594,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "UPDATE, other errors present" do
       wal_record = [
-        {"type", "UPDATE"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", Jason.encode!(@record)},
-        {"old_record", Jason.encode!(@old_record)},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", ["Error..."]},
-        {"slot_changes_count", 1}
+        "UPDATE",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        Jason.encode!(@record),
+        Jason.encode!(@old_record),
+        @ts,
+        [@subscription_id],
+        ["Error..."],
+        1
       ]
 
       assert %UpdatedRecord{
@@ -626,16 +626,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "DELETE, large payload error present" do
       wal_record = [
-        {"type", "DELETE"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", nil},
-        {"old_record", Jason.encode!(@old_record)},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", ["Error 413: Payload Too Large"]},
-        {"slot_changes_count", 1}
+        "DELETE",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        nil,
+        Jason.encode!(@old_record),
+        @ts,
+        [@subscription_id],
+        ["Error 413: Payload Too Large"],
+        1
       ]
 
       assert %DeletedRecord{
@@ -656,16 +656,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "DELETE, other errors present" do
       wal_record = [
-        {"type", "DELETE"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", nil},
-        {"old_record", Jason.encode!(@old_record)},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", ["Error..."]},
-        {"slot_changes_count", 1}
+        "DELETE",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        nil,
+        Jason.encode!(@old_record),
+        @ts,
+        [@subscription_id],
+        ["Error..."],
+        1
       ]
 
       assert %DeletedRecord{
@@ -688,16 +688,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
   describe "generate_record/1 JSON encoding" do
     test "subscription_ids is excluded from JSON encoding for INSERT" do
       wal_record = [
-        {"type", "INSERT"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", Jason.encode!(@record)},
-        {"old_record", nil},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", []},
-        {"slot_changes_count", 1}
+        "INSERT",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        Jason.encode!(@record),
+        nil,
+        @ts,
+        [@subscription_id],
+        [],
+        1
       ]
 
       record = generate_record(wal_record)
@@ -711,16 +711,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "subscription_ids is excluded from JSON encoding for UPDATE" do
       wal_record = [
-        {"type", "UPDATE"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", Jason.encode!(@record)},
-        {"old_record", Jason.encode!(@old_record)},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", []},
-        {"slot_changes_count", 1}
+        "UPDATE",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        Jason.encode!(@record),
+        Jason.encode!(@old_record),
+        @ts,
+        [@subscription_id],
+        [],
+        1
       ]
 
       record = generate_record(wal_record)
@@ -732,16 +732,16 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
     test "subscription_ids is excluded from JSON encoding for DELETE" do
       wal_record = [
-        {"type", "DELETE"},
-        {"schema", "public"},
-        {"table", "todos"},
-        {"columns", Jason.encode!(@columns)},
-        {"record", nil},
-        {"old_record", Jason.encode!(@old_record)},
-        {"commit_timestamp", @ts},
-        {"subscription_ids", [@subscription_id]},
-        {"errors", []},
-        {"slot_changes_count", 1}
+        "DELETE",
+        "public",
+        "todos",
+        Jason.encode!(@columns),
+        nil,
+        Jason.encode!(@old_record),
+        @ts,
+        [@subscription_id],
+        [],
+        1
       ]
 
       record = generate_record(wal_record)


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Avoid Enum.zip
* Use :ets.lookup_element instead of lookup


The Enum.zip avoidance on my benchmarks meant 2.3x faster and 2.3x less memory

lookup_element won't be faster but it will generate less memory garbage