### PR TITLE
chore: reduce e2e flakiness

### DIFF
--- a/test/e2e/bun.lock
+++ b/test/e2e/bun.lock
@@ -7,12 +7,12 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/context-async-hooks": "^2.7.1",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
         "@opentelemetry/sdk-trace-base": "^2.7.1",
         "@opentelemetry/semantic-conventions": "^1.41.1",
-        "@supabase/supabase-js": "2.106.0",
-        "commander": "^12.1.0",
+        "@supabase/supabase-js": "^2.106.1",
+        "commander": "^14.0.3",
         "kleur": "^4.1.5",
       },
     },
@@ -20,92 +20,48 @@
   "packages": {
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.213.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw=="],
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw=="],
 
     "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
 
-    "@opentelemetry/core": ["@opentelemetry/core@2.6.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg=="],
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
-    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-exporter-base": "0.213.0", "@opentelemetry/otlp-transformer": "0.213.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/sdk-trace-base": "2.6.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-tnRmJD39aWrE/Sp7F6AbRNAjKHToDkAqBi6i0lESpGWz3G+f4bhVAV6mgSXH2o18lrDVJXo6jf9bAywQw43wRA=="],
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw=="],
 
-    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/otlp-transformer": "0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg=="],
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA=="],
 
-    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.213.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.213.0", "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/sdk-logs": "0.213.0", "@opentelemetry/sdk-metrics": "2.6.0", "@opentelemetry/sdk-trace-base": "2.6.0", "protobufjs": "^7.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-RSuAlxFFPjeK4d5Y6ps8L2WhaQI6CXWllIjvo5nkAlBpmq2XdYWEBGiAbOF4nDs8CX4QblJDv5BbMUft3sEfDw=="],
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ=="],
 
     "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
 
-    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.213.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.213.0", "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-00xlU3GZXo3kXKve4DLdrAL0NAFUaZ9appU/mn00S/5kSUdAvyYsORaDUfR04Mp2CLagAOhrzfUvYozY/EZX2g=="],
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag=="],
 
-    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-CicxWZxX6z35HR83jl+PLgtFgUrKRQ9LCXyxgenMnz5A1lgYWfAog7VtdOvGkJYyQgMNPhXQwkYrDLujk7z1Iw=="],
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
 
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
-    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.106.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7eyheXfAGwkB9bZewJPs+N3UYt6kra2JG6mIxNEgbkvcO15PLD1e75PTIUEYYl3zrifm3GrpShVl7QZxKrXO/w=="],
 
-    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
-
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
-
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
-
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
-
-    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
-
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
-
-    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
-
-    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
-
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
-
-    "@supabase/auth-js": ["@supabase/auth-js@2.106.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-JY7602OvjK2l3BjsQkpePpxR+6P0iG37gCrZNWAMhAuNh1iFnhGRwj/y5EshUG0INMPGFrj0UA9MErQ/kOEKFg=="],
-
-    "@supabase/functions-js": ["@supabase/functions-js@2.106.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-ADIkJYH5w7HbnGVAAlCbyKoLF5QdfyezBLfYXpUqhxZOacK6YepOvnP/8p4p+50bhTPWp6VhDxu19KO7e/qU2g=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.106.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-XbOPnR2mW7jp/EcW447xmGwCa+/Wc00Hkw8t4tUIJjRsHQ4xAESsLKcyLRhRJjJoUnJVXUlC+w0wUxUCM7CG2A=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.2", "", {}, "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.106.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-vNKFAXQrtmUn7J3LbN+uMlt0jciAwRIBpdy6Do4DKrpf1xj0kJhbqXTX4y8ziewWUEEx8G5GPnDmprXXaO9f3w=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.106.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-Qbn6d2lqiqeaBX1Uko0e/hL90dtQGRN6CG2wMVQtJpRFstlVW45qmUTyTOsiB8dYUWu1fWYo4YzJuDbokGv3tQ=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.106.0", "", { "dependencies": { "@supabase/phoenix": "^0.4.2", "tslib": "2.8.1" } }, "sha512-mYZoaYpkyjlecixbvxCu0h3jw12uHfEcUqNdaRATNI8zQVI5arels+VJzAGcHwNiD+/Juv0OXIuk+M7SHsdI4A=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.106.1", "", { "dependencies": { "@supabase/phoenix": "^0.4.2", "tslib": "2.8.1" } }, "sha512-eQCYri5E8KsjpDgC7g28cOOS2britjUWdNSJluFMainqrMRepzjOnaxqXc3RoAz7H0dxmBrfLUNF6NGP8C+YaA=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.106.0", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-BHc3nIjD3zfdDxBenphXrLJSoQ+qwo24VD96cVzmjBFbQVk5krvwRNUXrA5ozPplA3Vhlst2d/hy9R9ViqH2lg=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.106.1", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-HWcLIhqinhWKpOQ3WzglR2unjW0eh9J7yOu3IZrZNIEkraK4La/HDvTqndljGsNw0itPtyHhuKBxRoPG1VUARw=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.106.0", "", { "dependencies": { "@supabase/auth-js": "2.106.0", "@supabase/functions-js": "2.106.0", "@supabase/postgrest-js": "2.106.0", "@supabase/realtime-js": "2.106.0", "@supabase/storage-js": "2.106.0" } }, "sha512-OOoo3sLj9iVXNp6b+fkyOfFeQrvvNy7nQbaONNf72dOaictUeS39hFDS9argIRTag6M3ZxIypNWcrDAwLgUihQ=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.106.1", "", { "dependencies": { "@supabase/auth-js": "2.106.1", "@supabase/functions-js": "2.106.1", "@supabase/postgrest-js": "2.106.1", "@supabase/realtime-js": "2.106.1", "@supabase/storage-js": "2.106.1" } }, "sha512-gP4HurGkGu7Z3xoOCjtAI17BKKp7jpsmwY0Ssbsks9XQRzJ7ZhK7LxfLdBSYgUdgZCQgjRK+Mr7+cl4Gxrk0Rw=="],
 
-    "@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
-
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
-    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
-
-    "protobufjs": ["protobufjs@7.6.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
-
-    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
-
-    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ=="],
-
-    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
-
-    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ=="],
-
-    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
-
-    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
-
-    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
-
-    "@opentelemetry/sdk-trace-base/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
   }
 }

--- a/test/e2e/flake.nix
+++ b/test/e2e/flake.nix
@@ -30,7 +30,7 @@
           installPhase = "cp -r node_modules $out";
           outputHashMode = "recursive";
           outputHashAlgo = "sha256";
-          outputHash = "sha256-wzHnAy1Dgy+nKWJ+s7CZrZTiN6sfgKmDhMJ+qimBudw=";
+          outputHash = "sha256-J7wDvqGoiOAQTt8x1b2hnpxxmxg0zkMrJJ6lKRzbBAw=";
         };
       in {
         packages.default = pkgs.stdenv.mkDerivation {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -4,12 +4,12 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/context-async-hooks": "^2.7.1",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
     "@opentelemetry/resources": "^2.7.1",
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@opentelemetry/semantic-conventions": "^1.41.1",
-    "@supabase/supabase-js": "2.106.0",
-    "commander": "^12.1.0",
+    "@supabase/supabase-js": "^2.106.1",
+    "commander": "^14.0.3",
     "kleur": "^4.1.5"
   },
   "scripts": {

--- a/test/e2e/realtime-check.ts
+++ b/test/e2e/realtime-check.ts
@@ -65,6 +65,7 @@ const DB_URL = DB_URL_ARG ?? (() => {
 const DB_SSL = env !== "local" ? { rejectUnauthorized: false } : false;
 
 const REALTIME_OPTS = { heartbeatIntervalMs: 5000, timeout: 5000 };
+const REALTIME_OPTS_REPLAY = { heartbeatIntervalMs: 5000, timeout: 10000 };
 const BROADCAST_CONFIG = { config: { broadcast: { self: true } } };
 const EVENT_TIMEOUT_MS = 8000;
 const RATE_LIMIT_PAUSE_MS = 2000;
@@ -261,19 +262,28 @@ async function waitForSubscribed(channel: ReturnType<SupabaseClient["channel"]>)
   });
 }
 
-async function waitForPostgresChannel(channel: ReturnType<SupabaseClient["channel"]>): Promise<{ subscribeMs: number; systemMs: number }> {
+// Subscribes a channel and waits until it is fully joined.
+// All data operations must happen after this returns to avoid delivery races.
+async function openChannel(channel: ReturnType<SupabaseClient["channel"]>): Promise<number> {
+  channel.subscribe();
+  return waitForSubscribed(channel);
+}
+
+// Subscribes a postgres_changes channel and waits for both the join and the
+// system:ok confirmation that the server-side WAL subscription is active.
+async function openPostgresChannel(channel: ReturnType<SupabaseClient["channel"]>): Promise<{ subscribeMs: number; systemMs: number }> {
   const start = performance.now();
   let systemOk = false;
   channel.on("system", "*", ({ status }: { status: string }) => { if (status === "ok") systemOk = true; });
-  const subscribeMs = await waitForSubscribed(channel);
+  const subscribeMs = await openChannel(channel);
   const { latencyMs: systemMs } = await waitFor(() => systemOk ? true : null, "system ok");
   return { subscribeMs, systemMs: performance.now() - start };
 }
 
 type TableName = "pg_changes" | "dummy" | "authorization" | "broadcast_changes" | "wallet" | "replay_check";
 
-async function executeInsert(supabase: SupabaseClient, table: TableName): Promise<number> {
-  const { data, error } = await supabase.from(table).insert([{ value: crypto.randomUUID() }]).select("id");
+async function executeInsert(supabase: SupabaseClient, table: TableName, value?: string): Promise<number> {
+  const { data, error } = await supabase.from(table).insert([{ value: value ?? crypto.randomUUID() }]).select("id");
   if (error) throw new Error(`Error inserting into ${table}: ${error.message}`);
   return (data as { id: number }[])[0].id;
 }
@@ -453,8 +463,8 @@ async function runConnectionTest() {
   await test("first connect latency", async () => {
     const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS });
     try {
-      const channel = supabase.channel("topic:" + crypto.randomUUID()).subscribe();
-      const connectMs = await waitForSubscribed(channel);
+      const channel = supabase.channel("topic:" + crypto.randomUUID());
+      const connectMs = await openChannel(channel);
       return [{ label: "connect", value: connectMs, unit: "ms" }];
     } finally {
       await stopClient(supabase);
@@ -477,10 +487,9 @@ async function runConnectionTest() {
         .on("broadcast", { event }, ({ payload }) => {
           const t = sendTimes.get(payload.seq);
           if (t !== undefined) latencies.push(performance.now() - t);
-        })
-        .subscribe();
+        });
 
-      await waitForSubscribed(channel);
+      await openChannel(channel);
 
       for (let i = 0; i < MESSAGES; i++) {
         sendTimes.set(i, performance.now());
@@ -506,9 +515,8 @@ async function runLoadPostgresChangesTests(testUser: { email: string; password: 
       await signInUser(supabase, testUser.email, testUser.password);
       const channel = supabase
         .channel("topic:" + crypto.randomUUID(), BROADCAST_CONFIG)
-        .on("postgres_changes", { event: "INSERT", schema: "public", table: "pg_changes" }, () => {})
-        .subscribe();
-      const { systemMs } = await waitForPostgresChannel(channel);
+        .on("postgres_changes", { event: "INSERT", schema: "public", table: "pg_changes" }, () => {});
+      const { systemMs } = await openPostgresChannel(channel);
       return [{ label: "system", value: systemMs, unit: "ms" }];
     } finally {
       await stopClient(supabase);
@@ -528,10 +536,9 @@ async function runLoadPostgresChangesTests(testUser: { email: string; password: 
         .on("postgres_changes", { event: "INSERT", schema: "public", table: "pg_changes" }, (p) => {
           const t = sendTimes.get(p.new.id);
           if (t !== undefined) latencies.push(performance.now() - t);
-        })
-        .subscribe();
+        });
 
-      await waitForPostgresChannel(channel);
+      await openPostgresChannel(channel);
 
       for (let i = 0; i < LOAD_MESSAGES; i++) {
         const t = performance.now();
@@ -552,8 +559,6 @@ async function runLoadPostgresChangesTests(testUser: { email: string; password: 
     const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS });
     try {
       await signInUser(supabase, testUser.email, testUser.password);
-      const ids = await Promise.all(Array.from({ length: LOAD_MESSAGES }, () => executeInsert(supabase, "pg_changes")));
-
       const sendTimes = new Map<number, number>();
       const latencies: number[] = [];
 
@@ -562,10 +567,11 @@ async function runLoadPostgresChangesTests(testUser: { email: string; password: 
         .on("postgres_changes", { event: "UPDATE", schema: "public", table: "pg_changes" }, (p) => {
           const t = sendTimes.get(p.new.id);
           if (t !== undefined) latencies.push(performance.now() - t);
-        })
-        .subscribe();
+        });
 
-      await waitForPostgresChannel(channel);
+      await openPostgresChannel(channel);
+
+      const ids = await Promise.all(Array.from({ length: LOAD_MESSAGES }, () => executeInsert(supabase, "pg_changes")));
 
       await Promise.all(ids.map((id) => {
         sendTimes.set(id, performance.now());
@@ -585,8 +591,6 @@ async function runLoadPostgresChangesTests(testUser: { email: string; password: 
     const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS });
     try {
       await signInUser(supabase, testUser.email, testUser.password);
-      const ids = await Promise.all(Array.from({ length: LOAD_MESSAGES }, () => executeInsert(supabase, "pg_changes")));
-
       const sendTimes = new Map<number, number>();
       const latencies: number[] = [];
 
@@ -595,10 +599,11 @@ async function runLoadPostgresChangesTests(testUser: { email: string; password: 
         .on("postgres_changes", { event: "DELETE", schema: "public", table: "pg_changes" }, (p) => {
           const t = sendTimes.get(p.old.id);
           if (t !== undefined) latencies.push(performance.now() - t);
-        })
-        .subscribe();
+        });
 
-      await waitForPostgresChannel(channel);
+      await openPostgresChannel(channel);
+
+      const ids = await Promise.all(Array.from({ length: LOAD_MESSAGES }, () => executeInsert(supabase, "pg_changes")));
 
       await Promise.all(ids.map((id) => {
         sendTimes.set(id, performance.now());
@@ -633,9 +638,8 @@ async function runLoadPresenceTests() {
           if (e.key === "observer") return;
           const t = trackTimes.get(e.key);
           if (t !== undefined) latencies.push(performance.now() - t);
-        })
-        .subscribe();
-      await waitForSubscribed(observerChannel);
+        });
+      await openChannel(observerChannel);
 
       const clients = Array.from({ length: CLIENTS }, (_, i) => ({
         client: createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS }),
@@ -644,8 +648,8 @@ async function runLoadPresenceTests() {
       senders.push(...clients.map((c) => c.client));
 
       const channels = await Promise.all(clients.map(async ({ client, key }) => {
-        const ch = client.channel(topic, { config: { presence: { key } } }).subscribe();
-        await waitForSubscribed(ch);
+        const ch = client.channel(topic, { config: { presence: { key } } });
+        await openChannel(ch);
         return { ch, key };
       }));
 
@@ -680,10 +684,9 @@ async function runLoadBroadcastFromDbTests(testUser: { email: string; password: 
         .on("broadcast", { event: "INSERT" }, (res) => {
           const t = sendTimes.get(res.payload.record.id);
           if (t !== undefined) latencies.push(performance.now() - t);
-        })
-        .subscribe();
+        });
 
-      await waitForSubscribed(channel);
+      await openChannel(channel);
 
       await Promise.all(Array.from({ length: LOAD_MESSAGES }, async () => {
         const id = crypto.randomUUID();
@@ -719,10 +722,9 @@ async function runLoadBroadcastTests() {
         .on("broadcast", { event }, ({ payload }) => {
           const t = sendTimes.get(payload.seq);
           if (t !== undefined) latencies.push(performance.now() - t);
-        })
-        .subscribe();
+        });
 
-      await waitForSubscribed(channel);
+      await openChannel(channel);
 
       for (let i = 0; i < LOAD_MESSAGES; i++) {
         sendTimes.set(i, performance.now());
@@ -751,10 +753,9 @@ async function runLoadBroadcastTests() {
         .on("broadcast", { event }, ({ payload }) => {
           const t = sendTimes.get(payload.seq);
           if (t !== undefined) latencies.push(performance.now() - t);
-        })
-        .subscribe();
+        });
 
-      await waitForSubscribed(channel);
+      await openChannel(channel);
 
       await Promise.all(Array.from({ length: LOAD_MESSAGES }, async (_, i) => {
         sendTimes.set(i, performance.now());
@@ -780,7 +781,7 @@ async function runLoadBroadcastReplayTests(testUser: { email: string; password: 
 
   await sleep(RATE_LIMIT_PAUSE_MS);
   await test("broadcast replay throughput", async () => {
-    const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS });
+    const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS_REPLAY });
     try {
       await signInUser(supabase, testUser.email, testUser.password);
       const event = crypto.randomUUID();
@@ -797,8 +798,8 @@ async function runLoadBroadcastReplayTests(testUser: { email: string; password: 
         config: { private: true, broadcast: { replay: { since, limit: 25 } } },
       }).on("broadcast", { event }, () => {
         latencies.push(performance.now() - replayStart);
-      }).subscribe();
-      await waitForSubscribed(receiver);
+      });
+      await openChannel(receiver);
 
       await settle(() => latencies.length, LOAD_MESSAGES, LOAD_SETTLE_MS);
 
@@ -823,10 +824,9 @@ async function runBroadcastTests() {
 
       const channel = supabase
         .channel(topic, BROADCAST_CONFIG)
-        .on("broadcast", { event }, ({ payload }) => (result = payload))
-        .subscribe();
+        .on("broadcast", { event }, ({ payload }) => (result = payload));
 
-      const subscribeMs = await waitForSubscribed(channel);
+      const subscribeMs = await openChannel(channel);
       await channel.send({ type: "broadcast", event, payload: expectedPayload });
       const { latencyMs: eventMs } = await waitFor(() => result, "broadcast event");
 
@@ -847,10 +847,9 @@ async function runBroadcastTests() {
 
       const channel = supabase
         .channel(topic, BROADCAST_CONFIG)
-        .on("broadcast", { event }, ({ payload }) => (result = payload))
-        .subscribe();
+        .on("broadcast", { event }, ({ payload }) => (result = payload));
 
-      const subscribeMs = await waitForSubscribed(channel);
+      const subscribeMs = await openChannel(channel);
 
       const res = await fetch(`${PROJECT_URL}/realtime/v1/api/broadcast`, {
         method: "POST",
@@ -881,10 +880,9 @@ async function runPresenceTests(testUser: { email: string; password: string }) {
 
       const channel = supabase
         .channel(topic, { config: { broadcast: { self: true }, presence: { key } } })
-        .on("presence", { event: "join" }, (e) => (joinEvent = e))
-        .subscribe();
+        .on("presence", { event: "join" }, (e) => (joinEvent = e));
 
-      const subscribeMs = await waitForSubscribed(channel);
+      const subscribeMs = await openChannel(channel);
       const trackStart = performance.now();
       if (await channel.track({ message }, { timeout: 5000 }) === "timed out") throw new Error("track() timed out");
       const trackMs = performance.now() - trackStart;
@@ -911,10 +909,9 @@ async function runPresenceTests(testUser: { email: string; password: string }) {
 
       const channel = supabase
         .channel(topic, { config: { private: true, broadcast: { self: true }, presence: { key } } })
-        .on("presence", { event: "join" }, (e) => (joinEvent = e))
-        .subscribe();
+        .on("presence", { event: "join" }, (e) => (joinEvent = e));
 
-      const subscribeMs = await waitForSubscribed(channel);
+      const subscribeMs = await openChannel(channel);
       const trackStart = performance.now();
       if (await channel.track({ message }, { timeout: 5000 }) === "timed out") throw new Error("track() timed out");
       const trackMs = performance.now() - trackStart;
@@ -955,14 +952,8 @@ async function runAuthorizationTests(testUser: { email: string; password: string
     const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS });
     try {
       await signInUser(supabase, testUser.email, testUser.password);
-
-      let connected = false;
-      const channel = supabase
-        .channel("topic:" + crypto.randomUUID(), { config: { private: true } })
-        .subscribe((status: string) => { if (status === "SUBSCRIBED") connected = true; });
-
-      const subscribeMs = await waitForSubscribed(channel);
-      assert.strictEqual(connected, true);
+      const channel = supabase.channel("topic:" + crypto.randomUUID(), { config: { private: true } });
+      const subscribeMs = await openChannel(channel);
       return [{ label: "subscribe", value: subscribeMs, unit: "ms" }];
     } finally {
       await stopClient(supabase);
@@ -984,10 +975,9 @@ async function runBroadcastChangesTests(testUser: { email: string; password: str
 
       const channel = supabase
         .channel("topic:test", { config: { private: true } })
-        .on("broadcast", { event: "INSERT" }, (res) => (result = res))
-        .subscribe();
+        .on("broadcast", { event: "INSERT" }, (res) => (result = res));
 
-      const subscribeMs = await waitForSubscribed(channel);
+      const subscribeMs = await openChannel(channel);
       await supabase.from("broadcast_changes").insert({ value, id });
       const { latencyMs: eventMs } = await waitFor(() => result, "INSERT event");
 
@@ -1011,15 +1001,14 @@ async function runBroadcastChangesTests(testUser: { email: string; password: str
       const id = crypto.randomUUID();
       const originalValue = crypto.randomUUID();
       const updatedValue = crypto.randomUUID();
-      await supabase.from("broadcast_changes").insert({ value: originalValue, id });
       let result: any = null;
 
       const channel = supabase
         .channel("topic:test", { config: { private: true } })
-        .on("broadcast", { event: "UPDATE" }, (res) => (result = res))
-        .subscribe();
+        .on("broadcast", { event: "UPDATE" }, (res) => (result = res));
 
-      const subscribeMs = await waitForSubscribed(channel);
+      const subscribeMs = await openChannel(channel);
+      await supabase.from("broadcast_changes").insert({ value: originalValue, id });
       await supabase.from("broadcast_changes").update({ value: updatedValue }).eq("id", id);
       const { latencyMs: eventMs } = await waitFor(() => result, "UPDATE event");
 
@@ -1043,15 +1032,14 @@ async function runBroadcastChangesTests(testUser: { email: string; password: str
       await signInUser(supabase, testUser.email, testUser.password);
       const id = crypto.randomUUID();
       const value = crypto.randomUUID();
-      await supabase.from("broadcast_changes").insert({ value, id });
       let result: any = null;
 
       const channel = supabase
         .channel("topic:test", { config: { private: true } })
-        .on("broadcast", { event: "DELETE" }, (res) => (result = res))
-        .subscribe();
+        .on("broadcast", { event: "DELETE" }, (res) => (result = res));
 
-      const subscribeMs = await waitForSubscribed(channel);
+      const subscribeMs = await openChannel(channel);
+      await supabase.from("broadcast_changes").insert({ value, id });
       await supabase.from("broadcast_changes").delete().eq("id", id);
       const { latencyMs: eventMs } = await waitFor(() => result, "DELETE event");
 
@@ -1078,23 +1066,21 @@ async function runPostgresChangesTests(testUser: { email: string; password: stri
       await signInUser(supabase, testUser.email, testUser.password);
 
       let result: unknown = null;
-      const previousId = await executeInsert(supabase, "pg_changes");
-      await executeInsert(supabase, "dummy");
+      const uniqueValue = crypto.randomUUID();
 
       const channel = supabase
         .channel("topic:" + crypto.randomUUID(), BROADCAST_CONFIG)
         .on("postgres_changes",
-          { event: "INSERT", schema: "public", table: "pg_changes", filter: `id=eq.${previousId + 1}` },
-          (payload) => (result = payload))
-        .subscribe();
+          { event: "INSERT", schema: "public", table: "pg_changes", filter: `value=eq.${uniqueValue}` },
+          (payload) => (result = payload));
 
-      const { subscribeMs } = await waitForPostgresChannel(channel);
-      await executeInsert(supabase, "pg_changes");
+      const { subscribeMs } = await openPostgresChannel(channel);
+      await executeInsert(supabase, "pg_changes", uniqueValue);
       await executeInsert(supabase, "dummy");
       const { latencyMs: eventMs } = await waitFor(() => result, "INSERT event");
 
       assert.strictEqual(result.eventType, "INSERT");
-      assert.strictEqual(result.new.id, previousId + 1);
+      assert.strictEqual(result.new.value, uniqueValue);
       return [{ label: "subscribe", value: subscribeMs, unit: "ms" }, { label: "event", value: eventMs, unit: "ms" }];
     } finally {
       await stopClient(supabase);
@@ -1116,10 +1102,9 @@ async function runPostgresChangesTests(testUser: { email: string; password: stri
         .channel("topic:" + crypto.randomUUID(), BROADCAST_CONFIG)
         .on("postgres_changes",
           { event: "UPDATE", schema: "public", table: "pg_changes", filter: `id=eq.${mainId}` },
-          (payload) => (result = payload))
-        .subscribe();
+          (payload) => (result = payload));
 
-      const { subscribeMs } = await waitForPostgresChannel(channel);
+      const { subscribeMs } = await openPostgresChannel(channel);
       await Promise.all([
         executeUpdate(supabase, "pg_changes", mainId),
         executeUpdate(supabase, "pg_changes", fakeId),
@@ -1150,10 +1135,9 @@ async function runPostgresChangesTests(testUser: { email: string; password: stri
         .channel("topic:" + crypto.randomUUID(), BROADCAST_CONFIG)
         .on("postgres_changes",
           { event: "DELETE", schema: "public", table: "pg_changes", filter: `id=eq.${mainId}` },
-          (payload) => (result = payload))
-        .subscribe();
+          (payload) => (result = payload));
 
-      const { subscribeMs } = await waitForPostgresChannel(channel);
+      const { subscribeMs } = await openPostgresChannel(channel);
       await Promise.all([
         executeDelete(supabase, "pg_changes", mainId),
         executeDelete(supabase, "pg_changes", fakeId),
@@ -1176,21 +1160,20 @@ async function runPostgresChangesTests(testUser: { email: string; password: stri
       await signInUser(supabase, testUser.email, testUser.password);
       let insertResult: unknown = null, updateResult: unknown = null, deleteResult: unknown = null;
 
-      const insertId = await executeInsert(supabase, "pg_changes");
+      const insertValue = crypto.randomUUID();
       const updateId = await executeInsert(supabase, "pg_changes");
       const deleteId = await executeInsert(supabase, "pg_changes");
 
       const channel = supabase
         .channel("topic:" + crypto.randomUUID(), BROADCAST_CONFIG)
-        .on("postgres_changes", { event: "INSERT", schema: "public", table: "pg_changes", filter: `id=eq.${insertId + 3}` }, (p) => (insertResult = p))
+        .on("postgres_changes", { event: "INSERT", schema: "public", table: "pg_changes", filter: `value=eq.${insertValue}` }, (p) => (insertResult = p))
         .on("postgres_changes", { event: "UPDATE", schema: "public", table: "pg_changes", filter: `id=eq.${updateId}` }, (p) => (updateResult = p))
-        .on("postgres_changes", { event: "DELETE", schema: "public", table: "pg_changes", filter: `id=eq.${deleteId}` }, (p) => (deleteResult = p))
-        .subscribe();
+        .on("postgres_changes", { event: "DELETE", schema: "public", table: "pg_changes", filter: `id=eq.${deleteId}` }, (p) => (deleteResult = p));
 
-      const { subscribeMs } = await waitForPostgresChannel(channel);
+      const { subscribeMs } = await openPostgresChannel(channel);
 
       await Promise.all([
-        executeInsert(supabase, "pg_changes"),
+        executeInsert(supabase, "pg_changes", insertValue),
         executeUpdate(supabase, "pg_changes", updateId),
         executeDelete(supabase, "pg_changes", deleteId),
       ]);
@@ -1220,7 +1203,7 @@ async function runBroadcastReplayTests(testUser: { email: string; password: stri
   suite("broadcast replay");
 
   await test("replayed messages are delivered on join", async () => {
-    const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS });
+    const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS_REPLAY });
     try {
       await signInUser(supabase, testUser.email, testUser.password);
       const event = crypto.randomUUID();
@@ -1235,8 +1218,8 @@ async function runBroadcastReplayTests(testUser: { email: string; password: stri
       let result: any = null;
       const receiver = supabase.channel(topic, {
         config: { private: true, broadcast: { replay: { since, limit: 1 } } },
-      }).on("broadcast", { event }, (msg) => (result = msg.payload)).subscribe();
-      const subscribeMs = await waitForSubscribed(receiver);
+      }).on("broadcast", { event }, (msg) => (result = msg.payload));
+      const subscribeMs = await openChannel(receiver);
 
       const { latencyMs: replayMs } = await waitFor(() => result, "replayed broadcast event");
 
@@ -1248,7 +1231,7 @@ async function runBroadcastReplayTests(testUser: { email: string; password: stri
   });
 
   await test("replayed messages carry meta.replayed flag", async () => {
-    const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS });
+    const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS_REPLAY });
     try {
       await signInUser(supabase, testUser.email, testUser.password);
       const event = crypto.randomUUID();
@@ -1262,8 +1245,8 @@ async function runBroadcastReplayTests(testUser: { email: string; password: stri
       let receivedMeta: any = null;
       const receiver = supabase.channel(topic, {
         config: { private: true, broadcast: { replay: { since, limit: 1 } } },
-      }).on("broadcast", { event }, (msg) => (receivedMeta = msg.meta)).subscribe();
-      await waitForSubscribed(receiver);
+      }).on("broadcast", { event }, (msg) => (receivedMeta = msg.meta));
+      await openChannel(receiver);
 
       await waitFor(() => receivedMeta, "replayed broadcast meta");
 
@@ -1275,7 +1258,7 @@ async function runBroadcastReplayTests(testUser: { email: string; password: stri
   });
 
   await test("messages before since are not replayed", async () => {
-    const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS });
+    const supabase = createClient(PROJECT_URL, ANON_KEY, { realtime: REALTIME_OPTS_REPLAY });
     try {
       await signInUser(supabase, testUser.email, testUser.password);
       const event = crypto.randomUUID();
@@ -1291,8 +1274,8 @@ async function runBroadcastReplayTests(testUser: { email: string; password: stri
       let result: any = null;
       const receiver = supabase.channel(topic, {
         config: { private: true, broadcast: { replay: { since, limit: 25 } } },
-      }).on("broadcast", { event }, (msg) => (result = msg.payload)).subscribe();
-      await waitForSubscribed(receiver);
+      }).on("broadcast", { event }, (msg) => (result = msg.payload));
+      await openChannel(receiver);
 
       await sleep(500);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

* broadcast_changes UPDATE/DELETE — subscribe before touching the table; a broadcast event fired into an unestablished subscription was getting dropped server-side.
* postgres_changes INSERT filter — replaced id=eq.${previousId + 1} (breaks under concurrent inserts) with value=eq.${uniqueValue} using a pre-generated UUID.
* broadcast_replay APAC — raised the Phoenix channel join timeout to 10 s (REALTIME_OPTS_REPLAY) for replay channels, which carry an extra server-side message-lookup step that was consistently hitting the 5 s limit in high-latency regions.
* openChannel / openPostgresChannel helpers — subscribe + wait is now a single call used everywhere; .subscribe() can no longer appear loose in a chain before data operations. Also cleaned up the redundant connected variable in the auth test.
* Dependencies — supabase-js → 2.106.1, exporter-trace-otlp-http → 0.218.0, commander → 14.0.3.
