### PR TITLE
feat: add mix openapi.export task

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -33,6 +33,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify committed OpenAPI snapshot exists
+        run: |
+          if ! git ls-files --error-unmatch priv/openapi.json > /dev/null 2>&1; then
+            echo "::error file=priv/openapi.json::OpenAPI snapshot is not yet committed to the repository."
+            echo ""
+            echo "Bootstrap one-time: run 'mix openapi.export' locally and commit"
+            echo "priv/openapi.json. Or download the 'openapi-spec' artifact from a"
+            echo "previous run on this PR and commit it."
+            exit 1
+          fi
+
       - uses: erlef/setup-beam@v1
         with:
           version-file: .tool-versions

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,74 @@
+name: OpenAPI
+
+on:
+  pull_request:
+    paths:
+      - "lib/realtime_web/**"
+      - "lib/mix/tasks/openapi.export.ex"
+      - "priv/openapi.json"
+      - "mix.exs"
+      - "mix.lock"
+      - ".github/workflows/openapi.yml"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openapi-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift_check:
+    name: Spec drift check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    env:
+      MIX_ENV: dev
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get
+
+      - name: Regenerate OpenAPI spec
+        run: mix openapi.export
+
+      - name: Fail if committed spec is out of date
+        run: |
+          if ! git diff --exit-code -- priv/openapi.json; then
+            echo ""
+            echo "::error::The OpenAPI spec is out of date."
+            echo "Run 'mix openapi.export' locally and commit priv/openapi.json."
+            exit 1
+          fi
+
+      - name: Upload spec artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: priv/openapi.json
+          if-no-files-found: warn

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -35,8 +35,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          version-file: .tool-versions
-          version-type: strict
+          otp-version: 27.x
+          elixir-version: 1.18.x
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -33,17 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify committed OpenAPI snapshot exists
-        run: |
-          if ! git ls-files --error-unmatch priv/openapi.json > /dev/null 2>&1; then
-            echo "::error file=priv/openapi.json::OpenAPI snapshot is not yet committed to the repository."
-            echo ""
-            echo "Bootstrap one-time: run 'mix openapi.export' locally and commit"
-            echo "priv/openapi.json. Or download the 'openapi-spec' artifact from a"
-            echo "previous run on this PR and commit it."
-            exit 1
-          fi
-
       - uses: erlef/setup-beam@v1
         with:
           version-file: .tool-versions
@@ -64,8 +53,31 @@ jobs:
           mix local.rebar --force
           mix deps.get
 
+      # Regenerate first and always upload the result, so the snapshot can be
+      # bootstrapped from the artifact on the very first run (before any
+      # priv/openapi.json is committed). The drift gates below still enforce
+      # that a committed, in-sync snapshot exists.
       - name: Regenerate OpenAPI spec
         run: mix openapi.export
+
+      - name: Upload spec artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: priv/openapi.json
+          if-no-files-found: warn
+
+      - name: Verify committed OpenAPI snapshot exists
+        run: |
+          if ! git ls-files --error-unmatch priv/openapi.json > /dev/null 2>&1; then
+            echo "::error file=priv/openapi.json::OpenAPI snapshot is not yet committed to the repository."
+            echo ""
+            echo "Bootstrap one-time: run 'mix openapi.export' locally and commit"
+            echo "priv/openapi.json. Or download the 'openapi-spec' artifact from"
+            echo "this run and commit it."
+            exit 1
+          fi
 
       - name: Fail if committed spec is out of date
         run: |
@@ -75,11 +87,3 @@ jobs:
             echo "Run 'mix openapi.export' locally and commit priv/openapi.json."
             exit 1
           fi
-
-      - name: Upload spec artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: openapi-spec
-          path: priv/openapi.json
-          if-no-files-found: warn

--- a/lib/mix/tasks/openapi.export.ex
+++ b/lib/mix/tasks/openapi.export.ex
@@ -20,7 +20,13 @@ defmodule Mix.Tasks.Openapi.Export do
 
     output = Keyword.get(opts, :output, @default_output)
 
-    Mix.Task.run("app.start")
+    # Compile and load the app metadata, but do NOT start it. The spec is
+    # derived from the router and compiled modules, so booting the supervision
+    # tree — which would require a database connection and the runtime secrets
+    # in config/runtime.exs — is unnecessary and would make the export fail in
+    # a bare CI environment.
+    Mix.Task.run("compile")
+    _ = Application.load(:realtime)
 
     spec =
       RealtimeWeb.ApiSpec.spec()

--- a/lib/mix/tasks/openapi.export.ex
+++ b/lib/mix/tasks/openapi.export.ex
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.Openapi.Export do
+  @moduledoc """
+  Exports the RealtimeWeb OpenAPI spec to a JSON file on disk.
+
+      mix openapi.export                       # writes priv/openapi.json
+      mix openapi.export --output path.json    # writes the given path
+
+  Used by CI to enforce that the committed spec stays in sync with the routes.
+  """
+  use Mix.Task
+
+  @shortdoc "Exports the RealtimeWeb OpenAPI spec to a JSON file"
+
+  @default_output "priv/openapi.json"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} =
+      OptionParser.parse(args, strict: [output: :string], aliases: [o: :output])
+
+    output = Keyword.get(opts, :output, @default_output)
+
+    Mix.Task.run("app.start")
+
+    spec =
+      RealtimeWeb.ApiSpec.spec()
+      |> Jason.encode!(pretty: true)
+
+    output |> Path.dirname() |> File.mkdir_p!()
+    File.write!(output, spec <> "\n")
+
+    Mix.shell().info("Wrote OpenAPI spec to #{output}")
+  end
+end

--- a/priv/openapi.json
+++ b/priv/openapi.json
@@ -1,0 +1,1197 @@
+{
+  "components": {
+    "responses": {},
+    "schemas": {
+      "BroadcastSingleBinaryParams": {
+        "description": "Binary payload - raw binary data",
+        "format": "binary",
+        "title": "BroadcastSingleBinaryParams",
+        "type": "string"
+      },
+      "BroadcastSingleJsonParams": {
+        "description": "JSON payload - any valid JSON object",
+        "example": {
+          "text": "hello world",
+          "user": "alice"
+        },
+        "title": "BroadcastSingleJsonParams",
+        "type": "object"
+      },
+      "EmptyResponse": {
+        "default": "",
+        "title": "EmptyResponse",
+        "type": "string"
+      },
+      "ErrorResponse": {
+        "properties": {
+          "error": {
+            "default": "error message",
+            "type": "string"
+          }
+        },
+        "title": "ErrorResponse",
+        "type": "object"
+      },
+      "NotFoundResponse": {
+        "properties": {
+          "error": {
+            "default": "not found",
+            "type": "string"
+          }
+        },
+        "title": "NotFoundResponse",
+        "type": "object"
+      },
+      "TenantBatchParams": {
+        "properties": {
+          "messages": {
+            "items": {
+              "properties": {
+                "event": {
+                  "description": "Name of the event being broadcast",
+                  "type": "string"
+                },
+                "payload": {
+                  "type": "object"
+                },
+                "private": {
+                  "type": "boolean"
+                },
+                "topic": {
+                  "description": "Note: libraries will prepend the channel name with 'realtime:' so if you use this endpoint directly you'll need to also prepend 'realtime:' so it's captured by clients properly",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "TenantBatchParams",
+        "type": "object"
+      },
+      "TenantHealthResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TenantHealthResponseValue"
+          }
+        },
+        "title": "TenantHealthResponse",
+        "type": "object"
+      },
+      "TenantHealthResponseValue": {
+        "example": {
+          "connected_cluster": 10,
+          "db_connected": true,
+          "healthy": true,
+          "replication_connected": true
+        },
+        "properties": {
+          "connected_cluster": {
+            "description": "The count of currently connected clients for a tenant on the Realtime cluster",
+            "type": "integer"
+          },
+          "db_connected": {
+            "description": "Indicates if Realtime has an active connection to the tenant database",
+            "type": "boolean"
+          },
+          "healthy": {
+            "description": "Tenant is healthy or not",
+            "type": "boolean"
+          },
+          "replication_connected": {
+            "description": "Indicates if Realtime has an active replication connection for broadcast changes",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "healthy",
+          "db_connected",
+          "replication_connected",
+          "connected_cluster"
+        ],
+        "title": "TenantHealthResponseValue",
+        "type": "object"
+      },
+      "TenantParams": {
+        "example": {
+          "tenant": {
+            "extensions": [
+              {
+                "settings": {
+                  "db_host": "db_host",
+                  "db_name": "postgres",
+                  "db_password": "password",
+                  "db_port": "5432",
+                  "db_user": "postgres",
+                  "poll_interval_ms": 100,
+                  "poll_max_changes": 100,
+                  "poll_max_record_bytes": 1048576,
+                  "publication": "supabase_realtime",
+                  "region": "us-west-1",
+                  "slot_name": "supabase_realtime_replication_slot"
+                },
+                "tenant_external_id": "tenant-1",
+                "type": "postgres_cdc_rls"
+              }
+            ],
+            "external_id": "tenant-1",
+            "jwt_secret": "4a218613-b539-4c52-adaa-64b14b25ee88",
+            "max_bytes_per_second": 1000,
+            "max_channels_per_client": 100,
+            "max_concurrent_users": 1000,
+            "max_events_per_second": 1000,
+            "max_joins_per_second": 1000,
+            "name": "First Tenant",
+            "postgres_cdc_default": "postgres_cdc_rls"
+          }
+        },
+        "properties": {
+          "tenant": {
+            "properties": {
+              "client_presence_window_ms": {
+                "description": "Client presence rate limit window in milliseconds (overrides environment default when set)",
+                "nullable": true,
+                "type": "number"
+              },
+              "extensions": {
+                "items": {
+                  "properties": {
+                    "settings": {
+                      "description": "Extension database configuration",
+                      "type": "object"
+                    },
+                    "tenant_external_id": {
+                      "description": "Tenant external ID",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Postgres CDC extension type",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "settings",
+                    "tenant_external_id"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "external_id": {
+                "description": "External ID",
+                "type": "string"
+              },
+              "jwt_jwks": {
+                "description": "JWKS for verifying JWTs",
+                "properties": {
+                  "keys": {
+                    "description": "Set of JWKs",
+                    "items": {
+                      "description": "JWK",
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "jwt_secret": {
+                "description": "JWT secret",
+                "type": "string"
+              },
+              "max_bytes_per_second": {
+                "description": "Maximum bytes per second",
+                "type": "number"
+              },
+              "max_channels_per_client": {
+                "description": "Maximum channels per WebSocket connection",
+                "type": "number"
+              },
+              "max_client_presence_events_per_window": {
+                "description": "Maximum client presence events (overrides environment default when set)",
+                "nullable": true,
+                "type": "number"
+              },
+              "max_concurrent_users": {
+                "description": "Maximum connected concurrent clients",
+                "type": "number"
+              },
+              "max_events_per_second": {
+                "description": "Maximum events, or messages, per second",
+                "type": "number"
+              },
+              "max_joins_per_second": {
+                "description": "Maximum channel joins per second",
+                "type": "number"
+              },
+              "max_payload_size_in_kb": {
+                "description": "Maximum payload size in KB",
+                "type": "number"
+              },
+              "max_presence_events_per_second": {
+                "description": "Maximum presence events per second",
+                "type": "number"
+              },
+              "name": {
+                "description": "Tenant name",
+                "type": "string"
+              },
+              "postgres_cdc_default": {
+                "description": "Default Postgres CDC extension",
+                "type": "string"
+              },
+              "presence_enabled": {
+                "description": "When true, presence is enabled for clients that do not explicitly opt in",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "external_id",
+              "jwt_secret"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "tenant"
+        ],
+        "title": "TenantParams",
+        "type": "object"
+      },
+      "TenantResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TenantResponseValue"
+          }
+        },
+        "title": "TenantResponse",
+        "type": "object"
+      },
+      "TenantResponseList": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TenantResponseValue"
+            },
+            "type": "array"
+          }
+        },
+        "title": "TenantResponseList",
+        "type": "object"
+      },
+      "TenantResponseValue": {
+        "example": {
+          "extensions": [
+            {
+              "inserted_at": "2023-01-01T00:00:00Z",
+              "settings": {
+                "db_host": "db_host",
+                "db_name": "postgres",
+                "db_password": "password",
+                "db_port": "5432",
+                "db_user": "postgres",
+                "poll_interval_ms": 100,
+                "poll_max_changes": 100,
+                "poll_max_record_bytes": 1048576,
+                "publication": "supabase_realtime",
+                "region": "us-west-1",
+                "slot_name": "supabase_realtime_replication_slot"
+              },
+              "tenant_external_id": "tenant-1",
+              "type": "postgres_cdc_rls",
+              "updated_at": "2023-01-01T00:00:00Z"
+            }
+          ],
+          "external_id": "tenant-1",
+          "id": "d4448862-666f-4af2-9966-78298e8af6bf",
+          "inserted_at": "2023-01-01T00:00:00Z",
+          "max_channels_per_client": 100,
+          "max_concurrent_users": 1000,
+          "max_events_per_second": 100,
+          "max_joins_per_second": 100,
+          "name": "First Tenant"
+        },
+        "properties": {
+          "client_presence_window_ms": {
+            "description": "Client presence rate limit window in milliseconds (overrides environment default when set)",
+            "nullable": true,
+            "type": "number"
+          },
+          "extensions": {
+            "items": {
+              "properties": {
+                "inserted_at": {
+                  "description": "Insert timestamp",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "settings": {
+                  "description": "Extension database configuration",
+                  "type": "object"
+                },
+                "tenant_external_id": {
+                  "description": "Tenant external ID",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Postgres CDC extension type",
+                  "type": "string"
+                },
+                "updated_at": {
+                  "description": "Update timestamp",
+                  "format": "date-time",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "settings",
+                "tenant_external_id"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "external_id": {
+            "description": "External ID",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID",
+            "type": "string"
+          },
+          "inserted_at": {
+            "description": "Insert timestamp",
+            "format": "date-time",
+            "type": "string"
+          },
+          "jwt_jwks": {
+            "description": "JWKS for verifying JWTs",
+            "properties": {
+              "keys": {
+                "description": "Set of JWKs",
+                "items": {
+                  "description": "JWK",
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "max_channels_per_client": {
+            "description": "Maximum channels per connected client",
+            "type": "number"
+          },
+          "max_client_presence_events_per_window": {
+            "description": "Maximum client presence events (overrides environment default when set)",
+            "nullable": true,
+            "type": "number"
+          },
+          "max_concurrent_users": {
+            "description": "Maximum connected concurrent clients",
+            "type": "number"
+          },
+          "max_events_per_second": {
+            "description": "Maximum number of events, or messages, that all connected clients are permitted to send",
+            "type": "number"
+          },
+          "max_joins_per_second": {
+            "description": "Maximum number of channel joins permitted for all connected clients",
+            "type": "number"
+          },
+          "name": {
+            "description": "Tenant name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "external_id",
+          "jwt_secret"
+        ],
+        "title": "TenantResponseValue",
+        "type": "object"
+      },
+      "TooManyRequestsResponse": {
+        "properties": {
+          "error": {
+            "properties": {
+              "messages": {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "title": "TooManyRequestsResponse",
+        "type": "object"
+      },
+      "UnauthorizedResponse": {
+        "properties": {
+          "error": {
+            "default": "unauthorized",
+            "type": "string"
+          }
+        },
+        "title": "UnauthorizedResponse",
+        "type": "object"
+      },
+      "UnprocessableEntityResponse": {
+        "properties": {
+          "error": {
+            "properties": {
+              "messages": {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "title": "UnprocessableEntityResponse",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "authorization": {
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "title": "realtime",
+    "version": "2.107.5"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/broadcast": {
+      "post": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.BroadcastController.broadcast",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantBatchParams"
+              }
+            }
+          },
+          "description": "Tenant Batch Params",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityResponse"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "summary": "Broadcasts a batch of messages",
+        "tags": []
+      }
+    },
+    "/api/broadcast/{topic}/events/{event}": {
+      "post": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.BroadcastSingleController.broadcast",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "example": "room:123",
+            "in": "path",
+            "name": "topic",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Event name for the broadcast",
+            "example": "message",
+            "in": "path",
+            "name": "event",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Whether this is a private broadcast (requires RLS authorization). Defaults to false.",
+            "example": false,
+            "in": "query",
+            "name": "private",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "text": "hello world",
+                "user": "alice"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/BroadcastSingleJsonParams"
+              }
+            },
+            "application/octet-stream": {
+              "schema": {
+                "$ref": "#/components/schemas/BroadcastSingleBinaryParams"
+              }
+            }
+          },
+          "description": "Broadcast message payload. Supports both JSON and binary formats.",
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnprocessableEntityResponse"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyRequestsResponse"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "summary": "Broadcasts a single message",
+        "tags": []
+      }
+    },
+    "/api/tenants": {
+      "get": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.index",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponseList"
+                }
+              }
+            },
+            "description": "Tenant List Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          }
+        },
+        "summary": "List tenants",
+        "tags": []
+      },
+      "post": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.create",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantParams"
+              }
+            }
+          },
+          "description": "Tenant Params",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponse"
+                }
+              }
+            },
+            "description": "Tenant Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          }
+        },
+        "summary": "Create or update tenant",
+        "tags": []
+      }
+    },
+    "/api/tenants/{tenant_id}": {
+      "delete": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.delete",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant ID",
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Delete tenant",
+        "tags": []
+      },
+      "get": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.show",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant ID",
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponse"
+                }
+              }
+            },
+            "description": "Tenant Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Fetch tenant",
+        "tags": []
+      },
+      "patch": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.update (2)",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant ID",
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantParams"
+              }
+            }
+          },
+          "description": "Tenant Params",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponse"
+                }
+              }
+            },
+            "description": "Tenant Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          }
+        },
+        "summary": "Create or update tenant",
+        "tags": []
+      },
+      "put": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.update",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant ID",
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantParams"
+              }
+            }
+          },
+          "description": "Tenant Params",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantResponse"
+                }
+              }
+            },
+            "description": "Tenant Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          }
+        },
+        "summary": "Create or update tenant",
+        "tags": []
+      }
+    },
+    "/api/tenants/{tenant_id}/health": {
+      "get": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.health",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant ID",
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantHealthResponse"
+                }
+              }
+            },
+            "description": "Tenant Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Tenant health",
+        "tags": []
+      }
+    },
+    "/api/tenants/{tenant_id}/reload": {
+      "post": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.reload",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant ID",
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Reload tenant",
+        "tags": []
+      }
+    },
+    "/api/tenants/{tenant_id}/shutdown": {
+      "post": {
+        "callbacks": {},
+        "operationId": "RealtimeWeb.TenantController.shutdown",
+        "parameters": [
+          {
+            "description": "",
+            "example": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2ODAxNjIxNTR9.U9orU6YYqXAtpF8uAiw6MS553tm4XxRzxOhz2IwDhpY",
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tenant ID",
+            "in": "path",
+            "name": "tenant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Empty Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Shutdowns the Connect module for a tenant",
+        "tags": []
+      }
+    }
+  },
+  "security": [],
+  "servers": [
+    {
+      "url": "http://{tenant}.localhost:4000/",
+      "variables": {
+        "tenant": {
+          "default": "tenant"
+        }
+      }
+    }
+  ],
+  "tags": []
+}


### PR DESCRIPTION
### What this is
- A `mix openapi.export` task that materializes the OpenApiSpex-generated REST spec to `priv/openapi.json`, plus a PR-time drift gate.

### What maintainers need to do
- Bootstrap once: `mix openapi.export`, commit `priv/openapi.json`.
- On future PRs touching `lib/realtime_web/`: re-run the task and commit the updated snapshot.

### What it's used for
- Today the REST management spec only exists at runtime via `/api/openapi`. Committing a snapshot makes it a static, versioned artifact SDKs and type generators can pin to.
- Scope is REST only. The channel protocol (broadcast, presence, postgres_changes) is intentionally out of scope — would need AsyncAPI separately.

### What was added and why
- `lib/mix/tasks/openapi.export.ex` — task that writes `RealtimeWeb.ApiSpec.spec()` JSON to `priv/openapi.json` (or `--output PATH`).
- `.github/workflows/openapi.yml` — re-runs the task on PRs touching `lib/realtime_web/` and fails on `git diff` if the committed snapshot is stale. Uploads the regenerated spec as an artifact.
