### PR TITLE
fix(dashboard): preserve rls policies on tenant migrations fix plan

### DIFF
--- a/lib/realtime_web/dashboard/tenant_migrations.ex
+++ b/lib/realtime_web/dashboard/tenant_migrations.ex
@@ -13,7 +13,15 @@ defmodule RealtimeWeb.Dashboard.TenantMigrations do
   alias Realtime.Api.Tenant
   alias Realtime.Database
 
-  @pg_delta_filter ~s({"and": [{"*/schema": "realtime"}, {"not": {"table/is_partition": true}}]})
+  @pg_delta_filter ~s"""
+  {
+    "and": [
+      {"*/schema": "realtime"},
+      {"not": {"table/is_partition": true}},
+      {"not": {"and": [{"objectType": "rls_policy"}, {"operation": "drop"}]}}
+    ]
+  }
+  """
   @application_name "realtime_dashboard_tenant_migrations"
   @query_timeout 30_000
   @schema_migrations_query "SELECT version, inserted_at FROM realtime.schema_migrations ORDER BY version DESC"


### PR DESCRIPTION
Add a filter in pgdelta to preserve RLS policies in the realtime schema.

This is important to let Tenant Migrations fix schemas without dropping existing RLS.

For eg a schema with missing `messages_inserted_at_topic_index` and existing RLS policies in `realtime.messages` without pgdelta filter does create a plan like:

```sql
-- Risk: safe
DROP POLICY "authenticated broadcast on topic" ON realtime.messages;

DROP POLICY "authenticated receive on topic" ON realtime.messages;

CREATE INDEX messages_inserted_at_topic_index ON realtime.messages
(inserted_at DESC, topic) WHERE extension = 'broadcast'::text AND
private IS TRUE;
```

With the new filter only the `CREATE INDEX` in included in the plan.