### PR TITLE
chore(ci): use blacksmith arm runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,4 +3,4 @@ self-hosted-runner:
     - blacksmith-2vcpu-ubuntu-2404
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-8vcpu-ubuntu-2404
-    - arm-runner
+    - blacksmith-4vcpu-ubuntu-2404-arm

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   docker_x86_build:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,15 +6,36 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  docker_x86_build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 120
+    env:
+      arch: amd64
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1.4.0
 
-      - name: Build Docker image
-        run: docker build .
+      - uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        with:
+          context: .
+          push: false
+          platforms: linux/${{ env.arch }}
+
+  docker_arm_build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    timeout-minutes: 120
+    env:
+      arch: arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1.4.0
+
+      - uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        with:
+          context: .
+          push: false
+          platforms: linux/${{ env.arch }}

--- a/.github/workflows/manual_prod_build.yml
+++ b/.github/workflows/manual_prod_build.yml
@@ -17,6 +17,8 @@ jobs:
     outputs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
@@ -41,7 +43,7 @@ jobs:
           platforms: linux/${{ env.arch }}
 
   docker_arm_release:
-    runs-on: arm-runner
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 120
     env:
       arch: arm64
@@ -73,7 +75,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/${{ env.arch }}
-          no-cache: true
 
   merge_manifest:
     needs: [docker_x86_release, docker_arm_release]

--- a/.github/workflows/prod_build.yml
+++ b/.github/workflows/prod_build.yml
@@ -84,7 +84,7 @@ jobs:
 
   docker_arm_release:
     needs: release
-    runs-on: arm-runner
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     if: needs.release.outputs.published == 'true'
     timeout-minutes: 120
     env:
@@ -120,7 +120,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/${{ env.arch }}
-          no-cache: true
 
   merge_manifest:
     needs: [release, docker_x86_release, docker_arm_release]


### PR DESCRIPTION
The job `docker_arm_release` should be using blacksmith but config seems incomplete and it's taking ~7m to finish due to `Warning: Failed to setup Blacksmith builder, using local builder`.

Also changed `.github/workflows/docker-build.yml` to test all archs to avoid false positives.