### PR TITLE
fix: create messages partitions on tenant health check

### DIFF
--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -90,7 +90,6 @@ defmodule Realtime.Database do
   @doc """
   Checks if the Tenant CDC extension information is properly configured and that we're able to query against the tenant database.
   """
-
   @spec check_tenant_connection(Tenant.t() | nil) :: {:error, atom()} | {:ok, pid(), non_neg_integer()}
   def check_tenant_connection(nil), do: {:error, :tenant_not_found}
 

--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -79,9 +79,10 @@ defmodule Realtime.Tenants do
       nil ->
         {:error, :tenant_not_found}
 
-      {:ok, _health_conn} ->
+      {:ok, health_conn} ->
         connected_cluster = UsersCounter.tenant_users(external_id)
         replication_connected = replication_connected?(external_id)
+        Migrations.create_partitions(health_conn)
 
         {:ok,
          %{
@@ -95,17 +96,22 @@ defmodule Realtime.Tenants do
 
       connected_cluster when is_integer(connected_cluster) ->
         tenant = Cache.get_tenant_by_external_id(external_id)
-        result? = Migrations.run_migrations(tenant)
 
         {:ok,
          %{
-           healthy: result? == :ok || result? == :noop,
+           healthy: provision_tenant(tenant) == :ok,
            db_connected: false,
            replication_connected: false,
            connected_cluster: connected_cluster,
            region: region,
            node: node
          }}
+    end
+  end
+
+  defp provision_tenant(tenant) do
+    with res when res in [:ok, :noop] <- Migrations.run_migrations(tenant) do
+      Migrations.create_partitions(tenant)
     end
   end
 

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -283,8 +283,24 @@ defmodule Realtime.Tenants.Migrations do
   defp error_code(_), do: :other
 
   @doc """
-  Create partitions against tenant db connection
+  Create partitions for `realtime.messages` on tenant database.
+
+  Accepts either an existing tenant database connection or a `Tenant`.
   """
+  @spec create_partitions(Tenant.t()) :: :ok | {:error, term()}
+  def create_partitions(%Tenant{} = tenant) do
+    case Database.connect(tenant, "realtime_health_check") do
+      {:ok, conn} ->
+        result = create_partitions(conn)
+        GenServer.stop(conn)
+        result
+
+      {:error, error} ->
+        log_error("PartitionCreationFailed", error)
+        {:error, error}
+    end
+  end
+
   @spec create_partitions(pid()) :: :ok
   def create_partitions(db_conn_pid) do
     Logger.info("Creating partitions for realtime.messages")

--- a/priv/repo/tenant_db_baseline.json
+++ b/priv/repo/tenant_db_baseline.json
@@ -13178,22 +13178,22 @@
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.binary_payload",
-      "deptype": "a"
+      "deptype": "n"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.binary_payload",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
-      "referenced_stable_id": "column:realtime.messages.payload",
       "deptype": "a"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.payload",
       "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
+      "referenced_stable_id": "column:realtime.messages.payload",
+      "deptype": "a"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_pkey",
@@ -15943,12 +15943,12 @@
     {
       "dependent_stable_id": "publication:supabase_realtime",
       "referenced_stable_id": "table:public.test_tenant",
-      "deptype": "a"
+      "deptype": "n"
     },
     {
       "dependent_stable_id": "publication:supabase_realtime",
       "referenced_stable_id": "table:public.test_tenant",
-      "deptype": "n"
+      "deptype": "a"
     },
     {
       "dependent_stable_id": "rule:extensions.pg_stat_statements_info.\"_RETURN\"",
@@ -16356,22 +16356,22 @@
       "deptype": "n"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16857",
+      "dependent_stable_id": "unknown:pg_class.16853",
       "referenced_stable_id": "column:realtime.messages.extension",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16857",
+      "dependent_stable_id": "unknown:pg_class.16853",
       "referenced_stable_id": "column:realtime.messages.inserted_at",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16857",
+      "dependent_stable_id": "unknown:pg_class.16853",
       "referenced_stable_id": "column:realtime.messages.private",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16857",
+      "dependent_stable_id": "unknown:pg_class.16853",
       "referenced_stable_id": "column:realtime.messages.topic",
       "deptype": "a"
     },

--- a/priv/repo/tenant_db_baseline.json
+++ b/priv/repo/tenant_db_baseline.json
@@ -13178,22 +13178,22 @@
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.binary_payload",
-      "deptype": "n"
+      "deptype": "a"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.binary_payload",
-      "deptype": "a"
-    },
-    {
-      "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
-      "referenced_stable_id": "column:realtime.messages.payload",
       "deptype": "n"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.payload",
       "deptype": "a"
+    },
+    {
+      "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
+      "referenced_stable_id": "column:realtime.messages.payload",
+      "deptype": "n"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_pkey",
@@ -15943,12 +15943,12 @@
     {
       "dependent_stable_id": "publication:supabase_realtime",
       "referenced_stable_id": "table:public.test_tenant",
-      "deptype": "n"
+      "deptype": "a"
     },
     {
       "dependent_stable_id": "publication:supabase_realtime",
       "referenced_stable_id": "table:public.test_tenant",
-      "deptype": "a"
+      "deptype": "n"
     },
     {
       "dependent_stable_id": "rule:extensions.pg_stat_statements_info.\"_RETURN\"",
@@ -16356,22 +16356,22 @@
       "deptype": "n"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16853",
+      "dependent_stable_id": "unknown:pg_class.16857",
       "referenced_stable_id": "column:realtime.messages.extension",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16853",
+      "dependent_stable_id": "unknown:pg_class.16857",
       "referenced_stable_id": "column:realtime.messages.inserted_at",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16853",
+      "dependent_stable_id": "unknown:pg_class.16857",
       "referenced_stable_id": "column:realtime.messages.private",
       "deptype": "a"
     },
     {
-      "dependent_stable_id": "unknown:pg_class.16853",
+      "dependent_stable_id": "unknown:pg_class.16857",
       "referenced_stable_id": "column:realtime.messages.topic",
       "deptype": "a"
     },

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -572,7 +572,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       assert response(conn, 403) == ""
     end
 
-    test "runs migrations", %{conn: conn} do
+    test "runs migrations and creates partitions", %{conn: conn} do
       tenant = Containers.checkout_tenant(run_migrations: false)
 
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
@@ -583,6 +583,15 @@ defmodule RealtimeWeb.TenantControllerTest do
       Process.sleep(1000)
 
       assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
+
+      assert {:ok, %{rows: [[partitions]]}} =
+               Postgrex.query(
+                 db_conn,
+                 "SELECT count(*) FROM pg_inherits WHERE inhparent = 'realtime.messages'::regclass",
+                 []
+               )
+
+      assert partitions > 0
 
       assert %{"healthy" => true, "db_connected" => false, "replication_connected" => false, "connected_cluster" => 0} =
                data


### PR DESCRIPTION
Prevents `ErrorSendingBroadcastMessage` on `realtime.send` before a subscription is established.

Fixes REAL-848