### PR TITLE
fix: remove replication_slot_lag_check feature flag

### DIFF
--- a/lib/realtime/tenants/replication_connection/watchdog.ex
+++ b/lib/realtime/tenants/replication_connection/watchdog.ex
@@ -12,7 +12,6 @@ defmodule Realtime.Tenants.ReplicationConnection.Watchdog do
   use GenServer
   use Realtime.Logs
   alias Realtime.Database
-  alias Realtime.FeatureFlags
   alias Realtime.Tenants.Connect
   alias Realtime.Tenants.ReplicationConnection
 
@@ -94,13 +93,9 @@ defmodule Realtime.Tenants.ReplicationConnection.Watchdog do
   defp check_slot_lag(%{replication_slot_name: nil}), do: :ok
 
   defp check_slot_lag(%{tenant_id: tenant_id, replication_slot_name: slot_name}) do
-    if FeatureFlags.enabled?("replication_slot_lag_check", tenant_id) do
-      case Connect.get_status(tenant_id) do
-        {:ok, conn} -> Database.check_replication_slot_lag(conn, slot_name)
-        {:error, reason} -> {:error, reason}
-      end
-    else
-      :ok
+    case Connect.get_status(tenant_id) do
+      {:ok, conn} -> Database.check_replication_slot_lag(conn, slot_name)
+      {:error, reason} -> {:error, reason}
     end
   end
 end

--- a/test/realtime/tenants/replication_connection/watchdog_test.exs
+++ b/test/realtime/tenants/replication_connection/watchdog_test.exs
@@ -6,7 +6,6 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
   import ExUnit.CaptureLog
 
   alias Realtime.Database
-  alias Realtime.FeatureFlags
   alias Realtime.Tenants.Connect
   alias Realtime.Tenants.ReplicationConnection.Watchdog
 
@@ -159,7 +158,6 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
     end
 
     test "continues when slot lag is below threshold", %{fake_pid: fake_pid} do
-      stub(FeatureFlags, :enabled?, fn _flag, _tenant -> true end)
       stub(Connect, :get_status, fn _tenant_id -> {:ok, :fake_conn} end)
       stub(Database, :check_replication_slot_lag, fn _conn, _slot -> :ok end)
 
@@ -173,7 +171,6 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
            replication_slot_name: "test_slot"}
         )
 
-      Mimic.allow(FeatureFlags, self(), watchdog_pid)
       Mimic.allow(Connect, self(), watchdog_pid)
       Mimic.allow(Database, self(), watchdog_pid)
 
@@ -183,7 +180,6 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
     end
 
     test "stops with :slot_lag_too_high when lag exceeds threshold", %{fake_pid: fake_pid} do
-      stub(FeatureFlags, :enabled?, fn _flag, _tenant -> true end)
       stub(Connect, :get_status, fn _tenant_id -> {:ok, :fake_conn} end)
       stub(Database, :check_replication_slot_lag, fn _conn, _slot -> {:error, :lag_too_high} end)
 
@@ -199,7 +195,6 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
                replication_slot_name: "test_slot"}
             )
 
-          Mimic.allow(FeatureFlags, self(), watchdog_pid)
           Mimic.allow(Connect, self(), watchdog_pid)
           Mimic.allow(Database, self(), watchdog_pid)
 
@@ -211,7 +206,6 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
     end
 
     test "continues when DB connection is unavailable (graceful degradation)", %{fake_pid: fake_pid} do
-      stub(FeatureFlags, :enabled?, fn _flag, _tenant -> true end)
       stub(Connect, :get_status, fn _tenant_id -> {:error, :tenant_database_unavailable} end)
 
       logs =
@@ -226,7 +220,6 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
                replication_slot_name: "test_slot"}
             )
 
-          Mimic.allow(FeatureFlags, self(), watchdog_pid)
           Mimic.allow(Connect, self(), watchdog_pid)
 
           Process.sleep(120)
@@ -235,27 +228,6 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
         end)
 
       assert logs =~ "ReplicationSlotLagCheckSkipped"
-    end
-
-    test "skips lag check when feature flag is disabled", %{fake_pid: fake_pid} do
-      stub(FeatureFlags, :enabled?, fn _flag, _tenant -> false end)
-      reject(&Database.check_replication_slot_lag/2)
-
-      watchdog_pid =
-        start_supervised!(
-          {Watchdog,
-           parent_pid: fake_pid,
-           tenant_id: "lag-test",
-           watchdog_interval: 50,
-           watchdog_timeout: 100,
-           replication_slot_name: "test_slot"}
-        )
-
-      Mimic.allow(FeatureFlags, self(), watchdog_pid)
-
-      Process.sleep(120)
-
-      assert Process.alive?(watchdog_pid)
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature has been a success so no need to keep it under a flag