### PR TITLE
fix: channels closing when jwt claims contain decimal number

### DIFF
--- a/lib/realtime_web/channels/auth/jwt_verification.ex
+++ b/lib/realtime_web/channels/auth/jwt_verification.ex
@@ -40,8 +40,12 @@ defmodule RealtimeWeb.JwtVerification do
   def verify(token, jwt_secret, jwt_jwks) when is_binary(token) do
     with {:ok, _claims} <- check_claims_format(token),
          {:ok, header} <- check_header_format(token),
-         {:ok, signer} <- generate_signer(header, jwt_secret, jwt_jwks) do
-      JwtAuthToken.verify_and_validate(token, signer)
+         {:ok, signer} <- generate_signer(header, jwt_secret, jwt_jwks),
+         {:ok, claims} <- JwtAuthToken.verify_and_validate(token, signer) do
+      # JWT spec allows exp and iat to be a decimal number. This is uncommon
+      # though, so most implementation round them to integer to avoid unexpected
+      # type errors. So, we round it before returning.
+      {:ok, round_decimal_numbers(claims)}
     else
       {:error, _e} = error -> error
     end
@@ -61,6 +65,19 @@ defmodule RealtimeWeb.JwtVerification do
     case Joken.peek_header(token) do
       {:ok, header} when is_map(header) -> {:ok, header}
       _error -> {:error, :expected_header_map}
+    end
+  end
+
+  defp round_decimal_numbers(claims) do
+    claims
+    |> round_claim("exp")
+    |> round_claim("iat")
+  end
+
+  defp round_claim(claims, key) do
+    case Map.get(claims, key) do
+      value when is_number(value) -> Map.put(claims, key, round(value))
+      _ -> claims
     end
   end
 

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -1143,6 +1143,21 @@ defmodule RealtimeWeb.RealtimeChannelTest do
   end
 
   describe "access_token validations" do
+    test "access_token has exp and iat in decimal format", %{tenant: tenant} do
+      api_key = Generators.generate_jwt_token(tenant)
+
+      jwt =
+        Generators.generate_jwt_token(tenant, %{
+          role: "authenticated",
+          exp: System.system_time(:second) + 100.99,
+          iat: System.system_time(:second) - 100.99
+        })
+
+      assert {:ok, socket} = connect(UserSocket, %{}, conn_opts(tenant, api_key))
+
+      assert {:ok, _, _} = subscribe_and_join(socket, "realtime:test", %{"access_token" => jwt})
+    end
+
     test "access_token has expired", %{tenant: tenant} do
       api_key = Generators.generate_jwt_token(tenant)
       jwt = Generators.generate_jwt_token(tenant, %{role: "authenticated", exp: System.system_time(:second) - 1})


### PR DESCRIPTION
When `exp` and `iat` claims contain decimal number, channels close. This commit fixes that by rounding the numbers to integer.

Closes #1315.