### PR TITLE
fix(dashboard): tenant migrations on ipv6 hosts

### DIFF
--- a/lib/realtime_web/dashboard/tenant_migrations.ex
+++ b/lib/realtime_web/dashboard/tenant_migrations.ex
@@ -277,8 +277,10 @@ defmodule RealtimeWeb.Dashboard.TenantMigrations do
   defp format_ts(%DateTime{} = t), do: DateTime.to_string(t)
   defp format_ts(other), do: to_string(other)
 
-  defp postgres_url(%Database{} = db) do
+  @doc false
+  def postgres_url(%Database{} = db) do
     sslmode = if db.ssl, do: "require", else: "disable"
+    host = if :inet6 in db.socket_options, do: "[#{db.hostname}]", else: db.hostname
 
     IO.iodata_to_binary([
       "postgresql://",
@@ -286,11 +288,11 @@ defmodule RealtimeWeb.Dashboard.TenantMigrations do
       ":",
       URI.encode_www_form(db.password),
       "@",
-      db.hostname,
+      host,
       ":",
       Integer.to_string(db.port),
       "/",
-      db.database,
+      URI.encode_www_form(db.database),
       "?sslmode=",
       sslmode
     ])

--- a/test/realtime_web/dashboard/tenant_migrations_test.exs
+++ b/test/realtime_web/dashboard/tenant_migrations_test.exs
@@ -2,6 +2,9 @@ defmodule RealtimeWeb.Dashboard.TenantMigrationsTest do
   use RealtimeWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
+  alias Realtime.Database
+  alias RealtimeWeb.Dashboard.TenantMigrations
+
   setup do
     Application.put_env(:realtime, :dashboard_auth, :basic_auth)
     Application.put_env(:realtime, :dashboard_credentials, {"user", "pass"})
@@ -64,6 +67,52 @@ defmodule RealtimeWeb.Dashboard.TenantMigrationsTest do
     {:ok, view, _html} = live(conn, "/admin/dashboard/tenant_migrations?external_id=#{tenant.external_id}")
 
     assert has_element?(view, "h6", "pg-delta plan vs baseline")
+  end
+
+  describe "postgres_url/1" do
+    test "builds a valid URL for IPv4 hosts" do
+      url =
+        TenantMigrations.postgres_url(%Database{
+          hostname: "db.example.com",
+          port: 5432,
+          database: "postgres",
+          username: "supabase_admin",
+          password: "s3cr3t",
+          socket_options: [:inet],
+          ssl: true
+        })
+
+      assert %URI{
+               scheme: "postgresql",
+               host: "db.example.com",
+               port: 5432,
+               path: "/postgres",
+               userinfo: "supabase_admin:s3cr3t",
+               query: "sslmode=require"
+             } = URI.parse(url)
+    end
+
+    test "builds a valid URL for IPv6 hosts" do
+      url =
+        TenantMigrations.postgres_url(%Database{
+          hostname: "2600:1f14:359d:9302:205d:38ca:a017:c7e3",
+          port: 5432,
+          database: "postgres",
+          username: "supabase_admin",
+          password: "s3cr3t",
+          socket_options: [:inet6],
+          ssl: true
+        })
+
+      assert url =~ "@[2600:1f14:359d:9302:205d:38ca:a017:c7e3]:5432/"
+
+      assert %URI{
+               scheme: "postgresql",
+               host: "2600:1f14:359d:9302:205d:38ca:a017:c7e3",
+               port: 5432,
+               path: "/postgres"
+             } = URI.parse(url)
+    end
   end
 
   defp using_basic_auth(conn, username, password) do


### PR DESCRIPTION
Fix the following `pg-delta` connection error on ipv6 hosts:

```
pg-delta exited 1:
Command failed, TypeError: <redacted> cannot be parsed as a URL.
```
