### PR TITLE
feat: single broadcast api payload

### DIFF
--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -246,9 +246,9 @@ defmodule Realtime.Tenants.SingleBroadcast do
     %UserBroadcast{
       topic: topic,
       user_event: event,
-      # We don't use encode_to_iodata because this message will be sent through gen_rpc which will
-      # call term_to_iovec and then binary_to_term which is more expensive on an iolist compared to
-      # a single binary
+      # We don't use Jason.encode_to_iodata because this message will be sent through gen_rpc which will
+      # call term_to_iovec and then binary_to_term from the remote peer. All of this is more expensive on an
+      # iolist compared to a single binary. Reconstructing a single binary is cheaper than an iolist
       user_payload: Jason.encode!(payload),
       user_payload_encoding: :json,
       metadata: nil

--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -1,0 +1,255 @@
+defmodule Realtime.Tenants.SingleBroadcast do
+  @moduledoc """
+  Handles single broadcast messages via the /api/broadcast/:topic/:event API.
+
+  This module supports both JSON and binary payloads via Content-Type header:
+  - application/json: Sends Phoenix.Socket.Broadcast with JSON payload
+  - application/octet-stream: Sends RealtimeWeb.Socket.UserBroadcast with binary payload
+
+  Unlike the batch API, this API:
+  - Takes topic and event from URL path (not body)
+  - Sends single message (no batching)
+  - No message ID tracking
+  - Simpler validation
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Realtime.Api.Tenant
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
+  alias Realtime.Tenants
+  alias Realtime.Tenants.Authorization
+  alias Realtime.Tenants.Authorization.Policies
+  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Connect
+
+  alias RealtimeWeb.RealtimeChannel
+  alias RealtimeWeb.Socket.UserBroadcast
+  alias RealtimeWeb.TenantBroadcaster
+
+  @primary_key false
+  embedded_schema do
+    field :topic, :string
+    field :event, :string
+    field :payload, :any, virtual: true  # map for JSON, binary for binary
+    field :private, :boolean, default: false
+    field :content_type, :string  # "json" or "binary"
+  end
+
+  @type content_type :: :json | :binary
+
+  @doc """
+  Broadcasts a single message to the specified topic.
+
+  ## Parameters
+  - `conn` - Plug.Conn or auth_params map containing JWT claims
+  - `tenant` - Tenant struct
+  - `topic` - Channel topic from URL (e.g., "room:123")
+  - `event` - Event name from URL (e.g., "message")
+  - `private` - Whether this is a private broadcast (requires authorization)
+  - `payload` - Message payload (map for JSON, binary for binary)
+  - `content_type` - :json or :binary
+
+  ## Returns
+  - `:ok` on success
+  - `{:error, term()}` on failure
+  """
+  @spec broadcast(
+          Plug.Conn.t() | map(),
+          Tenant.t(),
+          String.t(),
+          String.t(),
+          boolean(),
+          any(),
+          content_type()
+        ) :: :ok | {:error, term()}
+  def broadcast(conn, tenant, topic, event, private, payload, content_type)
+
+  def broadcast(%Plug.Conn{} = conn, %Tenant{} = tenant, topic, event, private, payload, content_type) do
+    auth_params = %{
+      tenant_id: tenant.external_id,
+      headers: conn.req_headers,
+      claims: conn.assigns.claims,
+      role: conn.assigns.role,
+      sub: conn.assigns.sub
+    }
+
+    broadcast(auth_params, tenant, topic, event, private, payload, content_type)
+  end
+
+  def broadcast(auth_params, %Tenant{} = tenant, topic, event, private, payload, content_type) do
+    with %Ecto.Changeset{valid?: true} <- validate_message(topic, event, private, payload, content_type, tenant),
+         events_per_second_rate = Tenants.events_per_second_rate(tenant),
+         :ok <- check_rate_limit(events_per_second_rate, tenant) do
+      if private do
+        handle_private_message(tenant, auth_params, topic, event, payload, content_type, events_per_second_rate)
+      else
+        send_message_and_count(tenant, events_per_second_rate, topic, event, payload, content_type, true)
+        :ok
+      end
+    else
+      %Ecto.Changeset{valid?: false} = changeset -> {:error, changeset}
+      error -> error
+    end
+  end
+
+  def broadcast(_, nil, _, _, _, _, _), do: {:error, :tenant_not_found}
+
+  defp validate_message(topic, event, private, payload, content_type, tenant) do
+    %__MODULE__{}
+    |> cast(%{topic: topic, event: event, private: private, content_type: to_string(content_type)}, [
+      :topic,
+      :event,
+      :private,
+      :content_type
+    ])
+    |> put_change(:payload, payload)
+    |> validate_required([:topic, :event, :content_type])
+    |> validate_payload_present(content_type, payload)
+    |> validate_inclusion(:content_type, ["json", "binary"])
+    |> validate_payload_size(tenant, content_type)
+  end
+
+  defp validate_payload_present(changeset, content_type, payload) do
+    case {content_type, payload} do
+      # Binary payloads: <<>> is valid, nil is not
+      {:binary, payload} when is_binary(payload) ->
+        changeset
+
+      {:binary, nil} ->
+        add_error(changeset, :payload, "can't be blank")
+
+      # JSON payloads: any value (including nil map) is acceptable if present
+      {:json, nil} ->
+        add_error(changeset, :payload, "can't be blank")
+
+      {:json, _} ->
+        changeset
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp validate_payload_size(changeset, tenant, content_type) do
+    payload = get_change(changeset, :payload)
+
+    if is_nil(payload) do
+      changeset
+    else
+      case content_type do
+        :json ->
+          case Tenants.validate_payload_size(tenant, payload) do
+            :ok -> changeset
+            _ -> add_error(changeset, :payload, "Payload size exceeds tenant limit")
+          end
+
+        :binary when is_binary(payload) ->
+          # For binary, we check the actual byte size plus overhead
+          # to match the behavior of validate_payload_size which uses erlang.external_size
+          # Binary external size is byte_size + some overhead for the term encoding
+          max_payload_size = tenant.max_payload_size_in_kb * 1000 + 500
+          payload_size = :erlang.external_size(payload)
+
+          if payload_size > max_payload_size do
+            add_error(changeset, :payload, "Payload size exceeds tenant limit")
+          else
+            changeset
+          end
+
+        :binary ->
+          # Not a binary, will fail validation
+          changeset
+      end
+    end
+  end
+
+  defp handle_private_message(tenant, auth_params, topic, event, payload, content_type, rate_counter) do
+    case permissions_for_message(tenant, auth_params, topic) do
+      %Policies{broadcast: %BroadcastPolicies{write: true}} ->
+        send_message_and_count(tenant, rate_counter, topic, event, payload, content_type, false)
+        :ok
+
+      _ ->
+        # Silently fail unauthorized (same as batch API)
+        :ok
+    end
+  end
+
+  defp permissions_for_message(_, nil, _), do: nil
+
+  defp permissions_for_message(tenant, auth_params, topic) do
+    with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id) do
+      auth_params =
+        auth_params
+        |> Map.put(:topic, topic)
+        |> Authorization.build_authorization_params()
+
+      case Authorization.get_write_authorizations(db_conn, auth_params) do
+        {:ok, policies} -> policies
+        {:error, :not_found} -> nil
+        error -> error
+      end
+    end
+  end
+
+  defp check_rate_limit(events_per_second_rate, %Tenant{} = tenant) do
+    %{max_events_per_second: max_events_per_second} = tenant
+    {:ok, %{avg: events_per_second}} = RateCounter.get(events_per_second_rate)
+
+    if events_per_second >= max_events_per_second do
+      {:error, :too_many_requests, "You have exceeded your rate limit"}
+    else
+      :ok
+    end
+  end
+
+  @event_type "broadcast"
+  defp send_message_and_count(tenant, events_per_second_rate, topic, event, payload, content_type, public?) do
+    tenant_topic = Tenants.tenant_topic(tenant, topic, public?)
+
+    broadcast =
+      case content_type do
+        :json ->
+          build_json_broadcast(topic, event, payload)
+
+        :binary ->
+          build_binary_broadcast(topic, event, payload)
+      end
+
+    GenCounter.add(events_per_second_rate.id)
+
+    TenantBroadcaster.pubsub_broadcast(
+      tenant.external_id,
+      tenant_topic,
+      broadcast,
+      RealtimeChannel.MessageDispatcher,
+      :broadcast
+    )
+  end
+
+  defp build_json_broadcast(topic, event, payload) do
+    formatted_payload = %{
+      "payload" => payload,
+      "event" => event,
+      "type" => "broadcast"
+    }
+
+    %Phoenix.Socket.Broadcast{
+      topic: topic,
+      event: @event_type,
+      payload: formatted_payload
+    }
+  end
+
+  defp build_binary_broadcast(topic, event, binary) do
+    %UserBroadcast{
+      topic: topic,
+      user_event: event,
+      user_payload: binary,
+      user_payload_encoding: :binary,
+      metadata: nil
+    }
+  end
+end

--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -194,10 +194,6 @@ defmodule Realtime.Tenants.SingleBroadcast do
       {:error, error} ->
         log_error("UnableToSetPolicies", error)
         {:error, :internal_server_error, "Unable to authorize broadcast"}
-
-      other ->
-        log_error("UnableToSetPolicies", other)
-        {:error, :internal_server_error, "Unable to authorize broadcast"}
     end
   end
 

--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -1,16 +1,14 @@
 defmodule Realtime.Tenants.SingleBroadcast do
   @moduledoc """
-  Handles single broadcast messages via the /api/broadcast/:topic/:event API.
-
-  This module supports both JSON and binary payloads via Content-Type header:
-  - application/json: Sends Phoenix.Socket.Broadcast with JSON payload
-  - application/octet-stream: Sends RealtimeWeb.Socket.UserBroadcast with binary payload
+  Handles single broadcast messages via the /api/broadcast/:topic/events/:event API.
 
   Unlike the batch API, this API:
-  - Takes topic and event from URL path (not body)
+  - Takes topic and event from URL path
   - Sends single message (no batching)
-  - No message ID tracking
-  - Simpler validation
+
+  This module supports both JSON and binary payloads via Content-Type header:
+  - application/json
+  - application/octet-stream
   """
   use Ecto.Schema
   use Realtime.Logs
@@ -221,7 +219,6 @@ defmodule Realtime.Tenants.SingleBroadcast do
     end
   end
 
-  @event_type "broadcast"
   defp send_message_and_count(tenant, events_per_second_rate, topic, event, payload, content_type, public?) do
     tenant_topic = Tenants.tenant_topic(tenant, topic, public?)
 
@@ -246,16 +243,15 @@ defmodule Realtime.Tenants.SingleBroadcast do
   end
 
   defp build_json_broadcast(topic, event, payload) do
-    formatted_payload = %{
-      "payload" => payload,
-      "event" => event,
-      "type" => "broadcast"
-    }
-
-    %Phoenix.Socket.Broadcast{
+    %UserBroadcast{
       topic: topic,
-      event: @event_type,
-      payload: formatted_payload
+      user_event: event,
+      # We don't use encode_to_iodata because this message will be sent through gen_rpc which will
+      # call term_to_iovec and then binary_to_term which is more expensive on an iolist compared to
+      # a single binary
+      user_payload: Jason.encode!(payload),
+      user_payload_encoding: :json,
+      metadata: nil
     }
   end
 

--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -63,8 +63,6 @@ defmodule Realtime.Tenants.SingleBroadcast do
           any(),
           content_type()
         ) :: :ok | {:error, term()} | {:error, atom(), String.t()}
-  def broadcast(auth_params, tenant, topic, event, private, payload, content_type)
-
   def broadcast(auth_params, %Tenant{} = tenant, topic, event, private, payload, content_type) do
     with %Ecto.Changeset{valid?: true} <- validate_message(topic, event, private, payload, content_type, tenant),
          events_per_second_rate = Tenants.events_per_second_rate(tenant),
@@ -72,7 +70,7 @@ defmodule Realtime.Tenants.SingleBroadcast do
       if private do
         handle_private_message(tenant, auth_params, topic, event, payload, content_type, events_per_second_rate)
       else
-        send_message_and_count(tenant, events_per_second_rate, topic, event, payload, content_type, true)
+        send_message_and_count(tenant, events_per_second_rate, topic, event, payload, content_type, _public? = true)
         :ok
       end
     else
@@ -80,8 +78,6 @@ defmodule Realtime.Tenants.SingleBroadcast do
       error -> error
     end
   end
-
-  def broadcast(_, nil, _, _, _, _, _), do: {:error, :tenant_not_found}
 
   defp validate_message(topic, event, private, payload, content_type, tenant) do
     %__MODULE__{}
@@ -232,10 +228,10 @@ defmodule Realtime.Tenants.SingleBroadcast do
     broadcast =
       case content_type do
         :json ->
-          build_json_broadcast(topic, event, payload)
+          build_json_broadcast(tenant_topic, event, payload)
 
         :binary ->
-          build_binary_broadcast(topic, event, payload)
+          build_binary_broadcast(tenant_topic, event, payload)
       end
 
     GenCounter.add(events_per_second_rate.id)

--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -13,6 +13,7 @@ defmodule Realtime.Tenants.SingleBroadcast do
   - Simpler validation
   """
   use Ecto.Schema
+  use Realtime.Logs
   import Ecto.Changeset
 
   alias Realtime.Api.Tenant
@@ -32,9 +33,11 @@ defmodule Realtime.Tenants.SingleBroadcast do
   embedded_schema do
     field :topic, :string
     field :event, :string
-    field :payload, :any, virtual: true  # map for JSON, binary for binary
+    # map for JSON, binary for binary
+    field :payload, :any, virtual: true
     field :private, :boolean, default: false
-    field :content_type, :string  # "json" or "binary"
+    # "json" or "binary"
+    field :content_type, :string
   end
 
   @type content_type :: :json | :binary
@@ -63,7 +66,7 @@ defmodule Realtime.Tenants.SingleBroadcast do
           boolean(),
           any(),
           content_type()
-        ) :: :ok | {:error, term()}
+        ) :: :ok | {:error, term()} | {:error, atom(), String.t()}
   def broadcast(conn, tenant, topic, event, private, payload, content_type)
 
   def broadcast(%Plug.Conn{} = conn, %Tenant{} = tenant, topic, event, private, payload, content_type) do
@@ -167,17 +170,63 @@ defmodule Realtime.Tenants.SingleBroadcast do
 
   defp handle_private_message(tenant, auth_params, topic, event, payload, content_type, rate_counter) do
     case permissions_for_message(tenant, auth_params, topic) do
-      %Policies{broadcast: %BroadcastPolicies{write: true}} ->
+      {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}} ->
         send_message_and_count(tenant, rate_counter, topic, event, payload, content_type, false)
         :ok
 
-      _ ->
-        # Silently fail unauthorized (same as batch API)
-        :ok
+      {:ok, %Policies{broadcast: %BroadcastPolicies{write: _}}} ->
+        {:error, :forbidden, "Unauthorized"}
+
+      {:error, :forbidden} ->
+        {:error, :forbidden, "Unauthorized"}
+
+      {:error, :rls_policy_error, error} ->
+        log_error("RlsPolicyError", error)
+        {:error, :unprocessable_entity, "RLS policy error"}
+
+      {:error, :query_canceled, error} ->
+        log_error("QueryCanceled", error)
+        {:error, :unprocessable_entity, "Query canceled"}
+
+      {:error, :rpc_error, error} ->
+        log_error("RpcError", error)
+        {:error, :service_unavailable, "RPC error"}
+
+      {:error, :missing_partition} ->
+        log_error("MissingPartition", "Realtime was unable to find the expected messages partition")
+        {:error, :unprocessable_entity, "Missing messages partition"}
+
+      {:error, :increase_connection_pool} ->
+        {:error, :too_many_requests, "Connection pool exhausted"}
+
+      {:error, :tenant_database_unavailable} ->
+        log_error("UnableToConnectToProject", "Realtime was unable to connect to the project database")
+        {:error, :service_unavailable, "Tenant database unavailable"}
+
+      {:error, :initializing} ->
+        {:error, :unprocessable_entity, "Tenant database initializing"}
+
+      {:error, :tenant_database_connection_initializing} ->
+        {:error, :unprocessable_entity, "Tenant database connection initializing"}
+
+      {:error, :tenant_db_too_many_connections} ->
+        log_error("DatabaseLackOfConnections", "Database can't accept more connections, Realtime won't connect")
+        {:error, :unprocessable_entity, "Tenant database has too many connections"}
+
+      {:error, :connect_rate_limit_reached} ->
+        {:error, :unprocessable_entity, "Connect rate limit reached"}
+
+      {:error, error} ->
+        log_error("UnableToSetPolicies", error)
+        {:error, :internal_server_error, "Unable to authorize broadcast"}
+
+      other ->
+        log_error("UnableToSetPolicies", other)
+        {:error, :internal_server_error, "Unable to authorize broadcast"}
     end
   end
 
-  defp permissions_for_message(_, nil, _), do: nil
+  defp permissions_for_message(_, nil, _), do: {:error, :forbidden}
 
   defp permissions_for_message(tenant, auth_params, topic) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id) do
@@ -186,11 +235,7 @@ defmodule Realtime.Tenants.SingleBroadcast do
         |> Map.put(:topic, topic)
         |> Authorization.build_authorization_params()
 
-      case Authorization.get_write_authorizations(db_conn, auth_params) do
-        {:ok, policies} -> policies
-        {:error, :not_found} -> nil
-        error -> error
-      end
+      Authorization.get_write_authorizations(db_conn, auth_params)
     end
   end
 

--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -46,20 +46,16 @@ defmodule Realtime.Tenants.SingleBroadcast do
   Broadcasts a single message to the specified topic.
 
   ## Parameters
-  - `conn` - Plug.Conn or auth_params map containing JWT claims
+  - `auth_params` - `%Realtime.Tenants.Authorization{}` struct
   - `tenant` - Tenant struct
   - `topic` - Channel topic from URL (e.g., "room:123")
   - `event` - Event name from URL (e.g., "message")
   - `private` - Whether this is a private broadcast (requires authorization)
   - `payload` - Message payload (map for JSON, binary for binary)
   - `content_type` - :json or :binary
-
-  ## Returns
-  - `:ok` on success
-  - `{:error, term()}` on failure
   """
   @spec broadcast(
-          Plug.Conn.t() | map(),
+          Authorization.t(),
           Tenant.t(),
           String.t(),
           String.t(),
@@ -67,19 +63,7 @@ defmodule Realtime.Tenants.SingleBroadcast do
           any(),
           content_type()
         ) :: :ok | {:error, term()} | {:error, atom(), String.t()}
-  def broadcast(conn, tenant, topic, event, private, payload, content_type)
-
-  def broadcast(%Plug.Conn{} = conn, %Tenant{} = tenant, topic, event, private, payload, content_type) do
-    auth_params = %{
-      tenant_id: tenant.external_id,
-      headers: conn.req_headers,
-      claims: conn.assigns.claims,
-      role: conn.assigns.role,
-      sub: conn.assigns.sub
-    }
-
-    broadcast(auth_params, tenant, topic, event, private, payload, content_type)
-  end
+  def broadcast(auth_params, tenant, topic, event, private, payload, content_type)
 
   def broadcast(auth_params, %Tenant{} = tenant, topic, event, private, payload, content_type) do
     with %Ecto.Changeset{valid?: true} <- validate_message(topic, event, private, payload, content_type, tenant),
@@ -177,9 +161,6 @@ defmodule Realtime.Tenants.SingleBroadcast do
       {:ok, %Policies{broadcast: %BroadcastPolicies{write: _}}} ->
         {:error, :forbidden, "Unauthorized"}
 
-      {:error, :forbidden} ->
-        {:error, :forbidden, "Unauthorized"}
-
       {:error, :rls_policy_error, error} ->
         log_error("RlsPolicyError", error)
         {:error, :unprocessable_entity, "RLS policy error"}
@@ -190,7 +171,7 @@ defmodule Realtime.Tenants.SingleBroadcast do
 
       {:error, :rpc_error, error} ->
         log_error("RpcError", error)
-        {:error, :service_unavailable, "RPC error"}
+        {:error, :internal_server_error, "RPC error"}
 
       {:error, :missing_partition} ->
         log_error("MissingPartition", "Realtime was unable to find the expected messages partition")
@@ -201,7 +182,7 @@ defmodule Realtime.Tenants.SingleBroadcast do
 
       {:error, :tenant_database_unavailable} ->
         log_error("UnableToConnectToProject", "Realtime was unable to connect to the project database")
-        {:error, :service_unavailable, "Tenant database unavailable"}
+        {:error, :unprocessable_entity, "Tenant database unavailable"}
 
       {:error, :initializing} ->
         {:error, :unprocessable_entity, "Tenant database initializing"}
@@ -226,15 +207,9 @@ defmodule Realtime.Tenants.SingleBroadcast do
     end
   end
 
-  defp permissions_for_message(_, nil, _), do: {:error, :forbidden}
-
   defp permissions_for_message(tenant, auth_params, topic) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id) do
-      auth_params =
-        auth_params
-        |> Map.put(:topic, topic)
-        |> Authorization.build_authorization_params()
-
+      auth_params = %{auth_params | topic: topic}
       Authorization.get_write_authorizations(db_conn, auth_params)
     end
   end

--- a/lib/realtime_web/controllers/broadcast_single_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_single_controller.ex
@@ -34,9 +34,7 @@ defmodule RealtimeWeb.BroadcastSingleController do
         name: "topic",
         schema: %OpenApiSpex.Schema{type: :string},
         required: true,
-        example: "room:123",
-        description:
-          "Channel topic. Note: libraries will prepend the channel name with 'realtime:' so if you use this endpoint directly you'll need to also prepend 'realtime:' so it's captured by clients properly"
+        example: "room:123"
       ],
       event: [
         in: :path,
@@ -77,12 +75,10 @@ defmodule RealtimeWeb.BroadcastSingleController do
     }
   )
 
-  # Handles broadcast request with binary payload
   def broadcast(
         %{assigns: %{tenant: tenant}, body_params: %{"_binary" => binary}} = conn,
         %{"topic" => topic, "event" => event} = params
-      )
-      when is_binary(binary) do
+      ) do
     private = parse_private(params["private"])
     auth_params = build_auth_params(conn, tenant)
 
@@ -91,11 +87,7 @@ defmodule RealtimeWeb.BroadcastSingleController do
     end
   end
 
-  # Handles broadcast request with JSON payload
-  def broadcast(
-        %{assigns: %{tenant: tenant}} = conn,
-        %{"topic" => topic, "event" => event} = params
-      ) do
+  def broadcast(%{assigns: %{tenant: tenant}} = conn, %{"topic" => topic, "event" => event} = params) do
     private = parse_private(params["private"])
     payload = conn.body_params
     auth_params = build_auth_params(conn, tenant)

--- a/lib/realtime_web/controllers/broadcast_single_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_single_controller.ex
@@ -8,6 +8,7 @@ defmodule RealtimeWeb.BroadcastSingleController do
   use RealtimeWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.SingleBroadcast
   alias RealtimeWeb.OpenApiSchemas.EmptyResponse
   alias RealtimeWeb.OpenApiSchemas.BroadcastSingleJsonParams
@@ -83,8 +84,9 @@ defmodule RealtimeWeb.BroadcastSingleController do
       )
       when is_binary(binary) do
     private = parse_private(params["private"])
+    auth_params = build_auth_params(conn, tenant)
 
-    with :ok <- SingleBroadcast.broadcast(conn, tenant, topic, event, private, binary, :binary) do
+    with :ok <- SingleBroadcast.broadcast(auth_params, tenant, topic, event, private, binary, :binary) do
       send_resp(conn, :accepted, "")
     end
   end
@@ -96,10 +98,21 @@ defmodule RealtimeWeb.BroadcastSingleController do
       ) do
     private = parse_private(params["private"])
     payload = conn.body_params
+    auth_params = build_auth_params(conn, tenant)
 
-    with :ok <- SingleBroadcast.broadcast(conn, tenant, topic, event, private, payload, :json) do
+    with :ok <- SingleBroadcast.broadcast(auth_params, tenant, topic, event, private, payload, :json) do
       send_resp(conn, :accepted, "")
     end
+  end
+
+  defp build_auth_params(conn, tenant) do
+    Authorization.build_authorization_params(%{
+      tenant_id: tenant.external_id,
+      headers: conn.req_headers,
+      claims: conn.assigns.claims,
+      role: conn.assigns.role,
+      sub: conn.assigns.sub
+    })
   end
 
   defp parse_private("true"), do: true

--- a/lib/realtime_web/controllers/broadcast_single_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_single_controller.ex
@@ -78,9 +78,10 @@ defmodule RealtimeWeb.BroadcastSingleController do
 
   # Handles broadcast request with binary payload
   def broadcast(
-        %{assigns: %{tenant: tenant, binary_payload: binary}} = conn,
+        %{assigns: %{tenant: tenant}, body_params: %{"_binary" => binary}} = conn,
         %{"topic" => topic, "event" => event} = params
-      ) do
+      )
+      when is_binary(binary) do
     private = parse_private(params["private"])
 
     with :ok <- SingleBroadcast.broadcast(conn, tenant, topic, event, private, binary, :binary) do
@@ -94,7 +95,6 @@ defmodule RealtimeWeb.BroadcastSingleController do
         %{"topic" => topic, "event" => event} = params
       ) do
     private = parse_private(params["private"])
-    # Body is the payload directly
     payload = conn.body_params
 
     with :ok <- SingleBroadcast.broadcast(conn, tenant, topic, event, private, payload, :json) do

--- a/lib/realtime_web/controllers/broadcast_single_controller.ex
+++ b/lib/realtime_web/controllers/broadcast_single_controller.ex
@@ -1,0 +1,108 @@
+defmodule RealtimeWeb.BroadcastSingleController do
+  @moduledoc """
+  Controller for single broadcast API endpoint.
+
+  This API sends a single broadcast message using URL path parameters for topic and event.
+  Supports both JSON and binary payloads via Content-Type header.
+  """
+  use RealtimeWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Realtime.Tenants.SingleBroadcast
+  alias RealtimeWeb.OpenApiSchemas.EmptyResponse
+  alias RealtimeWeb.OpenApiSchemas.BroadcastSingleJsonParams
+  alias RealtimeWeb.OpenApiSchemas.BroadcastSingleBinaryParams
+  alias RealtimeWeb.OpenApiSchemas.TooManyRequestsResponse
+  alias RealtimeWeb.OpenApiSchemas.UnprocessableEntityResponse
+
+  action_fallback(RealtimeWeb.FallbackController)
+
+  operation(:broadcast,
+    summary: "Broadcasts a single message",
+    parameters: [
+      token: [
+        in: :header,
+        name: "Authorization",
+        schema: %OpenApiSpex.Schema{type: :string},
+        required: true,
+        example:
+          "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY"
+      ],
+      topic: [
+        in: :path,
+        name: "topic",
+        schema: %OpenApiSpex.Schema{type: :string},
+        required: true,
+        example: "room:123",
+        description:
+          "Channel topic. Note: libraries will prepend the channel name with 'realtime:' so if you use this endpoint directly you'll need to also prepend 'realtime:' so it's captured by clients properly"
+      ],
+      event: [
+        in: :path,
+        name: "event",
+        schema: %OpenApiSpex.Schema{type: :string},
+        required: true,
+        example: "message",
+        description: "Event name for the broadcast"
+      ],
+      private: [
+        in: :query,
+        name: "private",
+        schema: %OpenApiSpex.Schema{type: :boolean},
+        required: false,
+        example: false,
+        description: "Whether this is a private broadcast (requires RLS authorization). Defaults to false."
+      ]
+    ],
+    request_body: %OpenApiSpex.RequestBody{
+      description: "Broadcast message payload. Supports both JSON and binary formats.",
+      required: true,
+      content: %{
+        "application/json" => %OpenApiSpex.MediaType{
+          schema: BroadcastSingleJsonParams,
+          example: %{"text" => "hello world", "user" => "alice"}
+        },
+        "application/octet-stream" => %OpenApiSpex.MediaType{
+          schema: BroadcastSingleBinaryParams
+        }
+      }
+    },
+    responses: %{
+      202 => EmptyResponse.response(),
+      401 => EmptyResponse.response(),
+      415 => EmptyResponse.response(),
+      422 => UnprocessableEntityResponse.response(),
+      429 => TooManyRequestsResponse.response()
+    }
+  )
+
+  # Handles broadcast request with binary payload
+  def broadcast(
+        %{assigns: %{tenant: tenant, binary_payload: binary}} = conn,
+        %{"topic" => topic, "event" => event} = params
+      ) do
+    private = parse_private(params["private"])
+
+    with :ok <- SingleBroadcast.broadcast(conn, tenant, topic, event, private, binary, :binary) do
+      send_resp(conn, :accepted, "")
+    end
+  end
+
+  # Handles broadcast request with JSON payload
+  def broadcast(
+        %{assigns: %{tenant: tenant}} = conn,
+        %{"topic" => topic, "event" => event} = params
+      ) do
+    private = parse_private(params["private"])
+    # Body is the payload directly
+    payload = conn.body_params
+
+    with :ok <- SingleBroadcast.broadcast(conn, tenant, topic, event, private, payload, :json) do
+      send_resp(conn, :accepted, "")
+    end
+  end
+
+  defp parse_private("true"), do: true
+  defp parse_private(true), do: true
+  defp parse_private(_), do: false
+end

--- a/lib/realtime_web/endpoint.ex
+++ b/lib/realtime_web/endpoint.ex
@@ -84,7 +84,7 @@ defmodule RealtimeWeb.Endpoint do
   def log_level(_), do: :info
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
+    parsers: [:urlencoded, :multipart, :json, RealtimeWeb.Plugs.Parsers.OctetStream],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()
 

--- a/lib/realtime_web/open_api_schemas.ex
+++ b/lib/realtime_web/open_api_schemas.ex
@@ -55,6 +55,28 @@ defmodule RealtimeWeb.OpenApiSchemas do
     def params, do: {"Tenant Batch Params", "application/json", __MODULE__}
   end
 
+  defmodule BroadcastSingleJsonParams do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      description: "JSON payload - any valid JSON object",
+      example: %{"text" => "hello world", "user" => "alice"}
+    })
+  end
+
+  defmodule BroadcastSingleBinaryParams do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :string,
+      format: :binary,
+      description: "Binary payload - raw binary data"
+    })
+  end
+
   defmodule TenantParams do
     @moduledoc false
     require OpenApiSpex

--- a/lib/realtime_web/plugs/parsers/octet_stream.ex
+++ b/lib/realtime_web/plugs/parsers/octet_stream.ex
@@ -1,0 +1,41 @@
+defmodule RealtimeWeb.Plugs.Parsers.OctetStream do
+  @moduledoc """
+  `Plug.Parsers` implementation for `application/octet-stream` request bodies.
+
+  The raw binary body is placed in `conn.body_params` under the `"_binary"`
+  key, mirroring how `Plug.Parsers.JSON` exposes non-map top-level JSON via
+  `"_json"`.
+
+  Supports the same options as `Plug.Conn.read_body/2`: `:length`,
+  `:read_length`, `:read_timeout`, and `:body_reader`. Defaults inherit from
+  `Plug.Conn.read_body/2` (8 MB max length).
+  """
+
+  @behaviour Plug.Parsers
+
+  @impl true
+  def init(opts) do
+    Keyword.pop(opts, :body_reader, {Plug.Conn, :read_body, []})
+  end
+
+  @impl true
+  def parse(conn, "application", "octet-stream", _headers, {{mod, fun, args}, opts}) do
+    case apply(mod, fun, [conn, opts | args]) do
+      {:ok, body, conn} ->
+        {:ok, %{"_binary" => body}, conn}
+
+      {:more, _data, conn} ->
+        {:error, :too_large, conn}
+
+      {:error, :timeout} ->
+        raise Plug.TimeoutError
+
+      {:error, _} ->
+        raise Plug.BadRequestError
+    end
+  end
+
+  def parse(conn, _type, _subtype, _headers, _opts) do
+    {:next, conn}
+  end
+end

--- a/lib/realtime_web/plugs/validate_broadcast_content_type.ex
+++ b/lib/realtime_web/plugs/validate_broadcast_content_type.ex
@@ -1,0 +1,39 @@
+defmodule RealtimeWeb.Plugs.ValidateBroadcastContentType do
+  @moduledoc """
+  Validates the request `Content-Type` for the broadcast-single endpoint.
+
+  Allowed: `application/json` and `application/octet-stream` (optionally with
+  parameters such as `; charset=utf-8`). A missing header is also allowed for
+  backward compatibility with callers that historically POSTed JSON without
+  setting the header.
+
+  Any other media type is rejected with a 415 response carrying a JSON body.
+  """
+  import Plug.Conn
+
+  @allowed ["application/json", "application/octet-stream"]
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    case get_req_header(conn, "content-type") do
+      [] ->
+        conn
+
+      [content_type | _] ->
+        if Enum.any?(@allowed, &String.starts_with?(content_type, &1)) do
+          conn
+        else
+          conn
+          |> put_resp_content_type("application/json")
+          |> send_resp(
+            415,
+            Jason.encode!(%{
+              error: "Unsupported Media Type. Use application/json or application/octet-stream"
+            })
+          )
+          |> halt()
+        end
+    end
+  end
+end

--- a/lib/realtime_web/plugs/validate_broadcast_content_type.ex
+++ b/lib/realtime_web/plugs/validate_broadcast_content_type.ex
@@ -11,7 +11,7 @@ defmodule RealtimeWeb.Plugs.ValidateBroadcastContentType do
   """
   import Plug.Conn
 
-  @allowed ["application/json", "application/octet-stream"]
+  @allowed ["json", "octet-stream"]
 
   def init(opts), do: opts
 
@@ -21,18 +21,20 @@ defmodule RealtimeWeb.Plugs.ValidateBroadcastContentType do
         conn
 
       [content_type | _] ->
-        if Enum.any?(@allowed, &String.starts_with?(content_type, &1)) do
-          conn
-        else
-          conn
-          |> put_resp_content_type("application/json")
-          |> send_resp(
-            415,
-            Jason.encode!(%{
-              error: "Unsupported Media Type. Use application/json or application/octet-stream"
-            })
-          )
-          |> halt()
+        case Plug.Conn.Utils.content_type(content_type) do
+          {:ok, "application", subtype, _params} when subtype in @allowed ->
+            conn
+
+          _ ->
+            conn
+            |> put_resp_content_type("application/json")
+            |> send_resp(
+              415,
+              Jason.encode!(%{
+                error: "Unsupported Media Type. Use application/json or application/octet-stream"
+              })
+            )
+            |> halt()
         end
     end
   end

--- a/lib/realtime_web/router.ex
+++ b/lib/realtime_web/router.ex
@@ -36,6 +36,14 @@ defmodule RealtimeWeb.Router do
     plug(:set_span_request_id)
   end
 
+  pipeline :broadcast_single do
+    plug(:accepts, ["json", "octet-stream"])
+    plug(RealtimeWeb.Plugs.ValidateBroadcastContentType)
+    plug(RealtimeWeb.Plugs.AssignTenant)
+    plug(RealtimeWeb.Plugs.RateLimiter)
+    plug(:set_span_request_id)
+  end
+
   pipeline :dashboard_admin do
     plug(:dashboard_auth)
   end
@@ -104,6 +112,12 @@ defmodule RealtimeWeb.Router do
     pipe_through([:open_cors, :tenant_api, :secure_tenant_api])
 
     post("/broadcast", BroadcastController, :broadcast)
+  end
+
+  scope "/api", RealtimeWeb do
+    pipe_through([:open_cors, :broadcast_single, :secure_tenant_api])
+
+    post("/broadcast/:topic/events/:event", BroadcastSingleController, :broadcast)
   end
 
   # Enables LiveDashboard only for development

--- a/lib/realtime_web/socket/v2_serializer.ex
+++ b/lib/realtime_web/socket/v2_serializer.ex
@@ -37,11 +37,10 @@ defmodule RealtimeWeb.Socket.V2Serializer do
       user_payload_encoding::size(8),
       msg.topic::binary-size(topic_size),
       msg.user_event::binary-size(user_event_size),
-      metadata || <<>>::binary-size(metadata_size),
-      msg.user_payload::binary
+      metadata || <<>>::binary-size(metadata_size)
     >>
 
-    {:socket_push, :binary, bin}
+    {:socket_push, :binary, [bin, msg.user_payload]}
   end
 
   def fastlane!(%Broadcast{payload: {:binary, data}} = msg) do

--- a/lib/realtime_web/socket/v2_serializer.ex
+++ b/lib/realtime_web/socket/v2_serializer.ex
@@ -37,10 +37,11 @@ defmodule RealtimeWeb.Socket.V2Serializer do
       user_payload_encoding::size(8),
       msg.topic::binary-size(topic_size),
       msg.user_event::binary-size(user_event_size),
-      metadata || <<>>::binary-size(metadata_size)
+      metadata || <<>>::binary-size(metadata_size),
+      msg.user_payload::binary
     >>
 
-    {:socket_push, :binary, [bin, msg.user_payload]}
+    {:socket_push, :binary, bin}
   end
 
   def fastlane!(%Broadcast{payload: {:binary, data}} = msg) do

--- a/test/realtime/tenants/single_broadcast_test.exs
+++ b/test/realtime/tenants/single_broadcast_test.exs
@@ -345,11 +345,6 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
   end
 
   describe "error handling" do
-    test "returns error when tenant is nil" do
-      assert {:error, :tenant_not_found} =
-               SingleBroadcast.broadcast(%Authorization{}, nil, "topic", "event", false, %{"data" => "test"}, :json)
-    end
-
     test "database connection errors for private messages returns error", %{tenant: tenant} do
       topic = random_string()
       sub = random_string()
@@ -409,15 +404,8 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       RateCounter
       |> stub(:new, fn _ -> {:ok, nil} end)
       |> stub(:get, fn
-        ^events_per_second_rate ->
-          {:ok, %RateCounter{avg: 0}}
-
-        _ ->
-          {:ok,
-           %RateCounter{
-             avg: 0,
-             limit: %{log: true, value: 10, measurement: :sum, triggered: false, log_fn: fn -> :ok end}
-           }}
+        ^events_per_second_rate -> {:ok, %RateCounter{avg: 0}}
+        _ -> {:ok, %RateCounter{avg: 0}}
       end)
 
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
@@ -431,9 +419,6 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
 
       assert :ok =
                SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, %{"secret" => "data"}, :json)
-
-      broadcast_calls = calls(&TenantBroadcaster.pubsub_broadcast/5)
-      assert length(broadcast_calls) == 1
     end
   end
 end

--- a/test/realtime/tenants/single_broadcast_test.exs
+++ b/test/realtime/tenants/single_broadcast_test.exs
@@ -44,7 +44,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
         :ok
       end)
 
-      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, event, false, payload, :json)
+      assert :ok = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, event, false, payload, :json)
     end
 
     test "public messages do not have private prefix in topic", %{tenant: tenant} do
@@ -58,7 +58,8 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
         :ok
       end)
 
-      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, %{"data" => "test"}, :json)
+      assert :ok =
+               SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, %{"data" => "test"}, :json)
     end
 
     test "JSON payload can be empty map", %{tenant: tenant} do
@@ -68,7 +69,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
       expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
 
-      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, %{}, :json)
+      assert :ok = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, %{}, :json)
     end
   end
 
@@ -93,7 +94,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
         :ok
       end)
 
-      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, event, false, binary, :binary)
+      assert :ok = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, event, false, binary, :binary)
     end
 
     test "binary payload can be empty", %{tenant: tenant} do
@@ -103,7 +104,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
       expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
 
-      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, <<>>, :binary)
+      assert :ok = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, <<>>, :binary)
     end
 
     test "handles large binary payloads within limit", %{tenant: tenant} do
@@ -116,7 +117,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
       expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
 
-      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, binary, :binary)
+      assert :ok = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, binary, :binary)
     end
   end
 
@@ -127,22 +128,22 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       role = "authenticated"
       payload = %{"secret" => "data"}
 
-      auth_params = %{
-        tenant_id: tenant.external_id,
-        topic: topic,
-        headers: [{"header-1", "value-1"}],
-        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
-        role: role,
-        sub: sub
-      }
+      auth_params =
+        Authorization.build_authorization_params(%{
+          tenant_id: tenant.external_id,
+          headers: [{"header-1", "value-1"}],
+          claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+          role: role,
+          sub: sub
+        })
 
       broadcast_events_key = Tenants.events_per_second_key(tenant)
 
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
 
-      Authorization
-      |> expect(:build_authorization_params, fn params -> params end)
-      |> expect(:get_write_authorizations, fn _, _ -> {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}} end)
+      expect(Authorization, :get_write_authorizations, fn _, _ ->
+        {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
+      end)
 
       expect(TenantBroadcaster, :pubsub_broadcast, fn _, tenant_topic, _, _, _ ->
         assert String.contains?(tenant_topic, "-private")
@@ -157,24 +158,23 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       sub = random_string()
       role = "anon"
 
-      auth_params = %{
-        tenant_id: tenant.external_id,
-        topic: topic,
-        headers: [{"header-1", "value-1"}],
-        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
-        role: role,
-        sub: sub
-      }
+      auth_params =
+        Authorization.build_authorization_params(%{
+          tenant_id: tenant.external_id,
+          headers: [{"header-1", "value-1"}],
+          claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+          role: role,
+          sub: sub
+        })
 
-      Authorization
-      |> expect(:build_authorization_params, fn params -> params end)
-      |> expect(:get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _ ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: false}}}
       end)
 
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      assert :ok = SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, %{"data" => "test"}, :json)
+      assert {:error, :forbidden, "Unauthorized"} =
+               SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, %{"data" => "test"}, :json)
 
       assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
     end
@@ -187,22 +187,22 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       role = "authenticated"
       binary = <<255, 254, 253>>
 
-      auth_params = %{
-        tenant_id: tenant.external_id,
-        topic: topic,
-        headers: [{"header-1", "value-1"}],
-        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
-        role: role,
-        sub: sub
-      }
+      auth_params =
+        Authorization.build_authorization_params(%{
+          tenant_id: tenant.external_id,
+          headers: [{"header-1", "value-1"}],
+          claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+          role: role,
+          sub: sub
+        })
 
       broadcast_events_key = Tenants.events_per_second_key(tenant)
 
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
 
-      Authorization
-      |> expect(:build_authorization_params, fn params -> params end)
-      |> expect(:get_write_authorizations, fn _, _ -> {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}} end)
+      expect(Authorization, :get_write_authorizations, fn _, _ ->
+        {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
+      end)
 
       expect(TenantBroadcaster, :pubsub_broadcast, fn _, tenant_topic, broadcast, _, _ ->
         assert String.contains?(tenant_topic, "-private")
@@ -223,66 +223,25 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       sub = random_string()
       role = "anon"
 
-      auth_params = %{
-        tenant_id: tenant.external_id,
-        topic: topic,
-        headers: [{"header-1", "value-1"}],
-        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
-        role: role,
-        sub: sub
-      }
+      auth_params =
+        Authorization.build_authorization_params(%{
+          tenant_id: tenant.external_id,
+          headers: [{"header-1", "value-1"}],
+          claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+          role: role,
+          sub: sub
+        })
 
-      Authorization
-      |> expect(:build_authorization_params, fn params -> params end)
-      |> expect(:get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _ ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: false}}}
       end)
 
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      assert :ok = SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, <<1, 2, 3>>, :binary)
+      assert {:error, :forbidden, "Unauthorized"} =
+               SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, <<1, 2, 3>>, :binary)
 
       assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
-    end
-  end
-
-  describe "Plug.Conn integration" do
-    test "accepts and converts Plug.Conn to auth params for JSON", %{tenant: tenant} do
-      topic = random_string()
-      broadcast_events_key = Tenants.events_per_second_key(tenant)
-
-      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
-      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
-
-      conn =
-        build_conn()
-        |> Map.put(:assigns, %{
-          claims: %{"sub" => "user123", "role" => "authenticated"},
-          role: "authenticated",
-          sub: "user123"
-        })
-        |> Map.put(:req_headers, [{"authorization", "Bearer token"}])
-
-      assert :ok = SingleBroadcast.broadcast(conn, tenant, topic, "event", false, %{"data" => "test"}, :json)
-    end
-
-    test "accepts and converts Plug.Conn to auth params for binary", %{tenant: tenant} do
-      topic = random_string()
-      broadcast_events_key = Tenants.events_per_second_key(tenant)
-
-      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
-      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
-
-      conn =
-        build_conn()
-        |> Map.put(:assigns, %{
-          claims: %{"sub" => "user123", "role" => "authenticated"},
-          role: "authenticated",
-          sub: "user123"
-        })
-        |> Map.put(:req_headers, [{"authorization", "Bearer token"}])
-
-      assert :ok = SingleBroadcast.broadcast(conn, tenant, topic, "event", false, <<1, 2, 3>>, :binary)
     end
   end
 
@@ -290,7 +249,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
     test "returns changeset error when topic is empty", %{tenant: tenant} do
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      result = SingleBroadcast.broadcast(nil, tenant, "", "event", false, %{"data" => "test"}, :json)
+      result = SingleBroadcast.broadcast(%Authorization{}, tenant, "", "event", false, %{"data" => "test"}, :json)
       assert {:error, %Ecto.Changeset{valid?: false}} = result
     end
 
@@ -298,7 +257,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       topic = random_string()
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      result = SingleBroadcast.broadcast(nil, tenant, topic, "", false, %{"data" => "test"}, :json)
+      result = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "", false, %{"data" => "test"}, :json)
       assert {:error, %Ecto.Changeset{valid?: false}} = result
     end
 
@@ -306,7 +265,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       topic = random_string()
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, nil, :json)
+      result = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, nil, :json)
       assert {:error, %Ecto.Changeset{valid?: false}} = result
     end
 
@@ -314,7 +273,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       topic = random_string()
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, nil, :binary)
+      result = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, nil, :binary)
       assert {:error, %Ecto.Changeset{valid?: false}} = result
     end
   end
@@ -330,7 +289,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
 
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, %{"data" => "test"}, :json)
+      result = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, %{"data" => "test"}, :json)
       assert {:error, :too_many_requests, "You have exceeded your rate limit"} = result
     end
 
@@ -349,7 +308,15 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
 
       assert :ok =
-               SingleBroadcast.broadcast(nil, tenant, random_string(), "event", false, %{"data" => "test"}, :json)
+               SingleBroadcast.broadcast(
+                 %Authorization{},
+                 tenant,
+                 random_string(),
+                 "event",
+                 false,
+                 %{"data" => "test"},
+                 :json
+               )
     end
 
     test "rejects JSON payload when size exceeds tenant limit", %{tenant: tenant} do
@@ -358,7 +325,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
 
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, large_payload, :json)
+      result = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, large_payload, :json)
 
       assert {:error, %Ecto.Changeset{valid?: false, errors: errors}} = result
       assert {:payload, {"Payload size exceeds tenant limit", []}} in errors
@@ -370,7 +337,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
 
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, large_binary, :binary)
+      result = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, large_binary, :binary)
 
       assert {:error, %Ecto.Changeset{valid?: false, errors: errors}} = result
       assert {:payload, {"Payload size exceeds tenant limit", []}} in errors
@@ -380,21 +347,22 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
   describe "error handling" do
     test "returns error when tenant is nil" do
       assert {:error, :tenant_not_found} =
-               SingleBroadcast.broadcast(nil, nil, "topic", "event", false, %{"data" => "test"}, :json)
+               SingleBroadcast.broadcast(%Authorization{}, nil, "topic", "event", false, %{"data" => "test"}, :json)
     end
 
-    test "gracefully handles database connection errors for private messages", %{tenant: tenant} do
+    test "database connection errors for private messages returns error", %{tenant: tenant} do
       topic = random_string()
       sub = random_string()
       role = "authenticated"
 
-      auth_params = %{
-        tenant_id: tenant.external_id,
-        headers: [{"header-1", "value-1"}],
-        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
-        role: role,
-        sub: sub
-      }
+      auth_params =
+        Authorization.build_authorization_params(%{
+          tenant_id: tenant.external_id,
+          headers: [{"header-1", "value-1"}],
+          claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+          role: role,
+          sub: sub
+        })
 
       events_per_second_rate = Tenants.events_per_second_rate(tenant)
 
@@ -402,26 +370,12 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       |> stub(:new, fn _ -> {:ok, nil} end)
       |> stub(:get, fn ^events_per_second_rate -> {:ok, %RateCounter{avg: 0}} end)
 
-      expect(Connect, :lookup_or_start_connection, fn _ -> {:error, :connection_failed} end)
+      expect(Connect, :lookup_or_start_connection, fn _ -> {:error, :tenant_database_unavailable} end)
 
       reject(&TenantBroadcaster.pubsub_broadcast/5)
 
-      assert :ok = SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, %{"data" => "test"}, :json)
-
-      assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
-    end
-
-    test "handles missing auth params for private messages", %{tenant: tenant} do
-      events_per_second_rate = Tenants.events_per_second_rate(tenant)
-
-      RateCounter
-      |> stub(:new, fn _ -> {:ok, nil} end)
-      |> stub(:get, fn ^events_per_second_rate -> {:ok, %RateCounter{avg: 0}} end)
-
-      reject(&TenantBroadcaster.pubsub_broadcast/5)
-      reject(&Connect.lookup_or_start_connection/1)
-
-      assert :ok = SingleBroadcast.broadcast(nil, tenant, "topic", "event", true, %{"data" => "test"}, :json)
+      assert {:error, :unprocessable_entity, "Tenant database unavailable"} =
+               SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, %{"data" => "test"}, :json)
 
       assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
     end
@@ -440,14 +394,14 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
 
       create_rls_policies(db_conn, [:authenticated_write_broadcast], %{topic: topic})
 
-      auth_params = %{
-        tenant_id: tenant.external_id,
-        topic: topic,
-        headers: [{"header-1", "value-1"}],
-        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
-        role: role,
-        sub: sub
-      }
+      auth_params =
+        Authorization.build_authorization_params(%{
+          tenant_id: tenant.external_id,
+          headers: [{"header-1", "value-1"}],
+          claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+          role: role,
+          sub: sub
+        })
 
       events_per_second_rate = Tenants.events_per_second_rate(tenant)
       broadcast_events_key = Tenants.events_per_second_key(tenant)
@@ -469,9 +423,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
       expect(Connect, :lookup_or_start_connection, fn _ -> {:ok, db_conn} end)
 
-      Authorization
-      |> expect(:build_authorization_params, fn params -> params end)
-      |> expect(:get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _ ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
       end)
 

--- a/test/realtime/tenants/single_broadcast_test.exs
+++ b/test/realtime/tenants/single_broadcast_test.exs
@@ -25,21 +25,22 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
     test "broadcasts JSON public message successfully", %{tenant: tenant} do
       broadcast_events_key = Tenants.events_per_second_key(tenant)
       topic = random_string()
+      tenant_topic = Tenants.tenant_topic(tenant.external_id, topic)
       event = "test-event"
       payload = %{"text" => "hello", "user" => "alice"}
 
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
 
       expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, broadcast, _, _ ->
-        assert %Phoenix.Socket.Broadcast{
-                 topic: ^topic,
-                 event: "broadcast",
-                 payload: %{
-                   "payload" => ^payload,
-                   "event" => ^event,
-                   "type" => "broadcast"
-                 }
+        assert %UserBroadcast{
+                 topic: ^tenant_topic,
+                 user_event: ^event,
+                 user_payload: json,
+                 user_payload_encoding: :json,
+                 metadata: nil
                } = broadcast
+
+        assert IO.iodata_to_binary(json) == Jason.encode!(payload)
 
         :ok
       end)
@@ -77,6 +78,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
     test "broadcasts binary message successfully", %{tenant: tenant} do
       broadcast_events_key = Tenants.events_per_second_key(tenant)
       topic = random_string()
+      tenant_topic = Tenants.tenant_topic(tenant.external_id, topic)
       event = "binary-event"
       binary = <<1, 2, 3, 4, 5>>
 
@@ -84,7 +86,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
 
       expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, broadcast, _, _ ->
         assert %UserBroadcast{
-                 topic: ^topic,
+                 topic: ^tenant_topic,
                  user_event: ^event,
                  user_payload: ^binary,
                  user_payload_encoding: :binary,

--- a/test/realtime/tenants/single_broadcast_test.exs
+++ b/test/realtime/tenants/single_broadcast_test.exs
@@ -1,0 +1,487 @@
+defmodule Realtime.Tenants.SingleBroadcastTest do
+  use RealtimeWeb.ConnCase, async: true
+  use Mimic
+
+  alias Realtime.Database
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
+  alias Realtime.Tenants
+  alias Realtime.Tenants.SingleBroadcast
+  alias Realtime.Tenants.Authorization
+  alias Realtime.Tenants.Authorization.Policies
+  alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Connect
+
+  alias RealtimeWeb.TenantBroadcaster
+  alias RealtimeWeb.Socket.UserBroadcast
+
+  setup do
+    tenant = Containers.checkout_tenant(run_migrations: true)
+    Realtime.Tenants.Cache.update_cache(tenant)
+    {:ok, tenant: tenant}
+  end
+
+  describe "JSON public message broadcasting" do
+    test "broadcasts JSON public message successfully", %{tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      topic = random_string()
+      event = "test-event"
+      payload = %{"text" => "hello", "user" => "alice"}
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, broadcast, _, _ ->
+        assert %Phoenix.Socket.Broadcast{
+                 topic: ^topic,
+                 event: "broadcast",
+                 payload: %{
+                   "payload" => ^payload,
+                   "event" => ^event,
+                   "type" => "broadcast"
+                 }
+               } = broadcast
+
+        :ok
+      end)
+
+      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, event, false, payload, :json)
+    end
+
+    test "public messages do not have private prefix in topic", %{tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      topic = random_string()
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, tenant_topic, _, _, _ ->
+        refute String.contains?(tenant_topic, "-private")
+        :ok
+      end)
+
+      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, %{"data" => "test"}, :json)
+    end
+
+    test "JSON payload can be empty map", %{tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      topic = random_string()
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
+
+      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, %{}, :json)
+    end
+  end
+
+  describe "Binary public message broadcasting" do
+    test "broadcasts binary message successfully", %{tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      topic = random_string()
+      event = "binary-event"
+      binary = <<1, 2, 3, 4, 5>>
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, broadcast, _, _ ->
+        assert %UserBroadcast{
+                 topic: ^topic,
+                 user_event: ^event,
+                 user_payload: ^binary,
+                 user_payload_encoding: :binary,
+                 metadata: nil
+               } = broadcast
+
+        :ok
+      end)
+
+      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, event, false, binary, :binary)
+    end
+
+    test "binary payload can be empty", %{tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      topic = random_string()
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
+
+      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, <<>>, :binary)
+    end
+
+    test "handles large binary payloads within limit", %{tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      topic = random_string()
+      # Create binary well under the limit to account for erlang term overhead
+      # The max is in KB (1000 bytes per KB), plus 500 byte padding
+      binary = :crypto.strong_rand_bytes(tenant.max_payload_size_in_kb * 1000 - 100)
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
+
+      assert :ok = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, binary, :binary)
+    end
+  end
+
+  describe "JSON private message authorization" do
+    test "broadcasts private JSON message with valid authorization", %{tenant: tenant} do
+      topic = random_string()
+      sub = random_string()
+      role = "authenticated"
+      payload = %{"secret" => "data"}
+
+      auth_params = %{
+        tenant_id: tenant.external_id,
+        topic: topic,
+        headers: [{"header-1", "value-1"}],
+        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+        role: role,
+        sub: sub
+      }
+
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+
+      Authorization
+      |> expect(:build_authorization_params, fn params -> params end)
+      |> expect(:get_write_authorizations, fn _, _ -> {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}} end)
+
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, tenant_topic, _, _, _ ->
+        assert String.contains?(tenant_topic, "-private")
+        :ok
+      end)
+
+      assert :ok = SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, payload, :json)
+    end
+
+    test "skips private JSON message without authorization", %{tenant: tenant} do
+      topic = random_string()
+      sub = random_string()
+      role = "anon"
+
+      auth_params = %{
+        tenant_id: tenant.external_id,
+        topic: topic,
+        headers: [{"header-1", "value-1"}],
+        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+        role: role,
+        sub: sub
+      }
+
+      Authorization
+      |> expect(:build_authorization_params, fn params -> params end)
+      |> expect(:get_write_authorizations, fn _, _ ->
+        {:ok, %Policies{broadcast: %BroadcastPolicies{write: false}}}
+      end)
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      assert :ok = SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, %{"data" => "test"}, :json)
+
+      assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
+    end
+  end
+
+  describe "Binary private message authorization" do
+    test "broadcasts private binary message with valid authorization", %{tenant: tenant} do
+      topic = random_string()
+      sub = random_string()
+      role = "authenticated"
+      binary = <<255, 254, 253>>
+
+      auth_params = %{
+        tenant_id: tenant.external_id,
+        topic: topic,
+        headers: [{"header-1", "value-1"}],
+        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+        role: role,
+        sub: sub
+      }
+
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+
+      Authorization
+      |> expect(:build_authorization_params, fn params -> params end)
+      |> expect(:get_write_authorizations, fn _, _ -> {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}} end)
+
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, tenant_topic, broadcast, _, _ ->
+        assert String.contains?(tenant_topic, "-private")
+
+        assert %UserBroadcast{
+                 user_payload: ^binary,
+                 user_payload_encoding: :binary
+               } = broadcast
+
+        :ok
+      end)
+
+      assert :ok = SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, binary, :binary)
+    end
+
+    test "skips private binary message without authorization", %{tenant: tenant} do
+      topic = random_string()
+      sub = random_string()
+      role = "anon"
+
+      auth_params = %{
+        tenant_id: tenant.external_id,
+        topic: topic,
+        headers: [{"header-1", "value-1"}],
+        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+        role: role,
+        sub: sub
+      }
+
+      Authorization
+      |> expect(:build_authorization_params, fn params -> params end)
+      |> expect(:get_write_authorizations, fn _, _ ->
+        {:ok, %Policies{broadcast: %BroadcastPolicies{write: false}}}
+      end)
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      assert :ok = SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, <<1, 2, 3>>, :binary)
+
+      assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
+    end
+  end
+
+  describe "Plug.Conn integration" do
+    test "accepts and converts Plug.Conn to auth params for JSON", %{tenant: tenant} do
+      topic = random_string()
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
+
+      conn =
+        build_conn()
+        |> Map.put(:assigns, %{
+          claims: %{"sub" => "user123", "role" => "authenticated"},
+          role: "authenticated",
+          sub: "user123"
+        })
+        |> Map.put(:req_headers, [{"authorization", "Bearer token"}])
+
+      assert :ok = SingleBroadcast.broadcast(conn, tenant, topic, "event", false, %{"data" => "test"}, :json)
+    end
+
+    test "accepts and converts Plug.Conn to auth params for binary", %{tenant: tenant} do
+      topic = random_string()
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
+
+      conn =
+        build_conn()
+        |> Map.put(:assigns, %{
+          claims: %{"sub" => "user123", "role" => "authenticated"},
+          role: "authenticated",
+          sub: "user123"
+        })
+        |> Map.put(:req_headers, [{"authorization", "Bearer token"}])
+
+      assert :ok = SingleBroadcast.broadcast(conn, tenant, topic, "event", false, <<1, 2, 3>>, :binary)
+    end
+  end
+
+  describe "message validation" do
+    test "returns changeset error when topic is empty", %{tenant: tenant} do
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      result = SingleBroadcast.broadcast(nil, tenant, "", "event", false, %{"data" => "test"}, :json)
+      assert {:error, %Ecto.Changeset{valid?: false}} = result
+    end
+
+    test "returns changeset error when event is empty", %{tenant: tenant} do
+      topic = random_string()
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      result = SingleBroadcast.broadcast(nil, tenant, topic, "", false, %{"data" => "test"}, :json)
+      assert {:error, %Ecto.Changeset{valid?: false}} = result
+    end
+
+    test "returns changeset error when JSON payload is nil", %{tenant: tenant} do
+      topic = random_string()
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, nil, :json)
+      assert {:error, %Ecto.Changeset{valid?: false}} = result
+    end
+
+    test "returns changeset error when binary payload is nil", %{tenant: tenant} do
+      topic = random_string()
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, nil, :binary)
+      assert {:error, %Ecto.Changeset{valid?: false}} = result
+    end
+  end
+
+  describe "rate limiting" do
+    test "rejects broadcast when rate limit is exceeded", %{tenant: tenant} do
+      events_per_second_rate = Tenants.events_per_second_rate(tenant)
+      topic = random_string()
+
+      RateCounter
+      |> stub(:new, fn _ -> {:ok, nil} end)
+      |> stub(:get, fn ^events_per_second_rate -> {:ok, %RateCounter{avg: tenant.max_events_per_second + 1}} end)
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, %{"data" => "test"}, :json)
+      assert {:error, :too_many_requests, "You have exceeded your rate limit"} = result
+    end
+
+    test "allows broadcast at rate limit boundary", %{tenant: tenant} do
+      events_per_second_rate = Tenants.events_per_second_rate(tenant)
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      current_rate = tenant.max_events_per_second - 1
+
+      RateCounter
+      |> stub(:new, fn _ -> {:ok, nil} end)
+      |> stub(:get, fn ^events_per_second_rate ->
+        {:ok, %RateCounter{avg: current_rate}}
+      end)
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
+
+      assert :ok =
+               SingleBroadcast.broadcast(nil, tenant, random_string(), "event", false, %{"data" => "test"}, :json)
+    end
+
+    test "rejects JSON payload when size exceeds tenant limit", %{tenant: tenant} do
+      topic = random_string()
+      large_payload = %{"data" => random_string(tenant.max_payload_size_in_kb * 1000 + 1)}
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, large_payload, :json)
+
+      assert {:error, %Ecto.Changeset{valid?: false, errors: errors}} = result
+      assert {:payload, {"Payload size exceeds tenant limit", []}} in errors
+    end
+
+    test "rejects binary payload when size exceeds tenant limit", %{tenant: tenant} do
+      topic = random_string()
+      large_binary = :crypto.strong_rand_bytes(tenant.max_payload_size_in_kb * 1024 + 1)
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      result = SingleBroadcast.broadcast(nil, tenant, topic, "event", false, large_binary, :binary)
+
+      assert {:error, %Ecto.Changeset{valid?: false, errors: errors}} = result
+      assert {:payload, {"Payload size exceeds tenant limit", []}} in errors
+    end
+  end
+
+  describe "error handling" do
+    test "returns error when tenant is nil" do
+      assert {:error, :tenant_not_found} =
+               SingleBroadcast.broadcast(nil, nil, "topic", "event", false, %{"data" => "test"}, :json)
+    end
+
+    test "gracefully handles database connection errors for private messages", %{tenant: tenant} do
+      topic = random_string()
+      sub = random_string()
+      role = "authenticated"
+
+      auth_params = %{
+        tenant_id: tenant.external_id,
+        headers: [{"header-1", "value-1"}],
+        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+        role: role,
+        sub: sub
+      }
+
+      events_per_second_rate = Tenants.events_per_second_rate(tenant)
+
+      RateCounter
+      |> stub(:new, fn _ -> {:ok, nil} end)
+      |> stub(:get, fn ^events_per_second_rate -> {:ok, %RateCounter{avg: 0}} end)
+
+      expect(Connect, :lookup_or_start_connection, fn _ -> {:error, :connection_failed} end)
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      assert :ok = SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, %{"data" => "test"}, :json)
+
+      assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
+    end
+
+    test "handles missing auth params for private messages", %{tenant: tenant} do
+      events_per_second_rate = Tenants.events_per_second_rate(tenant)
+
+      RateCounter
+      |> stub(:new, fn _ -> {:ok, nil} end)
+      |> stub(:get, fn ^events_per_second_rate -> {:ok, %RateCounter{avg: 0}} end)
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+      reject(&Connect.lookup_or_start_connection/1)
+
+      assert :ok = SingleBroadcast.broadcast(nil, tenant, "topic", "event", true, %{"data" => "test"}, :json)
+
+      assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
+    end
+  end
+
+  describe "integration with RLS policies" do
+    setup %{tenant: tenant} do
+      {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+      %{db_conn: db_conn}
+    end
+
+    test "broadcasts private JSON message when RLS policy allows", %{tenant: tenant, db_conn: db_conn} do
+      topic = random_string()
+      sub = random_string()
+      role = "authenticated"
+
+      create_rls_policies(db_conn, [:authenticated_write_broadcast], %{topic: topic})
+
+      auth_params = %{
+        tenant_id: tenant.external_id,
+        topic: topic,
+        headers: [{"header-1", "value-1"}],
+        claims: %{"sub" => sub, "role" => role, "exp" => Joken.current_time() + 1_000},
+        role: role,
+        sub: sub
+      }
+
+      events_per_second_rate = Tenants.events_per_second_rate(tenant)
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+
+      RateCounter
+      |> stub(:new, fn _ -> {:ok, nil} end)
+      |> stub(:get, fn
+        ^events_per_second_rate ->
+          {:ok, %RateCounter{avg: 0}}
+
+        _ ->
+          {:ok,
+           %RateCounter{
+             avg: 0,
+             limit: %{log: true, value: 10, measurement: :sum, triggered: false, log_fn: fn -> :ok end}
+           }}
+      end)
+
+      expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
+      expect(Connect, :lookup_or_start_connection, fn _ -> {:ok, db_conn} end)
+
+      Authorization
+      |> expect(:build_authorization_params, fn params -> params end)
+      |> expect(:get_write_authorizations, fn _, _ ->
+        {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
+      end)
+
+      expect(TenantBroadcaster, :pubsub_broadcast, fn _, _, _, _, _ -> :ok end)
+
+      assert :ok =
+               SingleBroadcast.broadcast(auth_params, tenant, topic, "event", true, %{"secret" => "data"}, :json)
+
+      broadcast_calls = calls(&TenantBroadcaster.pubsub_broadcast/5)
+      assert length(broadcast_calls) == 1
+    end
+  end
+end

--- a/test/realtime_web/controllers/broadcast_single_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_single_controller_test.exs
@@ -1,0 +1,443 @@
+defmodule RealtimeWeb.BroadcastSingleControllerTest do
+  use RealtimeWeb.ConnCase, async: true
+  use Mimic
+
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
+  alias Realtime.Tenants
+
+  alias RealtimeWeb.RealtimeChannel
+  alias RealtimeWeb.Endpoint
+
+  @token "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsInJvbGUiOiJmb28iLCJleHAiOiJiYXIifQ.Ret2CevUozCsPhpgW2FMeFL7RooLgoOvfQzNpLBj5ak"
+  @expired_token "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MjEwNzMyOTAsImlhdCI6MTYyNzg4NjQ0MCwicm9sZSI6ImFub24ifQ.AHmuaydSU3XAxwoIFhd3gwGwjnBIKsjFil0JQEOLtRw"
+
+  setup %{conn: conn} do
+    tenant = Containers.checkout_tenant(run_migrations: true)
+    # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues
+    Realtime.Tenants.Cache.update_cache(tenant)
+
+    conn = generate_conn(conn, tenant)
+
+    {:ok, conn: conn, tenant: tenant}
+  end
+
+  defp subscribe(tenant_topic, topic) do
+    fastlane =
+      RealtimeChannel.MessageDispatcher.fastlane_metadata(
+        self(),
+        Phoenix.Socket.V1.JSONSerializer,
+        topic,
+        :error,
+        "tenant_id"
+      )
+
+    Endpoint.subscribe(tenant_topic, metadata: fastlane)
+  end
+
+  defp subscribe_v2(tenant_topic, topic) do
+    fastlane =
+      RealtimeChannel.MessageDispatcher.fastlane_metadata(
+        self(),
+        RealtimeWeb.Socket.V2Serializer,
+        topic,
+        :error,
+        "tenant_id"
+      )
+
+    Endpoint.subscribe(tenant_topic, metadata: fastlane)
+  end
+
+  defp assert_receive_message do
+    assert_receive {:socket_push, :text, data}
+
+    data
+    |> IO.iodata_to_binary()
+    |> Jason.decode!()
+  end
+
+  describe "JSON broadcast" do
+    test "returns 202 when JSON message is broadcasted", %{conn: conn, tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      GenCounter
+      |> expect(:add, fn ^request_events_key -> :ok end)
+      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+
+      sub_topic = "room:123"
+      event = "message"
+      topic = Tenants.tenant_topic(tenant, sub_topic)
+      payload = %{"text" => "hello", "user" => "alice"}
+
+      subscribe(topic, sub_topic)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), payload)
+
+      assert conn.status == 202
+
+      message = assert_receive_message()
+
+      assert message == %{
+               "event" => "broadcast",
+               "payload" => %{
+                 "payload" => payload,
+                 "event" => event,
+                 "type" => "broadcast"
+               },
+               "ref" => nil,
+               "topic" => sub_topic
+             }
+
+      refute_receive {:socket_push, _, _}
+    end
+
+    test "handles empty JSON payload", %{conn: conn, tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      GenCounter
+      |> expect(:add, fn ^request_events_key -> :ok end)
+      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+
+      sub_topic = "room:456"
+      event = "empty"
+      topic = Tenants.tenant_topic(tenant, sub_topic)
+
+      subscribe(topic, sub_topic)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{})
+
+      assert conn.status == 202
+
+      message = assert_receive_message()
+
+      assert message["payload"]["payload"] == %{}
+    end
+
+    test "handles topics with colons", %{conn: conn, tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      GenCounter
+      |> expect(:add, fn ^request_events_key -> :ok end)
+      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+
+      sub_topic = "room:lobby:main"
+      event = "message"
+      topic = Tenants.tenant_topic(tenant, sub_topic)
+
+      subscribe(topic, sub_topic)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"data" => "test"})
+
+      assert conn.status == 202
+    end
+
+    test "handles private=true query param", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      # Only expect request counter, not broadcast counter (since it will fail authorization silently)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      sub_topic = "private:room"
+      event = "secret"
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event) <> "?private=true", %{
+          "secret" => "data"
+        })
+
+      # Returns 202 even if unauthorized (silently fails)
+      assert conn.status == 202
+    end
+
+    test "handles private=false query param (default)", %{conn: conn, tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      GenCounter
+      |> expect(:add, fn ^request_events_key -> :ok end)
+      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+
+      sub_topic = "public:room"
+      event = "message"
+      topic = Tenants.tenant_topic(tenant, sub_topic)
+
+      subscribe(topic, sub_topic)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event) <> "?private=false", %{
+          "data" => "public"
+        })
+
+      assert conn.status == 202
+    end
+
+    test "returns 422 when JSON payload exceeds size limit", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      sub_topic = "room:large"
+      event = "message"
+      large_payload = %{"data" => String.duplicate("a", tenant.max_payload_size_in_kb * 1024)}
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), large_payload)
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["errors"]["payload"] == ["Payload size exceeds tenant limit"]
+
+      {:ok, rate_counter} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
+      assert rate_counter.avg == 0.0
+    end
+
+    test "returns 401 when JWT is expired", %{conn: conn, tenant: _tenant} do
+      sub_topic = "room:123"
+      event = "message"
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{@expired_token}")
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"data" => "test"})
+
+      assert conn.status == 401
+    end
+
+    test "returns 401 when JWT is missing", %{conn: conn, tenant: _tenant} do
+      sub_topic = "room:123"
+      event = "message"
+
+      conn =
+        conn
+        |> delete_req_header("authorization")
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"data" => "test"})
+
+      assert conn.status == 401
+    end
+  end
+
+  describe "Binary broadcast" do
+    test "returns 202 when binary message is broadcasted", %{conn: conn, tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      GenCounter
+      |> expect(:add, fn ^request_events_key -> :ok end)
+      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+
+      sub_topic = "binary:room"
+      event = "data"
+      topic = Tenants.tenant_topic(tenant, sub_topic)
+      binary_payload = <<1, 2, 3, 4, 5>>
+
+      # Subscribe with V2Serializer to receive binary messages
+      subscribe_v2(topic, sub_topic)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/octet-stream")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), binary_payload)
+
+      assert conn.status == 202
+
+      # Assert binary message received with V2Serializer format
+      assert_receive {:socket_push, :binary, data}
+
+      # Verify V2 binary format:
+      # Header: [type(1), topic_size(1), event_size(1), metadata_size(1), encoding(1)]
+      # Body: [topic, event, metadata?, payload]
+      topic_size = byte_size(sub_topic)
+      event_size = byte_size(event)
+
+      assert data == <<
+        # user broadcast type = 4
+        4::size(8),
+        # sizes
+        topic_size::size(8),
+        event_size::size(8),
+        # metadata_size = 0 (no metadata)
+        0::size(8),
+        # binary encoding = 0
+        0::size(8),
+        # topic and event strings
+        sub_topic::binary,
+        event::binary,
+        # binary payload
+        binary_payload::binary
+      >>
+    end
+
+    test "handles empty binary payload", %{conn: conn, tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      GenCounter
+      |> expect(:add, fn ^request_events_key -> :ok end)
+      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+
+      sub_topic = "binary:empty"
+      event = "empty"
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/octet-stream")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), <<>>)
+
+      assert conn.status == 202
+    end
+
+    test "returns 422 when binary payload exceeds size limit", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      sub_topic = "binary:large"
+      event = "data"
+      large_binary = :crypto.strong_rand_bytes(tenant.max_payload_size_in_kb * 1024 + 1)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/octet-stream")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), large_binary)
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["errors"]["payload"] == ["Payload size exceeds tenant limit"]
+
+      {:ok, rate_counter} = RateCounterHelper.tick!(Tenants.events_per_second_rate(tenant))
+      assert rate_counter.avg == 0.0
+    end
+
+    test "returns 401 when JWT is expired for binary", %{conn: conn, tenant: _tenant} do
+      sub_topic = "binary:room"
+      event = "data"
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{@expired_token}")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), <<1, 2, 3>>)
+
+      assert conn.status == 401
+    end
+  end
+
+  describe "Content-Type handling" do
+    test "returns 415 for unsupported content type", %{conn: conn, tenant: _tenant} do
+      sub_topic = "room:123"
+      event = "message"
+
+      conn =
+        conn
+        |> put_req_header("content-type", "text/plain")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), "plain text")
+
+      assert conn.status == 415
+      assert Jason.decode!(conn.resp_body)["error"] =~ "Unsupported Media Type"
+    end
+
+    test "handles application/json with charset", %{conn: conn, tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      GenCounter
+      |> expect(:add, fn ^request_events_key -> :ok end)
+      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+
+      sub_topic = "room:charset"
+      event = "message"
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json; charset=utf-8")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"data" => "test"})
+
+      assert conn.status == 202
+    end
+  end
+
+  describe "Rate limiting" do
+    test "returns 429 when rate limit is exceeded", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      events_per_second_rate = Tenants.events_per_second_rate(tenant)
+
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      RateCounter
+      |> stub(:new, fn _ -> {:ok, nil} end)
+      |> stub(:get, fn rate ->
+        case rate do
+          ^events_per_second_rate ->
+            {:ok, %RateCounter{avg: tenant.max_events_per_second + 1}}
+
+          _ ->
+            {:ok, %RateCounter{avg: 0}}
+        end
+      end)
+
+      sub_topic = "room:rate-limited"
+      event = "message"
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"data" => "test"})
+
+      assert conn.status == 429
+    end
+  end
+
+  describe "URL parameter extraction" do
+    test "correctly extracts topic and event from URL", %{conn: conn, tenant: tenant} do
+      broadcast_events_key = Tenants.events_per_second_key(tenant)
+      request_events_key = Tenants.requests_per_second_key(tenant)
+
+      GenCounter
+      |> expect(:add, fn ^request_events_key -> :ok end)
+      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+
+      # Test with URL-encoded topic
+      sub_topic = "room:test"
+      event = "my-event"
+      topic = Tenants.tenant_topic(tenant, sub_topic)
+
+      subscribe(topic, sub_topic)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"msg" => "test"})
+
+      assert conn.status == 202
+
+      message = assert_receive_message()
+      assert message["payload"]["event"] == event
+      assert message["topic"] == sub_topic
+    end
+  end
+
+  defp generate_conn(conn, tenant) do
+    conn
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("authorization", "Bearer #{@token}")
+    |> then(&%{&1 | host: "#{tenant.external_id}.supabase.com"})
+  end
+end

--- a/test/realtime_web/controllers/broadcast_single_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_single_controller_test.exs
@@ -52,8 +52,10 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       event = "message"
       topic = Tenants.tenant_topic(tenant, sub_topic)
       payload = %{"text" => "hello", "user" => "alice"}
+      json_payload = Jason.encode!(payload)
 
       subscribe(topic, sub_topic)
+      subscribe(topic, sub_topic, RealtimeWeb.Socket.V2Serializer)
 
       conn =
         conn
@@ -74,6 +76,32 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
                "ref" => nil,
                "topic" => sub_topic
              }
+
+      # Assert binary message received with V2Serializer format
+      assert_receive {:socket_push, :binary, data}
+
+      # Verify V2 binary format:
+      # Header: [type(1), topic_size(1), event_size(1), metadata_size(1), encoding(1)]
+      # Body: [topic, event, metadata?, payload]
+      topic_size = byte_size(sub_topic)
+      event_size = byte_size(event)
+
+      assert IO.iodata_to_binary(data) == <<
+               # user broadcast type = 4
+               4::size(8),
+               # sizes
+               topic_size::size(8),
+               event_size::size(8),
+               # metadata_size = 0 (no metadata)
+               0::size(8),
+               # json encoding = 1
+               1::size(8),
+               # topic and event strings
+               sub_topic::binary,
+               event::binary,
+               # binary payload
+               json_payload::binary
+             >>
 
       refute_receive {:socket_push, _, _}
     end
@@ -277,7 +305,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       topic_size = byte_size(sub_topic)
       event_size = byte_size(event)
 
-      assert data == <<
+      assert IO.iodata_to_binary(data) == <<
                # user broadcast type = 4
                4::size(8),
                # sizes
@@ -496,7 +524,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       assert Jason.decode!(conn.resp_body)["message"] == "Connection pool exhausted"
     end
 
-    test "returns 503 when tenant database is unavailable", %{conn: conn, tenant: tenant} do
+    test "returns 422 when tenant database is unavailable", %{conn: conn, tenant: tenant} do
       request_events_key = Tenants.requests_per_second_key(tenant)
       expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
@@ -507,7 +535,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
         |> put_req_header("content-type", "application/json")
         |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
 
-      assert conn.status == 503
+      assert conn.status == 422
       assert Jason.decode!(conn.resp_body)["message"] == "Tenant database unavailable"
     end
 
@@ -586,7 +614,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       assert Jason.decode!(conn.resp_body)["message"] == "Connect rate limit reached"
     end
 
-    test "returns 503 when an RPC error occurs while looking up the connection", %{conn: conn, tenant: tenant} do
+    test "returns 500 when an RPC error occurs while looking up the connection", %{conn: conn, tenant: tenant} do
       request_events_key = Tenants.requests_per_second_key(tenant)
       expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
@@ -597,7 +625,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
         |> put_req_header("content-type", "application/json")
         |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
 
-      assert conn.status == 503
+      assert conn.status == 500
       assert Jason.decode!(conn.resp_body)["message"] == "RPC error"
     end
   end

--- a/test/realtime_web/controllers/broadcast_single_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_single_controller_test.exs
@@ -2,9 +2,12 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
   use RealtimeWeb.ConnCase, async: true
   use Mimic
 
+  alias Realtime.Crypto
   alias Realtime.GenCounter
   alias Realtime.RateCounter
   alias Realtime.Tenants
+  alias Realtime.Tenants.Authorization
+  alias Realtime.Tenants.Connect
 
   alias RealtimeWeb.RealtimeChannel
   alias RealtimeWeb.Endpoint
@@ -22,28 +25,8 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
     {:ok, conn: conn, tenant: tenant}
   end
 
-  defp subscribe(tenant_topic, topic) do
-    fastlane =
-      RealtimeChannel.MessageDispatcher.fastlane_metadata(
-        self(),
-        Phoenix.Socket.V1.JSONSerializer,
-        topic,
-        :error,
-        "tenant_id"
-      )
-
-    Endpoint.subscribe(tenant_topic, metadata: fastlane)
-  end
-
-  defp subscribe_v2(tenant_topic, topic) do
-    fastlane =
-      RealtimeChannel.MessageDispatcher.fastlane_metadata(
-        self(),
-        RealtimeWeb.Socket.V2Serializer,
-        topic,
-        :error,
-        "tenant_id"
-      )
+  defp subscribe(tenant_topic, topic, serializer \\ Phoenix.Socket.V1.JSONSerializer) do
+    fastlane = RealtimeChannel.MessageDispatcher.fastlane_metadata(self(), serializer, topic, :error, "tenant_id")
 
     Endpoint.subscribe(tenant_topic, metadata: fastlane)
   end
@@ -118,7 +101,18 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
 
       message = assert_receive_message()
 
-      assert message["payload"]["payload"] == %{}
+      assert message == %{
+               "event" => "broadcast",
+               "payload" => %{
+                 "payload" => %{},
+                 "event" => event,
+                 "type" => "broadcast"
+               },
+               "ref" => nil,
+               "topic" => sub_topic
+             }
+
+      refute_receive {:socket_push, _, _}
     end
 
     test "handles topics with colons", %{conn: conn, tenant: tenant} do
@@ -141,12 +135,27 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
         |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"data" => "test"})
 
       assert conn.status == 202
+
+      message = assert_receive_message()
+
+      assert message == %{
+               "event" => "broadcast",
+               "payload" => %{
+                 "payload" => %{"data" => "test"},
+                 "event" => event,
+                 "type" => "broadcast"
+               },
+               "ref" => nil,
+               "topic" => sub_topic
+             }
+
+      refute_receive {:socket_push, _, _}
     end
 
-    test "handles private=true query param", %{conn: conn, tenant: tenant} do
+    test "returns 422 when private=true and the JWT role cannot be set in Postgres", %{conn: conn, tenant: tenant} do
       request_events_key = Tenants.requests_per_second_key(tenant)
 
-      # Only expect request counter, not broadcast counter (since it will fail authorization silently)
+      # Only request counter is bumped; broadcast counter must NOT be incremented because no message is published.
       expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
       sub_topic = "private:room"
@@ -159,8 +168,8 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
           "secret" => "data"
         })
 
-      # Returns 202 even if unauthorized (silently fails)
-      assert conn.status == 202
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["message"] == "RLS policy error"
     end
 
     test "handles private=false query param (default)", %{conn: conn, tenant: tenant} do
@@ -250,7 +259,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       binary_payload = <<1, 2, 3, 4, 5>>
 
       # Subscribe with V2Serializer to receive binary messages
-      subscribe_v2(topic, sub_topic)
+      subscribe(topic, sub_topic, RealtimeWeb.Socket.V2Serializer)
 
       conn =
         conn
@@ -269,21 +278,21 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       event_size = byte_size(event)
 
       assert data == <<
-        # user broadcast type = 4
-        4::size(8),
-        # sizes
-        topic_size::size(8),
-        event_size::size(8),
-        # metadata_size = 0 (no metadata)
-        0::size(8),
-        # binary encoding = 0
-        0::size(8),
-        # topic and event strings
-        sub_topic::binary,
-        event::binary,
-        # binary payload
-        binary_payload::binary
-      >>
+               # user broadcast type = 4
+               4::size(8),
+               # sizes
+               topic_size::size(8),
+               event_size::size(8),
+               # metadata_size = 0 (no metadata)
+               0::size(8),
+               # binary encoding = 0
+               0::size(8),
+               # topic and event strings
+               sub_topic::binary,
+               event::binary,
+               # binary payload
+               binary_payload::binary
+             >>
     end
 
     test "handles empty binary payload", %{conn: conn, tenant: tenant} do
@@ -405,32 +414,191 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
     end
   end
 
-  describe "URL parameter extraction" do
-    test "correctly extracts topic and event from URL", %{conn: conn, tenant: tenant} do
-      broadcast_events_key = Tenants.events_per_second_key(tenant)
+  describe "Private broadcast authorization" do
+    setup %{conn: conn, tenant: tenant} do
+      jwt_secret = Crypto.decrypt!(tenant.jwt_secret)
+      claims = %{sub: "test-user", role: "anon", exp: Joken.current_time() + 1_000}
+      signer = Joken.Signer.create("HS256", jwt_secret)
+      jwt = Joken.generate_and_sign!(%{}, claims, signer)
+
+      conn =
+        conn
+        |> delete_req_header("authorization")
+        |> put_req_header("authorization", "Bearer #{jwt}")
+
+      {:ok, conn: conn}
+    end
+
+    test "returns 403 when anon caller has no RLS write policy", %{conn: conn, tenant: tenant} do
       request_events_key = Tenants.requests_per_second_key(tenant)
 
-      GenCounter
-      |> expect(:add, fn ^request_events_key -> :ok end)
-      |> expect(:add, fn ^broadcast_events_key -> :ok end)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
-      # Test with URL-encoded topic
-      sub_topic = "room:test"
-      event = "my-event"
-      topic = Tenants.tenant_topic(tenant, sub_topic)
-
-      subscribe(topic, sub_topic)
+      sub_topic = "private:room"
+      event = "secret"
 
       conn =
         conn
         |> put_req_header("content-type", "application/json")
-        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"msg" => "test"})
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event) <> "?private=true", %{
+          "secret" => "data"
+        })
 
-      assert conn.status == 202
+      assert conn.status == 403
+      assert Jason.decode!(conn.resp_body)["message"] == "Unauthorized"
+    end
 
-      message = assert_receive_message()
-      assert message["payload"]["event"] == event
-      assert message["topic"] == sub_topic
+    test "returns 422 when authorization query is canceled", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Authorization, :get_write_authorizations, fn _, _ ->
+        {:error, :query_canceled,
+         %Postgrex.Error{postgres: %{code: :query_canceled, message: "canceling statement due to user request"}}}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["message"] == "Query canceled"
+    end
+
+    test "returns 422 when messages partition is missing", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Authorization, :get_write_authorizations, fn _, _ -> {:error, :missing_partition} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["message"] == "Missing messages partition"
+    end
+
+    test "returns 429 when authorization signals connection pool exhaustion", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Authorization, :get_write_authorizations, fn _, _ -> {:error, :increase_connection_pool} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 429
+      assert Jason.decode!(conn.resp_body)["message"] == "Connection pool exhausted"
+    end
+
+    test "returns 503 when tenant database is unavailable", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Authorization, :get_write_authorizations, fn _, _ -> {:error, :tenant_database_unavailable} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 503
+      assert Jason.decode!(conn.resp_body)["message"] == "Tenant database unavailable"
+    end
+
+    test "returns 500 for unexpected authorization errors", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Authorization, :get_write_authorizations, fn _, _ -> {:error, "boom"} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 500
+      assert Jason.decode!(conn.resp_body)["message"] == "Unable to authorize broadcast"
+    end
+
+    test "returns 422 when tenant database is initializing", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Connect, :lookup_or_start_connection, fn _ -> {:error, :initializing} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["message"] == "Tenant database initializing"
+    end
+
+    test "returns 422 when tenant database connection is initializing", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Connect, :lookup_or_start_connection, fn _ -> {:error, :tenant_database_connection_initializing} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["message"] == "Tenant database connection initializing"
+    end
+
+    test "returns 422 when tenant database has too many connections", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Connect, :lookup_or_start_connection, fn _ -> {:error, :tenant_db_too_many_connections} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["message"] == "Tenant database has too many connections"
+    end
+
+    test "returns 422 when connect rate limit is reached", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Connect, :lookup_or_start_connection, fn _ -> {:error, :connect_rate_limit_reached} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["message"] == "Connect rate limit reached"
+    end
+
+    test "returns 503 when an RPC error occurs while looking up the connection", %{conn: conn, tenant: tenant} do
+      request_events_key = Tenants.requests_per_second_key(tenant)
+      expect(GenCounter, :add, fn ^request_events_key -> :ok end)
+
+      expect(Connect, :lookup_or_start_connection, fn _ -> {:error, :rpc_error, :timeout} end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, "private:room", "evt") <> "?private=true", %{"a" => 1})
+
+      assert conn.status == 503
+      assert Jason.decode!(conn.resp_body)["message"] == "RPC error"
     end
   end
 

--- a/test/realtime_web/controllers/broadcast_single_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_single_controller_test.exs
@@ -77,7 +77,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
                "topic" => sub_topic
              }
 
-      # Assert binary message received with V2Serializer format
+      # Assert WebSocket binary message received with V2Serializer format
       assert_receive {:socket_push, :binary, data}
 
       # Verify V2 binary format:

--- a/test/realtime_web/plugs/parsers/octet_stream_test.exs
+++ b/test/realtime_web/plugs/parsers/octet_stream_test.exs
@@ -1,0 +1,125 @@
+defmodule RealtimeWeb.Plugs.Parsers.OctetStreamTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+  import Plug.Conn
+
+  alias RealtimeWeb.Plugs.Parsers.OctetStream
+
+  defmodule TimeoutReader do
+    def read_body(_conn, _opts), do: {:error, :timeout}
+  end
+
+  defmodule ErrorReader do
+    def read_body(_conn, _opts), do: {:error, :closed}
+  end
+
+  describe "init/1" do
+    test "defaults the body reader to Plug.Conn.read_body/2" do
+      assert {{Plug.Conn, :read_body, []}, opts} = OctetStream.init([])
+      assert opts == []
+    end
+
+    test "passes other opts through untouched" do
+      assert {{Plug.Conn, :read_body, []}, opts} = OctetStream.init(length: 42)
+      assert Keyword.get(opts, :length) == 42
+    end
+
+    test "pops :body_reader out of opts" do
+      reader = {TimeoutReader, :read_body, []}
+      assert {^reader, opts} = OctetStream.init(body_reader: reader, length: 10)
+      refute Keyword.has_key?(opts, :body_reader)
+      assert Keyword.get(opts, :length) == 10
+    end
+  end
+
+  describe "parse/5" do
+    test "returns {:next, conn} for non-octet-stream content types" do
+      conn = conn(:post, "/", "anything")
+      opts = OctetStream.init([])
+
+      assert {:next, ^conn} = OctetStream.parse(conn, "application", "json", %{}, opts)
+      assert {:next, ^conn} = OctetStream.parse(conn, "text", "plain", %{}, opts)
+      assert {:next, ^conn} = OctetStream.parse(conn, "application", "x-www-form-urlencoded", %{}, opts)
+    end
+
+    test "parses application/octet-stream body into %{\"_binary\" => body}" do
+      body = <<1, 2, 3, 4, 5>>
+
+      conn =
+        conn(:post, "/", body)
+        |> put_req_header("content-type", "application/octet-stream")
+
+      opts = OctetStream.init([])
+
+      assert {:ok, %{"_binary" => ^body}, %Plug.Conn{}} =
+               OctetStream.parse(conn, "application", "octet-stream", %{}, opts)
+    end
+
+    test "handles empty binary body" do
+      conn =
+        conn(:post, "/", <<>>)
+        |> put_req_header("content-type", "application/octet-stream")
+
+      opts = OctetStream.init([])
+
+      assert {:ok, %{"_binary" => <<>>}, %Plug.Conn{}} =
+               OctetStream.parse(conn, "application", "octet-stream", %{}, opts)
+    end
+
+    test "returns {:error, :too_large, conn} when body exceeds :length" do
+      body = :crypto.strong_rand_bytes(2_000)
+
+      conn =
+        conn(:post, "/", body)
+        |> put_req_header("content-type", "application/octet-stream")
+
+      opts = OctetStream.init(length: 100, read_length: 100)
+
+      assert {:error, :too_large, %Plug.Conn{}} =
+               OctetStream.parse(conn, "application", "octet-stream", %{}, opts)
+    end
+
+    test "raises Plug.TimeoutError when body reader returns {:error, :timeout}" do
+      conn =
+        conn(:post, "/", <<1, 2, 3>>)
+        |> put_req_header("content-type", "application/octet-stream")
+
+      opts = OctetStream.init(body_reader: {TimeoutReader, :read_body, []})
+
+      assert_raise Plug.TimeoutError, fn ->
+        OctetStream.parse(conn, "application", "octet-stream", %{}, opts)
+      end
+    end
+
+    test "raises Plug.BadRequestError for other read_body errors" do
+      conn =
+        conn(:post, "/", <<1, 2, 3>>)
+        |> put_req_header("content-type", "application/octet-stream")
+
+      opts = OctetStream.init(body_reader: {ErrorReader, :read_body, []})
+
+      assert_raise Plug.BadRequestError, fn ->
+        OctetStream.parse(conn, "application", "octet-stream", %{}, opts)
+      end
+    end
+
+    test "ignores content-type parameters" do
+      body = <<10, 20, 30>>
+
+      conn =
+        conn(:post, "/", body)
+        |> put_req_header("content-type", "application/octet-stream; charset=binary")
+
+      opts = OctetStream.init([])
+
+      assert {:ok, %{"_binary" => ^body}, %Plug.Conn{}} =
+               OctetStream.parse(
+                 conn,
+                 "application",
+                 "octet-stream",
+                 %{"charset" => "binary"},
+                 opts
+               )
+    end
+  end
+end

--- a/test/realtime_web/plugs/validate_broadcast_content_type_test.exs
+++ b/test/realtime_web/plugs/validate_broadcast_content_type_test.exs
@@ -1,0 +1,97 @@
+defmodule RealtimeWeb.Plugs.ValidateBroadcastContentTypeTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+  import Plug.Conn
+
+  alias RealtimeWeb.Plugs.ValidateBroadcastContentType
+
+  defp call(conn) do
+    ValidateBroadcastContentType.call(conn, ValidateBroadcastContentType.init([]))
+  end
+
+  describe "allowed content types" do
+    test "passes application/json through unchanged" do
+      conn =
+        conn(:post, "/", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> call()
+
+      refute conn.halted
+      assert is_nil(conn.status)
+    end
+
+    test "passes application/json with charset through" do
+      conn =
+        conn(:post, "/", "{}")
+        |> put_req_header("content-type", "application/json; charset=utf-8")
+        |> call()
+
+      refute conn.halted
+      assert is_nil(conn.status)
+    end
+
+    test "passes application/octet-stream through" do
+      conn =
+        conn(:post, "/", <<1, 2, 3>>)
+        |> put_req_header("content-type", "application/octet-stream")
+        |> call()
+
+      refute conn.halted
+      assert is_nil(conn.status)
+    end
+
+    test "passes through when content-type header is missing" do
+      conn =
+        conn(:post, "/", "")
+        |> call()
+
+      refute conn.halted
+      assert is_nil(conn.status)
+    end
+  end
+
+  describe "rejected content types" do
+    test "returns 415 for text/plain" do
+      conn =
+        conn(:post, "/", "plain text")
+        |> put_req_header("content-type", "text/plain")
+        |> call()
+
+      assert conn.halted
+      assert conn.status == 415
+      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      assert Jason.decode!(conn.resp_body)["error"] =~ "Unsupported Media Type"
+
+      assert Jason.decode!(conn.resp_body)["error"] ==
+               "Unsupported Media Type. Use application/json or application/octet-stream"
+    end
+
+    test "returns 415 for application/xml" do
+      conn =
+        conn(:post, "/", "<x/>")
+        |> put_req_header("content-type", "application/xml")
+        |> call()
+
+      assert conn.halted
+      assert conn.status == 415
+      assert Jason.decode!(conn.resp_body)["error"] =~ "Unsupported Media Type"
+    end
+
+    test "returns 415 for multipart/form-data" do
+      conn =
+        conn(:post, "/", "")
+        |> put_req_header("content-type", "multipart/form-data; boundary=abc")
+        |> call()
+
+      assert conn.halted
+      assert conn.status == 415
+    end
+  end
+
+  describe "init/1" do
+    test "returns its input unchanged" do
+      assert ValidateBroadcastContentType.init([]) == []
+      assert ValidateBroadcastContentType.init(foo: :bar) == [foo: :bar]
+    end
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduce a new endpoint: `POST /api/broadcast/:topic/events/:event_name` where the content-type defines the type of payload (`application/json` vs `application/octet-stream`)

if the channel is private a query string can be passed `?private=true`