### PR TITLE
fix: avoid using BatchBroadcast from ReplicationConnection

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -491,7 +491,7 @@ defmodule Realtime.Tenants do
 
   @doc """
   """
-  @spec validate_payload_size(Tenant.t() | binary(), map()) :: :ok | {:error, :payload_size_exceeded}
+  @spec validate_payload_size(Tenant.t() | binary(), map() | binary()) :: :ok | {:error, :payload_size_exceeded}
   def validate_payload_size(tenant_id, payload) when is_binary(tenant_id) do
     tenant_id
     |> Cache.get_tenant_by_external_id()

--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -27,9 +27,13 @@ defmodule Realtime.Tenants.ReplicationConnection do
   alias Realtime.Adapters.Postgres.Protocol.Write
   alias Realtime.Api.Tenant
   alias Realtime.Database
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
   alias Realtime.Telemetry
-  alias Realtime.Tenants.BatchBroadcast
+  alias Realtime.Tenants
   alias Realtime.Tenants.Cache
+  alias RealtimeWeb.RealtimeChannel
+  alias RealtimeWeb.TenantBroadcaster
 
   @default_query_timeout 30_000
 
@@ -373,14 +377,32 @@ defmodule Realtime.Tenants.ReplicationConnection do
          {:ok, topic} <- get_or_error(to_broadcast, "topic", :topic_missing),
          {:ok, private} <- get_or_error(to_broadcast, "private", :private_missing),
          %Tenant{} = tenant <- Cache.get_tenant_by_external_id(tenant_id),
-         broadcast_message = %{
-           id: id,
-           topic: topic,
-           event: event,
-           private: private,
-           payload: Jason.Fragment.new(payload)
-         },
-         :ok <- BatchBroadcast.broadcast(nil, tenant, %{messages: [broadcast_message]}, true) do
+         :ok <- Tenants.validate_payload_size(tenant, payload),
+         events_per_second_rate = Tenants.events_per_second_rate(tenant),
+         :ok <- check_rate_limit(events_per_second_rate) do
+      tenant_topic = Tenants.tenant_topic(tenant, topic, not private)
+
+      broadcast = %Phoenix.Socket.Broadcast{
+        topic: topic,
+        event: "broadcast",
+        payload: %{
+          "payload" => Jason.Fragment.new(payload),
+          "event" => event,
+          "type" => "broadcast",
+          "meta" => %{"id" => id}
+        }
+      }
+
+      GenCounter.add(events_per_second_rate.id)
+
+      TenantBroadcaster.pubsub_broadcast(
+        tenant.external_id,
+        tenant_topic,
+        broadcast,
+        RealtimeChannel.MessageDispatcher,
+        :broadcast
+      )
+
       latency_inserted_at = NaiveDateTime.utc_now(:microsecond) |> NaiveDateTime.diff(inserted_at, :microsecond)
 
       Telemetry.execute(
@@ -391,11 +413,6 @@ defmodule Realtime.Tenants.ReplicationConnection do
 
       {:noreply, state}
     else
-      {:error, %Ecto.Changeset{valid?: false} = changeset} ->
-        error = Ecto.Changeset.traverse_errors(changeset, &elem(&1, 0))
-        log_error("UnableToBroadcastChanges", error)
-        {:noreply, state}
-
       {:error, error} ->
         log_error("UnableToBroadcastChanges", error)
         {:noreply, state}
@@ -443,6 +460,13 @@ defmodule Realtime.Tenants.ReplicationConnection do
       {value, %{name: name, type: "bool"}} -> {name, value}
       {value, %{name: name}} -> {name, value}
     end)
+  end
+
+  defp check_rate_limit(events_per_second_rate) do
+    case RateCounter.get(events_per_second_rate) do
+      {:ok, %{limit: %{triggered: true}}} -> {:error, :too_many_requests}
+      _ -> :ok
+    end
   end
 
   defp get_or_error(map, key, error_type) do

--- a/test/realtime/tenants/replication_connection_test.exs
+++ b/test/realtime/tenants/replication_connection_test.exs
@@ -6,6 +6,8 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
 
   alias Realtime.Api.Message
   alias Realtime.Database
+  alias Realtime.GenCounter
+  alias Realtime.RateCounter
   alias Realtime.Tenants
   alias Realtime.Tenants.ReplicationConnection
   alias RealtimeWeb.Endpoint
@@ -422,7 +424,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
       assert logs =~ "UnableToBroadcastChanges"
     end
 
-    test "message that exceeds payload size logs error", %{tenant: tenant} do
+    test "message that exceeds payload size is not broadcast and logs error", %{tenant: tenant} do
       logs =
         capture_log(fn ->
           start_supervised!(
@@ -436,7 +438,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
 
           message_fixture(tenant, %{
             "event" => random_string(),
-            "topic" => random_string(),
+            "topic" => topic,
             "private" => true,
             "payload" => %{"data" => random_string(tenant.max_payload_size_in_kb * 1000 + 1)}
           })
@@ -444,7 +446,41 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
           refute_receive %Phoenix.Socket.Broadcast{}, 500
         end)
 
-      assert logs =~ "UnableToBroadcastChanges: %{messages: [%{payload: [\"Payload size exceeds tenant limit\"]}]}"
+      assert logs =~ "UnableToBroadcastChanges: :payload_size_exceeded"
+    end
+
+    test "message is not broadcast and logs error when rate limit is exceeded", %{tenant: tenant} do
+      events_per_second_rate = Tenants.events_per_second_rate(tenant)
+
+      # Start with a clean rate counter and push it well above the limit so the
+      # avg stays over the threshold for the full duration of the test.
+      RateCounterHelper.stop(tenant.external_id)
+      {:ok, _} = RateCounter.new(events_per_second_rate)
+      GenCounter.add(events_per_second_rate.id, tenant.max_events_per_second * 60 + 1)
+      {:ok, %{limit: %{triggered: true}}} = RateCounterHelper.tick!(events_per_second_rate)
+
+      logs =
+        capture_log(fn ->
+          start_supervised!(
+            {ReplicationConnection, %ReplicationConnection{tenant_id: tenant.external_id, monitored_pid: self()}},
+            restart: :transient
+          )
+
+          topic = random_string()
+          tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
+          assert :ok = Endpoint.subscribe(tenant_topic)
+
+          message_fixture(tenant, %{
+            "event" => "INSERT",
+            "topic" => topic,
+            "private" => true,
+            "payload" => %{"value" => random_string()}
+          })
+
+          refute_receive %Phoenix.Socket.Broadcast{}, 500
+        end)
+
+      assert logs =~ "UnableToBroadcastChanges: :too_many_requests"
     end
 
     test "payload without id", %{tenant: tenant, db_conn: db_conn} do


### PR DESCRIPTION
## What kind of change does this PR introduce?

This way we have a more straightforward approach to then add support to binary payloads without changing `BatchBroadcast`
