### PR TITLE
feat: tag tenant migration duration metric with origin platform_region

### DIFF
--- a/lib/realtime/monitoring/prom_ex/plugins/migrations.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/migrations.ex
@@ -21,6 +21,7 @@ defmodule Realtime.PromEx.Plugins.Migrations do
         unit: {:native, :millisecond},
         description: "Tenant migrations duration",
         keep: &__MODULE__.migrations_executed/1,
+        tags: [:platform_region],
         reporter_options: [peep_bucket_calculator: Buckets]
       ),
       counter(

--- a/lib/realtime/nodes.ex
+++ b/lib/realtime/nodes.ex
@@ -65,7 +65,6 @@ defmodule Realtime.Nodes do
   Lists the nodes in a region. Sorts by node name in case the list order
   is unstable.
   """
-
   @spec region_nodes(String.t() | nil) :: [atom()]
   def region_nodes(region) when is_binary(region) do
     :syn.members(RegionNodes, region)

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -227,6 +227,8 @@ defmodule Realtime.Tenants.Migrations do
   end
 
   defp migrate(tenant_external_id, settings) do
+    platform_region = Map.get(settings, "region")
+
     with {:ok, settings} <- Database.from_settings(settings, "realtime_migrations", :stop) do
       [
         hostname: settings.hostname,
@@ -242,7 +244,7 @@ defmodule Realtime.Tenants.Migrations do
       ]
       |> Repo.with_dynamic_repo(fn repo ->
         event = [:realtime, :tenants, :migrations]
-        metadata = %{external_id: tenant_external_id, hostname: settings.hostname}
+        metadata = %{external_id: tenant_external_id, hostname: settings.hostname, platform_region: platform_region}
         start_time = Telemetry.start(event, metadata)
 
         try do

--- a/test/realtime/monitoring/prom_ex/plugins/migrations_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/migrations_test.exs
@@ -23,30 +23,46 @@ defmodule Realtime.PromEx.Plugins.MigrationsTest do
   end
 
   test "records migration duration histogram on stop" do
-    start_time = Telemetry.start([:realtime, :tenants, :migrations], %{external_id: "tenant", hostname: "localhost"})
+    start_time =
+      Telemetry.start([:realtime, :tenants, :migrations], %{
+        external_id: "tenant",
+        hostname: "localhost",
+        platform_region: "sa-east-1"
+      })
 
     Telemetry.stop(
       [:realtime, :tenants, :migrations],
       start_time,
-      %{external_id: "tenant", hostname: "localhost", migrations_executed: 3}
+      %{external_id: "tenant", hostname: "localhost", platform_region: "sa-east-1", migrations_executed: 3}
     )
 
-    assert metric_value("realtime_tenants_migrations_duration_milliseconds_count") == 1
-    assert metric_value("realtime_tenants_migrations_duration_milliseconds_bucket", le: "100.0") > 0
+    assert metric_value("realtime_tenants_migrations_duration_milliseconds_count", platform_region: "sa-east-1") == 1
+
+    assert metric_value("realtime_tenants_migrations_duration_milliseconds_bucket",
+             platform_region: "sa-east-1",
+             le: "100.0"
+           ) > 0
   end
 
   test "skips duration histogram when migrations_executed is 0" do
-    before = metric_value("realtime_tenants_migrations_duration_milliseconds_count")
+    before =
+      metric_value("realtime_tenants_migrations_duration_milliseconds_count", platform_region: "sa-east-1") || 0
 
-    start_time = Telemetry.start([:realtime, :tenants, :migrations], %{external_id: "tenant", hostname: "localhost"})
+    start_time =
+      Telemetry.start([:realtime, :tenants, :migrations], %{
+        external_id: "tenant",
+        hostname: "localhost",
+        platform_region: "sa-east-1"
+      })
 
     Telemetry.stop(
       [:realtime, :tenants, :migrations],
       start_time,
-      %{external_id: "tenant", hostname: "localhost", migrations_executed: 0}
+      %{external_id: "tenant", hostname: "localhost", platform_region: "sa-east-1", migrations_executed: 0}
     )
 
-    assert metric_value("realtime_tenants_migrations_duration_milliseconds_count") == before
+    assert (metric_value("realtime_tenants_migrations_duration_milliseconds_count", platform_region: "sa-east-1") || 0) ==
+             before
   end
 
   test "tags Postgrex errors with the SQLSTATE atom" do


### PR DESCRIPTION
Adds a `platform_region` label to migration duration metrics exposing the tenant origin before [translation](https://github.com/supabase/realtime/pull/1680).

Combined with `region` we can correlate region x platform_region to find slow `REGION_MAPPING` combination.

First part of REAL-813