### PR TITLE
fix: defer replication connection setup on Connect start

### DIFF
--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -314,8 +314,13 @@ defmodule Realtime.Tenants.Connect do
 
   def handle_continue(:start_replication, state) do
     case start_replication_connection(state) do
-      {:ok, state} -> {:noreply, state, {:continue, :setup_connected_user_events}}
-      {:error, _error} -> {:stop, :shutdown, state}
+      {:ok, state} ->
+        {:noreply, state, {:continue, :setup_connected_user_events}}
+
+      {:error, error} ->
+        log_error("StartReplicationFailed", error)
+        state = open_replication_recovery(state)
+        {:noreply, state, {:continue, :setup_connected_user_events}}
     end
   end
 
@@ -391,25 +396,10 @@ defmodule Realtime.Tenants.Connect do
   # Handle replication connection termination
   def handle_info(
         {:DOWN, replication_connection_reference, _, _, _},
-        %{replication_connection_reference: replication_connection_reference, tenant_id: tenant_id} = state
+        %{replication_connection_reference: replication_connection_reference} = state
       ) do
-    %{backoff: backoff} = state
     log_warning("ReplicationConnectionDown", "Replication connection has been terminated, recovery window opened")
-    update_syn_replication_conn(tenant_id, nil)
-    {timeout, backoff} = Backoff.backoff(backoff)
-    Process.send_after(self(), :recover_replication_connection, timeout)
-
-    recovery_started_at = state.replication_recovery_started_at || System.monotonic_time(:millisecond)
-
-    state = %{
-      state
-      | replication_connection_pid: nil,
-        replication_connection_reference: nil,
-        backoff: backoff,
-        replication_recovery_started_at: recovery_started_at
-    }
-
-    {:noreply, state}
+    {:noreply, open_replication_recovery(state)}
   end
 
   @replication_connection_query "SELECT 1 from pg_stat_activity where application_name='realtime_replication_connection'"
@@ -505,6 +495,20 @@ defmodule Realtime.Tenants.Connect do
   defp tenant_suspended?(_), do: :ok
 
   defp rebalance_check_interval_in_ms(), do: Application.fetch_env!(:realtime, :rebalance_check_interval_in_ms)
+
+  defp open_replication_recovery(%{tenant_id: tenant_id} = state) do
+    update_syn_replication_conn(tenant_id, nil)
+    recovery_started_at = state.replication_recovery_started_at || System.monotonic_time(:millisecond)
+
+    state = %{
+      state
+      | replication_connection_pid: nil,
+        replication_connection_reference: nil,
+        replication_recovery_started_at: recovery_started_at
+    }
+
+    schedule_replication_retry(state)
+  end
 
   defp schedule_replication_retry(%{backoff: backoff} = state) do
     {timeout, backoff} = Backoff.backoff(backoff)

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -520,7 +520,7 @@ defmodule Realtime.Tenants.ConnectTest do
       assert replication_conn_before != replication_conn_after
     end
 
-    test "handles replication connection timeout by logging and shutting down", %{tenant: tenant} do
+    test "defers and keeps the tenant alive when replication connection times out", %{tenant: tenant} do
       expect(ReplicationConnection, :start, fn _tenant, _pid ->
         {:error, :replication_connection_timeout}
       end)
@@ -528,7 +528,9 @@ defmodule Realtime.Tenants.ConnectTest do
       log =
         capture_log(fn ->
           assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-          assert_process_down(db_conn)
+          pid = Connect.whereis(tenant.external_id)
+          assert wait_until(fn -> :sys.get_state(pid).replication_recovery_started_at != nil end)
+          refute_process_down(db_conn)
         end)
 
       assert log =~ "ReplicationConnectionTimeout"
@@ -573,7 +575,9 @@ defmodule Realtime.Tenants.ConnectTest do
       log =
         capture_log(fn ->
           assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-          assert_process_down(db_conn)
+          pid = Connect.whereis(tenant.external_id)
+          assert wait_until(fn -> :sys.get_state(pid).replication_recovery_started_at != nil end)
+          refute_process_down(db_conn)
         end)
 
       assert log =~ "ReplicationMaxWalSendersReached"
@@ -798,6 +802,41 @@ defmodule Realtime.Tenants.ConnectTest do
 
       Connect.shutdown(tenant.external_id)
     end
+
+    test "defers and recovers instead of terminating when slot is in use at startup", %{tenant: tenant} do
+      {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
+      slot_name = ReplicationConnection.replication_slot_name("realtime", "messages")
+
+      # Simulate a previous replication session still holding the slot during a
+      # restart/rebalance race so the initial replication start fails.
+      Postgrex.query!(db_conn, "SELECT pg_create_logical_replication_slot($1, 'test_decoding')", [slot_name])
+
+      log =
+        capture_log(fn ->
+          assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
+          pid = Connect.whereis(tenant.external_id)
+          assert wait_until(fn -> :sys.get_state(pid).replication_recovery_started_at != nil end)
+        end)
+
+      pid = Connect.whereis(tenant.external_id)
+      assert is_pid(pid)
+      assert log =~ "StartReplicationFailed"
+
+      # Connect stays alive with the recovery window open instead of shutting down.
+      refute_process_down(pid)
+      state = :sys.get_state(pid)
+      assert state.replication_connection_pid == nil
+      assert state.replication_recovery_started_at != nil
+
+      # Free the slot; the scheduled retry should reconnect on its own and clear
+      # the recovery window.
+      Postgrex.query!(db_conn, "SELECT pg_drop_replication_slot($1)", [slot_name])
+
+      assert {:ok, _} = assert_replication_status(tenant.external_id)
+      assert :sys.get_state(pid).replication_recovery_started_at == nil
+
+      Connect.shutdown(tenant.external_id)
+    end
   end
 
   describe "get_status/1 degraded state" do
@@ -877,6 +916,18 @@ defmodule Realtime.Tenants.ConnectTest do
       _ ->
         Process.sleep(500)
         assert_pid(call, attempts - 1)
+    end
+  end
+
+  defp wait_until(fun, attempts \\ 50)
+  defp wait_until(_fun, 0), do: false
+
+  defp wait_until(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(50)
+      wait_until(fun, attempts - 1)
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

We already have a nice backoff strategy to set up the Replication process. It works nice when the replication fails after Connect is established but we should do the same when ReplicationConnection is first started.