### PR TITLE
chore: test pg14

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -38,12 +38,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [pg14, pg17]
+        postgres: [pg14, pg15, pg17]
         include:
           - postgres: pg14
             postgres_image: supabase/postgres:14.1.0.85
+          - postgres: pg15
+            postgres_image: supabase/postgres:15.14.1.127
           - postgres: pg17
-            postgres_image: supabase/postgres:17.6.1.074
+            postgres_image: supabase/postgres:17.6.1.127
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -38,10 +38,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [pg15, pg17]
+        postgres: [pg14, pg17]
         include:
-          - postgres: pg15
-            postgres_image: supabase/postgres:15.14.1.122
+          - postgres: pg14
+            postgres_image: supabase/postgres:14.1.0.85
           - postgres: pg17
             postgres_image: supabase/postgres:17.6.1.074
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,12 +39,14 @@ jobs:
       fail-fast: false
       matrix:
         partition: [1, 2, 3, 4]
-        postgres: [pg14, pg17]
+        postgres: [pg14, pg15, pg17]
         include:
           - postgres: pg14
             postgres_image: supabase/postgres:14.1.0.85
+          - postgres: pg15
+            postgres_image: supabase/postgres:15.14.1.127
           - postgres: pg17
-            postgres_image: supabase/postgres:17.6.1.074
+            postgres_image: supabase/postgres:17.6.1.127
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,10 +39,10 @@ jobs:
       fail-fast: false
       matrix:
         partition: [1, 2, 3, 4]
-        postgres: [pg15, pg17]
+        postgres: [pg14, pg17]
         include:
-          - postgres: pg15
-            postgres_image: supabase/postgres:15.14.1.122
+          - postgres: pg14
+            postgres_image: supabase/postgres:14.1.0.85
           - postgres: pg17
             postgres_image: supabase/postgres:17.6.1.074
 

--- a/.github/workflows/update-tenant-db-baseline.yml
+++ b/.github/workflows/update-tenant-db-baseline.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  POSTGRES_IMAGE: supabase/postgres:17.6.1.074
+  POSTGRES_IMAGE: supabase/postgres:17.6.1.127
 
 jobs:
   update-tenant-db-baseline:

--- a/.github/workflows/update-tenant-db-baseline.yml
+++ b/.github/workflows/update-tenant-db-baseline.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   update-tenant-db-baseline:
-    name: Regenerate baseline and commit to PR if stale
+    name: Maybe regenerate tenant baseline
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.pull_request.head.repo.full_name == github.repository
 

--- a/compose.dbs.yml
+++ b/compose.dbs.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: ${POSTGRES_IMAGE:-supabase/postgres:17.6.1.074}
+    image: ${POSTGRES_IMAGE:-supabase/postgres:17.6.1.127}
     ports:
       - "5432:5432"
     volumes:
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   tenant_db:
-    image: ${POSTGRES_IMAGE:-supabase/postgres:17.6.1.074}
+    image: ${POSTGRES_IMAGE:-supabase/postgres:17.6.1.127}
     ports:
       - "5433:5432"
     volumes:

--- a/compose.dbs.yml
+++ b/compose.dbs.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./dev/postgres/00-supabase-schema.sql:/docker-entrypoint-initdb.d/00-supabase-schema.sql
+      - ./dev/postgres/zz-supabase-schema.sql:/docker-entrypoint-initdb.d/zz-supabase-schema.sql
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:
       POSTGRES_HOST: /var/run/postgresql
@@ -19,6 +19,8 @@ services:
     image: ${POSTGRES_IMAGE:-supabase/postgres:17.6.1.074}
     ports:
       - "5433:5432"
+    volumes:
+      - ./dev/postgres/zz-supabase-schema.sql:/docker-entrypoint-initdb.d/zz-supabase-schema.sql
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:
       POSTGRES_HOST: /var/run/postgresql

--- a/compose.tests.yml
+++ b/compose.tests.yml
@@ -1,7 +1,7 @@
 services:
   # Supabase Realtime service
   test_db:
-    image: ${POSTGRES_IMAGE:-supabase/postgres:17.6.1.074}
+    image: ${POSTGRES_IMAGE:-supabase/postgres:17.6.1.127}
     container_name: test-realtime-db
     ports:
       - "5532:5432"

--- a/dev/postgres/00-supabase-schema.sql
+++ b/dev/postgres/00-supabase-schema.sql
@@ -1,2 +1,0 @@
-create schema if not exists _realtime;
-create schema if not exists realtime;

--- a/dev/postgres/zz-supabase-schema.sql
+++ b/dev/postgres/zz-supabase-schema.sql
@@ -1,0 +1,69 @@
+do $$
+begin
+  if not exists (select from pg_roles where rolname = 'postgres') then
+    create role postgres with login superuser createdb createrole replication bypassrls password 'postgres';
+  end if;
+  if not exists (select from pg_roles where rolname = 'supabase_admin') then
+    create role supabase_admin with login superuser createdb createrole replication bypassrls password 'postgres';
+  end if;
+  if not exists (select from pg_roles where rolname = 'anon') then
+    create role anon nologin noinherit;
+  end if;
+  if not exists (select from pg_roles where rolname = 'authenticated') then
+    create role authenticated nologin noinherit;
+  end if;
+  if not exists (select from pg_roles where rolname = 'service_role') then
+    create role service_role nologin noinherit bypassrls;
+  end if;
+end$$;
+
+create schema if not exists _realtime;
+create schema if not exists realtime;
+
+-- auth schema and functions below are only used by tests
+do $$
+begin
+  if not exists (select 1 from pg_namespace where nspname = 'auth') then
+    create schema auth;
+
+    execute $f$
+      create function auth.uid() returns uuid language sql stable as $body$
+        select coalesce(
+          nullif(current_setting('request.jwt.claim.sub', true), ''),
+          (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub')
+        )::uuid
+      $body$
+    $f$;
+
+    execute $f$
+      create function auth.role() returns text language sql stable as $body$
+        select coalesce(
+          nullif(current_setting('request.jwt.claim.role', true), ''),
+          (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role')
+        )::text
+      $body$
+    $f$;
+
+    execute $f$
+      create function auth.email() returns text language sql stable as $body$
+        select coalesce(
+          nullif(current_setting('request.jwt.claim.email', true), ''),
+          (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'email')
+        )::text
+      $body$
+    $f$;
+
+    execute $f$
+      create function auth.jwt() returns jsonb language sql stable as $body$
+        select coalesce(
+          nullif(current_setting('request.jwt.claim', true), ''),
+          nullif(current_setting('request.jwt.claims', true), '')
+        )::jsonb
+      $body$
+    $f$;
+
+    grant usage on schema auth to anon, authenticated, service_role, supabase_admin;
+    grant execute on all functions in schema auth to anon, authenticated, service_role, supabase_admin;
+    alter default privileges in schema auth grant execute on functions to anon, authenticated, service_role, supabase_admin;
+  end if;
+end$$;

--- a/priv/repo/tenant_db_baseline.json
+++ b/priv/repo/tenant_db_baseline.json
@@ -449,26 +449,6 @@
         "procedure:extensions.uuid_ns_x500()"
       ]
     },
-    "extension:pg_graphql": {
-      "name": "pg_graphql",
-      "schema": "graphql",
-      "relocatable": false,
-      "version": "1.5.11",
-      "owner": "supabase_admin",
-      "comment": "pg_graphql: GraphQL support",
-      "members": [
-        "eventTrigger:graphql_watch_ddl",
-        "eventTrigger:graphql_watch_drop",
-        "procedure:graphql._internal_resolve(text,jsonb,text,jsonb)",
-        "procedure:graphql.comment_directive(text)",
-        "procedure:graphql.exception(text)",
-        "procedure:graphql.get_schema_version()",
-        "procedure:graphql.increment_schema_version()",
-        "procedure:graphql.resolve(text,jsonb,text,jsonb)",
-        "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
-        "sequence:graphql.seq_schema_version"
-      ]
-    },
     "extension:pg_stat_statements": {
       "name": "pg_stat_statements",
       "schema": "extensions",
@@ -784,10 +764,10 @@
       "all_argument_types": [],
       "argument_modes": null,
       "argument_defaults": null,
-      "source_code": "\nDECLARE\n    func_is_graphql_resolve bool;\nBEGIN\n    func_is_graphql_resolve = (\n        SELECT n.proname = 'resolve'\n        FROM pg_event_trigger_ddl_commands() AS ev\n        LEFT JOIN pg_catalog.pg_proc AS n\n        ON ev.objid = n.oid\n    );\n\n    IF func_is_graphql_resolve\n    THEN\n        -- Update public wrapper to pass all arguments through to the pg_graphql resolve func\n        DROP FUNCTION IF EXISTS graphql_public.graphql;\n        create or replace function graphql_public.graphql(\n            \"operationName\" text default null,\n            query text default null,\n            variables jsonb default null,\n            extensions jsonb default null\n        )\n            returns jsonb\n            language sql\n        as $$\n            select graphql.resolve(\n                query := query,\n                variables := coalesce(variables, '{}'),\n                \"operationName\" := \"operationName\",\n                extensions := extensions\n            );\n        $$;\n\n        -- This hook executes when `graphql.resolve` is created. That is not necessarily the last\n        -- function in the extension so we need to grant permissions on existing entities AND\n        -- update default permissions to any others that are created after `graphql.resolve`\n        grant usage on schema graphql to postgres, anon, authenticated, service_role;\n        grant select on all tables in schema graphql to postgres, anon, authenticated, service_role;\n        grant execute on all functions in schema graphql to postgres, anon, authenticated, service_role;\n        grant all on all sequences in schema graphql to postgres, anon, authenticated, service_role;\n        alter default privileges in schema graphql grant all on tables to postgres, anon, authenticated, service_role;\n        alter default privileges in schema graphql grant all on functions to postgres, anon, authenticated, service_role;\n        alter default privileges in schema graphql grant all on sequences to postgres, anon, authenticated, service_role;\n\n        -- Allow postgres role to allow granting usage on graphql and graphql_public schemas to custom roles\n        grant usage on schema graphql_public to postgres with grant option;\n        grant usage on schema graphql to postgres with grant option;\n    END IF;\n\nEND;\n",
+      "source_code": "\nbegin\n    if not exists (\n        select 1\n        from pg_event_trigger_ddl_commands() ev\n        join pg_catalog.pg_extension e on ev.objid = e.oid\n        where e.extname = 'pg_graphql'\n    ) then\n        return;\n    end if;\n\n    drop function if exists graphql_public.graphql;\n    create or replace function graphql_public.graphql(\n        \"operationName\" text default null,\n        query text default null,\n        variables jsonb default null,\n        extensions jsonb default null\n    )\n        returns jsonb\n        language sql\n    as $$\n        select graphql.resolve(\n            query := query,\n            variables := coalesce(variables, '{}'),\n            \"operationName\" := \"operationName\",\n            extensions := extensions\n        );\n    $$;\n\n    -- Attach the wrapper to the extension so DROP EXTENSION cascades to it,\n    -- which in turn triggers set_graphql_placeholder to reinstall the \"not enabled\" stub.\n    alter extension pg_graphql add function graphql_public.graphql(text, text, jsonb, jsonb);\n\n    grant usage on schema graphql to postgres, anon, authenticated, service_role;\n    grant execute on function graphql.resolve to postgres, anon, authenticated, service_role;\n    grant usage on schema graphql to postgres with grant option;\n    grant usage on schema graphql_public to postgres with grant option;\nend;\n",
       "binary_path": null,
       "sql_body": null,
-      "definition": "CREATE OR REPLACE FUNCTION extensions.grant_pg_graphql_access()\n RETURNS event_trigger\n LANGUAGE plpgsql\nAS $function$\nDECLARE\n    func_is_graphql_resolve bool;\nBEGIN\n    func_is_graphql_resolve = (\n        SELECT n.proname = 'resolve'\n        FROM pg_event_trigger_ddl_commands() AS ev\n        LEFT JOIN pg_catalog.pg_proc AS n\n        ON ev.objid = n.oid\n    );\n\n    IF func_is_graphql_resolve\n    THEN\n        -- Update public wrapper to pass all arguments through to the pg_graphql resolve func\n        DROP FUNCTION IF EXISTS graphql_public.graphql;\n        create or replace function graphql_public.graphql(\n            \"operationName\" text default null,\n            query text default null,\n            variables jsonb default null,\n            extensions jsonb default null\n        )\n            returns jsonb\n            language sql\n        as $$\n            select graphql.resolve(\n                query := query,\n                variables := coalesce(variables, '{}'),\n                \"operationName\" := \"operationName\",\n                extensions := extensions\n            );\n        $$;\n\n        -- This hook executes when `graphql.resolve` is created. That is not necessarily the last\n        -- function in the extension so we need to grant permissions on existing entities AND\n        -- update default permissions to any others that are created after `graphql.resolve`\n        grant usage on schema graphql to postgres, anon, authenticated, service_role;\n        grant select on all tables in schema graphql to postgres, anon, authenticated, service_role;\n        grant execute on all functions in schema graphql to postgres, anon, authenticated, service_role;\n        grant all on all sequences in schema graphql to postgres, anon, authenticated, service_role;\n        alter default privileges in schema graphql grant all on tables to postgres, anon, authenticated, service_role;\n        alter default privileges in schema graphql grant all on functions to postgres, anon, authenticated, service_role;\n        alter default privileges in schema graphql grant all on sequences to postgres, anon, authenticated, service_role;\n\n        -- Allow postgres role to allow granting usage on graphql and graphql_public schemas to custom roles\n        grant usage on schema graphql_public to postgres with grant option;\n        grant usage on schema graphql to postgres with grant option;\n    END IF;\n\nEND;\n$function$\n",
+      "definition": "CREATE OR REPLACE FUNCTION extensions.grant_pg_graphql_access()\n RETURNS event_trigger\n LANGUAGE plpgsql\nAS $function$\nbegin\n    if not exists (\n        select 1\n        from pg_event_trigger_ddl_commands() ev\n        join pg_catalog.pg_extension e on ev.objid = e.oid\n        where e.extname = 'pg_graphql'\n    ) then\n        return;\n    end if;\n\n    drop function if exists graphql_public.graphql;\n    create or replace function graphql_public.graphql(\n        \"operationName\" text default null,\n        query text default null,\n        variables jsonb default null,\n        extensions jsonb default null\n    )\n        returns jsonb\n        language sql\n    as $$\n        select graphql.resolve(\n            query := query,\n            variables := coalesce(variables, '{}'),\n            \"operationName\" := \"operationName\",\n            extensions := extensions\n        );\n    $$;\n\n    -- Attach the wrapper to the extension so DROP EXTENSION cascades to it,\n    -- which in turn triggers set_graphql_placeholder to reinstall the \"not enabled\" stub.\n    alter extension pg_graphql add function graphql_public.graphql(text, text, jsonb, jsonb);\n\n    grant usage on schema graphql to postgres, anon, authenticated, service_role;\n    grant execute on function graphql.resolve to postgres, anon, authenticated, service_role;\n    grant usage on schema graphql to postgres with grant option;\n    grant usage on schema graphql_public to postgres with grant option;\nend;\n$function$\n",
       "config": null,
       "owner": "supabase_admin",
       "comment": "Grants access to pg_graphql",
@@ -998,6 +978,79 @@
           "grantee": "postgres",
           "privilege": "EXECUTE",
           "grantable": true
+        }
+      ],
+      "security_labels": []
+    },
+    "procedure:graphql_public.graphql(text,text,jsonb,jsonb)": {
+      "schema": "graphql_public",
+      "name": "graphql",
+      "kind": "f",
+      "return_type": "jsonb",
+      "return_type_schema": "pg_catalog",
+      "language": "plpgsql",
+      "security_definer": false,
+      "volatility": "v",
+      "parallel_safety": "u",
+      "execution_cost": 100,
+      "result_rows": 0,
+      "is_strict": false,
+      "leakproof": false,
+      "returns_set": false,
+      "argument_count": 4,
+      "argument_default_count": 4,
+      "argument_names": [
+        "\"operationName\"",
+        "query",
+        "variables",
+        "extensions"
+      ],
+      "argument_types": [
+        "text",
+        "text",
+        "jsonb",
+        "jsonb"
+      ],
+      "all_argument_types": [],
+      "argument_modes": null,
+      "argument_defaults": "NULL::text, NULL::text, NULL::jsonb, NULL::jsonb",
+      "source_code": "\n            DECLARE\n                server_version float;\n            BEGIN\n                server_version = (SELECT (SPLIT_PART((select version()), ' ', 2))::float);\n\n                IF server_version >= 14 THEN\n                    RETURN jsonb_build_object(\n                        'errors', jsonb_build_array(\n                            jsonb_build_object(\n                                'message', 'pg_graphql extension is not enabled.'\n                            )\n                        )\n                    );\n                ELSE\n                    RETURN jsonb_build_object(\n                        'errors', jsonb_build_array(\n                            jsonb_build_object(\n                                'message', 'pg_graphql is only available on projects running Postgres 14 onwards.'\n                            )\n                        )\n                    );\n                END IF;\n            END;\n        ",
+      "binary_path": null,
+      "sql_body": null,
+      "definition": "CREATE OR REPLACE FUNCTION graphql_public.graphql(\"operationName\" text DEFAULT NULL::text, query text DEFAULT NULL::text, variables jsonb DEFAULT NULL::jsonb, extensions jsonb DEFAULT NULL::jsonb)\n RETURNS jsonb\n LANGUAGE plpgsql\nAS $function$\n            DECLARE\n                server_version float;\n            BEGIN\n                server_version = (SELECT (SPLIT_PART((select version()), ' ', 2))::float);\n\n                IF server_version >= 14 THEN\n                    RETURN jsonb_build_object(\n                        'errors', jsonb_build_array(\n                            jsonb_build_object(\n                                'message', 'pg_graphql extension is not enabled.'\n                            )\n                        )\n                    );\n                ELSE\n                    RETURN jsonb_build_object(\n                        'errors', jsonb_build_array(\n                            jsonb_build_object(\n                                'message', 'pg_graphql is only available on projects running Postgres 14 onwards.'\n                            )\n                        )\n                    );\n                END IF;\n            END;\n        $function$\n",
+      "config": null,
+      "owner": "supabase_admin",
+      "comment": null,
+      "privileges": [
+        {
+          "grantee": "PUBLIC",
+          "privilege": "EXECUTE",
+          "grantable": false
+        },
+        {
+          "grantee": "supabase_admin",
+          "privilege": "EXECUTE",
+          "grantable": false
+        },
+        {
+          "grantee": "postgres",
+          "privilege": "EXECUTE",
+          "grantable": false
+        },
+        {
+          "grantee": "anon",
+          "privilege": "EXECUTE",
+          "grantable": false
+        },
+        {
+          "grantee": "authenticated",
+          "privilege": "EXECUTE",
+          "grantable": false
+        },
+        {
+          "grantee": "service_role",
+          "privilege": "EXECUTE",
+          "grantable": false
         }
       ],
       "security_labels": []
@@ -3102,7 +3155,7 @@
       "connection_limit": -1,
       "can_bypass_rls": false,
       "config": [
-        "session_preload_libraries=safeupdate",
+        "session_preload_libraries=supautils, safeupdate",
         "statement_timeout=8s",
         "lock_timeout=8s"
       ],
@@ -5998,6 +6051,154 @@
       ],
       "security_labels": []
     },
+    "role:supabase_privileged_role": {
+      "name": "supabase_privileged_role",
+      "is_superuser": false,
+      "can_inherit": true,
+      "can_create_roles": false,
+      "can_create_databases": false,
+      "can_login": false,
+      "can_replicate": false,
+      "connection_limit": -1,
+      "can_bypass_rls": false,
+      "config": null,
+      "comment": null,
+      "members": [
+        {
+          "member": "supabase_etl_admin",
+          "grantor": "supabase_admin",
+          "admin_option": false,
+          "inherit_option": true,
+          "set_option": true
+        },
+        {
+          "member": "postgres",
+          "grantor": "supabase_admin",
+          "admin_option": false,
+          "inherit_option": true,
+          "set_option": true
+        }
+      ],
+      "default_privileges": [
+        {
+          "in_schema": null,
+          "objtype": "S",
+          "grantee": "supabase_privileged_role",
+          "privileges": [
+            {
+              "privilege": "USAGE",
+              "grantable": false
+            }
+          ],
+          "is_implicit": true
+        },
+        {
+          "in_schema": null,
+          "objtype": "T",
+          "grantee": "PUBLIC",
+          "privileges": [
+            {
+              "privilege": "USAGE",
+              "grantable": false
+            }
+          ],
+          "is_implicit": true
+        },
+        {
+          "in_schema": null,
+          "objtype": "T",
+          "grantee": "supabase_privileged_role",
+          "privileges": [
+            {
+              "privilege": "USAGE",
+              "grantable": false
+            }
+          ],
+          "is_implicit": true
+        },
+        {
+          "in_schema": null,
+          "objtype": "f",
+          "grantee": "PUBLIC",
+          "privileges": [
+            {
+              "privilege": "EXECUTE",
+              "grantable": false
+            }
+          ],
+          "is_implicit": true
+        },
+        {
+          "in_schema": null,
+          "objtype": "f",
+          "grantee": "supabase_privileged_role",
+          "privileges": [
+            {
+              "privilege": "EXECUTE",
+              "grantable": false
+            }
+          ],
+          "is_implicit": true
+        },
+        {
+          "in_schema": null,
+          "objtype": "n",
+          "grantee": "supabase_privileged_role",
+          "privileges": [
+            {
+              "privilege": "CREATE",
+              "grantable": false
+            },
+            {
+              "privilege": "USAGE",
+              "grantable": false
+            }
+          ],
+          "is_implicit": true
+        },
+        {
+          "in_schema": null,
+          "objtype": "r",
+          "grantee": "supabase_privileged_role",
+          "privileges": [
+            {
+              "privilege": "DELETE",
+              "grantable": false
+            },
+            {
+              "privilege": "INSERT",
+              "grantable": false
+            },
+            {
+              "privilege": "MAINTAIN",
+              "grantable": false
+            },
+            {
+              "privilege": "REFERENCES",
+              "grantable": false
+            },
+            {
+              "privilege": "SELECT",
+              "grantable": false
+            },
+            {
+              "privilege": "TRIGGER",
+              "grantable": false
+            },
+            {
+              "privilege": "TRUNCATE",
+              "grantable": false
+            },
+            {
+              "privilege": "UPDATE",
+              "grantable": false
+            }
+          ],
+          "is_implicit": true
+        }
+      ],
+      "security_labels": []
+    },
     "role:supabase_read_only_user": {
       "name": "supabase_read_only_user",
       "is_superuser": false,
@@ -6504,154 +6705,6 @@
           "in_schema": null,
           "objtype": "r",
           "grantee": "supabase_storage_admin",
-          "privileges": [
-            {
-              "privilege": "DELETE",
-              "grantable": false
-            },
-            {
-              "privilege": "INSERT",
-              "grantable": false
-            },
-            {
-              "privilege": "MAINTAIN",
-              "grantable": false
-            },
-            {
-              "privilege": "REFERENCES",
-              "grantable": false
-            },
-            {
-              "privilege": "SELECT",
-              "grantable": false
-            },
-            {
-              "privilege": "TRIGGER",
-              "grantable": false
-            },
-            {
-              "privilege": "TRUNCATE",
-              "grantable": false
-            },
-            {
-              "privilege": "UPDATE",
-              "grantable": false
-            }
-          ],
-          "is_implicit": true
-        }
-      ],
-      "security_labels": []
-    },
-    "role:supabase_superuser": {
-      "name": "supabase_superuser",
-      "is_superuser": false,
-      "can_inherit": true,
-      "can_create_roles": false,
-      "can_create_databases": false,
-      "can_login": false,
-      "can_replicate": false,
-      "connection_limit": -1,
-      "can_bypass_rls": false,
-      "config": null,
-      "comment": null,
-      "members": [
-        {
-          "member": "supabase_etl_admin",
-          "grantor": "supabase_admin",
-          "admin_option": false,
-          "inherit_option": true,
-          "set_option": true
-        },
-        {
-          "member": "postgres",
-          "grantor": "supabase_admin",
-          "admin_option": false,
-          "inherit_option": true,
-          "set_option": true
-        }
-      ],
-      "default_privileges": [
-        {
-          "in_schema": null,
-          "objtype": "S",
-          "grantee": "supabase_superuser",
-          "privileges": [
-            {
-              "privilege": "USAGE",
-              "grantable": false
-            }
-          ],
-          "is_implicit": true
-        },
-        {
-          "in_schema": null,
-          "objtype": "T",
-          "grantee": "PUBLIC",
-          "privileges": [
-            {
-              "privilege": "USAGE",
-              "grantable": false
-            }
-          ],
-          "is_implicit": true
-        },
-        {
-          "in_schema": null,
-          "objtype": "T",
-          "grantee": "supabase_superuser",
-          "privileges": [
-            {
-              "privilege": "USAGE",
-              "grantable": false
-            }
-          ],
-          "is_implicit": true
-        },
-        {
-          "in_schema": null,
-          "objtype": "f",
-          "grantee": "PUBLIC",
-          "privileges": [
-            {
-              "privilege": "EXECUTE",
-              "grantable": false
-            }
-          ],
-          "is_implicit": true
-        },
-        {
-          "in_schema": null,
-          "objtype": "f",
-          "grantee": "supabase_superuser",
-          "privileges": [
-            {
-              "privilege": "EXECUTE",
-              "grantable": false
-            }
-          ],
-          "is_implicit": true
-        },
-        {
-          "in_schema": null,
-          "objtype": "n",
-          "grantee": "supabase_superuser",
-          "privileges": [
-            {
-              "privilege": "CREATE",
-              "grantable": false
-            },
-            {
-              "privilege": "USAGE",
-              "grantable": false
-            }
-          ],
-          "is_implicit": true
-        },
-        {
-          "in_schema": null,
-          "objtype": "r",
-          "grantee": "supabase_superuser",
           "privileges": [
             {
               "privilege": "DELETE",
@@ -10520,7 +10573,7 @@
       "function_name": "grant_pg_graphql_access",
       "enabled": "O",
       "tags": [
-        "CREATE FUNCTION"
+        "CREATE EXTENSION"
       ],
       "owner": "supabase_admin",
       "comment": null,
@@ -10837,6 +10890,66 @@
     },
     {
       "dependent_stable_id": "acl:procedure:extensions.set_graphql_placeholder()::grantee:supabase_admin",
+      "referenced_stable_id": "role:supabase_admin",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:anon",
+      "referenced_stable_id": "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:anon",
+      "referenced_stable_id": "role:anon",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:authenticated",
+      "referenced_stable_id": "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:authenticated",
+      "referenced_stable_id": "role:authenticated",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:postgres",
+      "referenced_stable_id": "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:postgres",
+      "referenced_stable_id": "role:postgres",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:PUBLIC",
+      "referenced_stable_id": "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:PUBLIC",
+      "referenced_stable_id": "role:PUBLIC",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:service_role",
+      "referenced_stable_id": "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:service_role",
+      "referenced_stable_id": "role:service_role",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:supabase_admin",
+      "referenced_stable_id": "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "acl:procedure:graphql_public.graphql(text,text,jsonb,jsonb)::grantee:supabase_admin",
       "referenced_stable_id": "role:supabase_admin",
       "deptype": "n"
     },
@@ -12671,11 +12784,6 @@
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "comment:extension:pg_graphql",
-      "referenced_stable_id": "extension:pg_graphql",
-      "deptype": "a"
-    },
-    {
       "dependent_stable_id": "comment:extension:pg_stat_statements",
       "referenced_stable_id": "extension:pg_stat_statements",
       "deptype": "a"
@@ -14026,26 +14134,6 @@
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "eventTrigger:graphql_watch_ddl",
-      "referenced_stable_id": "procedure:graphql.increment_schema_version()",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "eventTrigger:graphql_watch_ddl",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "eventTrigger:graphql_watch_drop",
-      "referenced_stable_id": "procedure:graphql.increment_schema_version()",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "eventTrigger:graphql_watch_drop",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
       "dependent_stable_id": "eventTrigger:issue_graphql_placeholder",
       "referenced_stable_id": "procedure:extensions.set_graphql_placeholder()",
       "deptype": "n"
@@ -14113,16 +14201,6 @@
     {
       "dependent_stable_id": "extension:\"uuid-ossp\"",
       "referenced_stable_id": "schema:extensions",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "extension:pg_graphql",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "extension:pg_graphql",
-      "referenced_stable_id": "schema:graphql",
       "deptype": "n"
     },
     {
@@ -14626,6 +14704,26 @@
       "deptype": "n"
     },
     {
+      "dependent_stable_id": "membership:supabase_privileged_role->postgres",
+      "referenced_stable_id": "role:postgres",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "membership:supabase_privileged_role->postgres",
+      "referenced_stable_id": "role:supabase_privileged_role",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "membership:supabase_privileged_role->supabase_etl_admin",
+      "referenced_stable_id": "role:supabase_etl_admin",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "membership:supabase_privileged_role->supabase_etl_admin",
+      "referenced_stable_id": "role:supabase_privileged_role",
+      "deptype": "n"
+    },
+    {
       "dependent_stable_id": "membership:supabase_realtime_admin->postgres",
       "referenced_stable_id": "role:postgres",
       "deptype": "n"
@@ -14636,26 +14734,6 @@
       "deptype": "n"
     },
     {
-      "dependent_stable_id": "membership:supabase_superuser->postgres",
-      "referenced_stable_id": "role:postgres",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "membership:supabase_superuser->postgres",
-      "referenced_stable_id": "role:supabase_superuser",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "membership:supabase_superuser->supabase_etl_admin",
-      "referenced_stable_id": "role:supabase_etl_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "membership:supabase_superuser->supabase_etl_admin",
-      "referenced_stable_id": "role:supabase_superuser",
-      "deptype": "n"
-    },
-    {
       "dependent_stable_id": "procedure:auth.email()",
       "referenced_stable_id": "role:supabase_auth_admin",
       "deptype": "n"
@@ -15263,6 +15341,11 @@
     {
       "dependent_stable_id": "procedure:extensions.uuid_ns_x500()",
       "referenced_stable_id": "schema:extensions",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
+      "referenced_stable_id": "language:plpgsql",
       "deptype": "n"
     },
     {
@@ -15273,81 +15356,6 @@
     {
       "dependent_stable_id": "procedure:graphql_public.graphql(text,text,jsonb,jsonb)",
       "referenced_stable_id": "schema:graphql_public",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql._internal_resolve(text,jsonb,text,jsonb)",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql._internal_resolve(text,jsonb,text,jsonb)",
-      "referenced_stable_id": "schema:graphql",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.comment_directive(text)",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.comment_directive(text)",
-      "referenced_stable_id": "schema:graphql",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.exception(text)",
-      "referenced_stable_id": "language:plpgsql",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.exception(text)",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.exception(text)",
-      "referenced_stable_id": "schema:graphql",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.get_schema_version()",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.get_schema_version()",
-      "referenced_stable_id": "schema:graphql",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.increment_schema_version()",
-      "referenced_stable_id": "language:plpgsql",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.increment_schema_version()",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.increment_schema_version()",
-      "referenced_stable_id": "schema:graphql",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.resolve(text,jsonb,text,jsonb)",
-      "referenced_stable_id": "language:plpgsql",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.resolve(text,jsonb,text,jsonb)",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "procedure:graphql.resolve(text,jsonb,text,jsonb)",
-      "referenced_stable_id": "schema:graphql",
       "deptype": "n"
     },
     {
@@ -15736,16 +15744,6 @@
       "deptype": "n"
     },
     {
-      "dependent_stable_id": "sequence:graphql.seq_schema_version",
-      "referenced_stable_id": "role:supabase_admin",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "sequence:graphql.seq_schema_version",
-      "referenced_stable_id": "schema:graphql",
-      "deptype": "n"
-    },
-    {
       "dependent_stable_id": "sequence:public.test_tenant_id_seq",
       "referenced_stable_id": "column:public.test_tenant.id",
       "deptype": "a"
@@ -16031,22 +16029,22 @@
       "deptype": "n"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16851",
+      "dependent_stable_id": "unknown:pg_class.16853",
       "referenced_stable_id": "column:realtime.messages.extension",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16851",
+      "dependent_stable_id": "unknown:pg_class.16853",
       "referenced_stable_id": "column:realtime.messages.inserted_at",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16851",
+      "dependent_stable_id": "unknown:pg_class.16853",
       "referenced_stable_id": "column:realtime.messages.private",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16851",
+      "dependent_stable_id": "unknown:pg_class.16853",
       "referenced_stable_id": "column:realtime.messages.topic",
       "deptype": "a"
     },

--- a/priv/repo/tenant_db_baseline.json
+++ b/priv/repo/tenant_db_baseline.json
@@ -6693,6 +6693,24 @@
     }
   },
   "schemas": {
+    "schema:_realtime": {
+      "name": "_realtime",
+      "owner": "supabase_admin",
+      "comment": null,
+      "privileges": [
+        {
+          "grantee": "supabase_admin",
+          "privilege": "CREATE",
+          "grantable": false
+        },
+        {
+          "grantee": "supabase_admin",
+          "privilege": "USAGE",
+          "grantable": false
+        }
+      ],
+      "security_labels": []
+    },
     "schema:auth": {
       "name": "auth",
       "owner": "supabase_admin",
@@ -15650,6 +15668,11 @@
     {
       "dependent_stable_id": "rule:vault.decrypted_secrets.\"_RETURN\"",
       "referenced_stable_id": "procedure:vault._crypto_aead_det_decrypt(bytea,bytea,bigint,bytea,bytea)",
+      "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "schema:_realtime",
+      "referenced_stable_id": "role:supabase_admin",
       "deptype": "n"
     },
     {

--- a/test/integration/rt_channel/broadcast_test.exs
+++ b/test/integration/rt_channel/broadcast_test.exs
@@ -263,7 +263,8 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
     end
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence],
-         requires_data: true
+         requires_data: true,
+         requires_pg14_6_plus: true
     test "broadcast update event changes on update in table with trigger", %{
       tenant: tenant,
       topic: topic,
@@ -306,7 +307,8 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
                      1000
     end
 
-    @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
+    @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence],
+         requires_pg14_6_plus: true
     test "broadcast delete event changes on delete in table with trigger", %{
       tenant: tenant,
       topic: topic,

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -292,6 +292,8 @@ defmodule Containers do
   end
 
   defp docker_run!(name, port) do
+    initdb = Path.expand("../../dev/postgres", __DIR__)
+
     {_, 0} =
       System.cmd("docker", [
         "run",
@@ -303,6 +305,8 @@ defmodule Containers do
         "POSTGRES_HOST=/var/run/postgresql",
         "-e",
         "POSTGRES_PASSWORD=postgres",
+        "-v",
+        "#{initdb}:/docker-entrypoint-initdb.d",
         "-p",
         "#{port}:5432",
         image(),

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -7,7 +7,7 @@ defmodule Containers do
 
   use GenServer
 
-  defp image, do: System.get_env("POSTGRES_IMAGE", "supabase/postgres:17.6.1.074")
+  defp image, do: System.get_env("POSTGRES_IMAGE", "supabase/postgres:17.6.1.127")
 
   # Pull image if not available
   def pull do

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -292,7 +292,7 @@ defmodule Containers do
   end
 
   defp docker_run!(name, port) do
-    initdb = Path.expand("../../dev/postgres", __DIR__)
+    initdb = Path.expand("../../dev/postgres/zz-supabase-schema.sql", __DIR__)
 
     {_, 0} =
       System.cmd("docker", [
@@ -306,7 +306,7 @@ defmodule Containers do
         "-e",
         "POSTGRES_PASSWORD=postgres",
         "-v",
-        "#{initdb}:/docker-entrypoint-initdb.d",
+        "#{initdb}:/docker-entrypoint-initdb.d/zz-supabase-schema.sql",
         "-p",
         "#{port}:5432",
         image(),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,12 +3,14 @@ start_time = :os.system_time(:millisecond)
 alias Realtime.Api
 max_cases = String.to_integer(System.get_env("MAX_CASES", "4"))
 
+repo_config = Application.fetch_env!(:realtime, Realtime.Repo)
+
 {:ok, pg_conn} =
   Postgrex.start_link(
-    hostname: "127.0.0.1",
-    port: 5432,
-    username: "supabase_admin",
-    password: "postgres",
+    hostname: repo_config[:hostname],
+    port: repo_config[:port] || 5432,
+    username: repo_config[:username],
+    password: repo_config[:password],
     database: "postgres"
   )
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,22 @@ start_time = :os.system_time(:millisecond)
 
 alias Realtime.Api
 max_cases = String.to_integer(System.get_env("MAX_CASES", "4"))
-ExUnit.start(exclude: [:failing], max_cases: max_cases, capture_log: true)
+
+{:ok, pg_conn} =
+  Postgrex.start_link(
+    hostname: "127.0.0.1",
+    port: 5432,
+    username: "supabase_admin",
+    password: "postgres",
+    database: "postgres"
+  )
+
+%{rows: [[pg_version_num]]} = Postgrex.query!(pg_conn, "SELECT current_setting('server_version_num')::int")
+
+# `realtime.broadcast_changes(..., NEW record, OLD record, ...)` (introduced in commit 2922658c) called from a trigger via `PERFORM` fails on PG <= 14.5
+exclude = [:failing] ++ if pg_version_num < 140_006, do: [:requires_pg14_6_plus], else: []
+
+ExUnit.start(exclude: exclude, max_cases: max_cases, capture_log: true)
 
 max_cases = ExUnit.configuration()[:max_cases]
 


### PR DESCRIPTION
I found tenants running on versions as old as 14.1.0.3

I used 14.1.0.85 in tests because that's the oldest amd64 image available, and the only incompatibility I found was in the function `realtime.broadcast_changes` that fails on PG <=14.5 with:

```
Failed to process the row: type of parameter 7 (<table_name>) does not
match that when preparing the plan (record)
```

I believe it's linked to https://github.com/postgres/postgres/commit/56d45fdab7b12cd0c767a8c1e7ab6c04390a32d8 but I found no error on logs, so I just skipped the 2 tests that hit that scenario.