### PR TITLE
fix: revert partition creation on health check

### DIFF
--- a/lib/realtime/tenants.ex
+++ b/lib/realtime/tenants.ex
@@ -3,7 +3,7 @@ defmodule Realtime.Tenants do
   Everything to do with Tenants.
   """
 
-  require Logger
+  use Realtime.Logs
 
   alias Realtime.Api.Tenant
   alias Realtime.Database
@@ -79,10 +79,9 @@ defmodule Realtime.Tenants do
       nil ->
         {:error, :tenant_not_found}
 
-      {:ok, health_conn} ->
+      {:ok, _health_conn} ->
         connected_cluster = UsersCounter.tenant_users(external_id)
         replication_connected = replication_connected?(external_id)
-        Migrations.create_partitions(health_conn)
 
         {:ok,
          %{
@@ -96,10 +95,11 @@ defmodule Realtime.Tenants do
 
       connected_cluster when is_integer(connected_cluster) ->
         tenant = Cache.get_tenant_by_external_id(external_id)
+        migrations = Migrations.run_migrations(tenant)
 
         {:ok,
          %{
-           healthy: provision_tenant(tenant) == :ok,
+           healthy: migrations in [:ok, :noop],
            db_connected: false,
            replication_connected: false,
            connected_cluster: connected_cluster,
@@ -109,10 +109,39 @@ defmodule Realtime.Tenants do
     end
   end
 
-  defp provision_tenant(tenant) do
-    with res when res in [:ok, :noop] <- Migrations.run_migrations(tenant) do
-      Migrations.create_partitions(tenant)
-    end
+  @doc """
+  Creates the `realtime.messages` partitions for the days around today.
+  """
+  @spec create_messages_partitions(pid()) :: :ok
+  def create_messages_partitions(db_conn_pid) do
+    Logger.info("Creating partitions for realtime.messages")
+    today = Date.utc_today()
+    yesterday = Date.add(today, -1)
+    future = Date.add(today, 3)
+
+    dates = Date.range(yesterday, future)
+
+    Enum.each(dates, fn date ->
+      partition_name = "messages_#{date |> Date.to_iso8601() |> String.replace("-", "_")}"
+      start_timestamp = Date.to_string(date)
+      end_timestamp = Date.to_string(Date.add(date, 1))
+
+      Database.transaction(db_conn_pid, fn conn ->
+        query = """
+        CREATE TABLE IF NOT EXISTS realtime.#{partition_name}
+        PARTITION OF realtime.messages
+        FOR VALUES FROM ('#{start_timestamp}') TO ('#{end_timestamp}');
+        """
+
+        case Postgrex.query(conn, query, []) do
+          {:ok, _} -> Logger.debug("Partition #{partition_name} created")
+          {:error, %Postgrex.Error{postgres: %{code: :duplicate_table}}} -> :ok
+          {:error, error} -> log_error("PartitionCreationFailed", error)
+        end
+      end)
+    end)
+
+    :ok
   end
 
   defp replication_connected?(external_id) do

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -280,7 +280,7 @@ defmodule Realtime.Tenants.Connect do
 
     case Piper.run(pipes, state) do
       {:ok, acc} ->
-        {:noreply, acc, {:continue, :run_migrations}}
+        {:noreply, acc, {:continue, :provision_tenant}}
 
       {:error, :tenant_not_found} ->
         {:stop, {:shutdown, :tenant_not_found}, state}
@@ -294,12 +294,12 @@ defmodule Realtime.Tenants.Connect do
     end
   end
 
-  def handle_continue(:run_migrations, state) do
+  def handle_continue(:provision_tenant, state) do
     %{tenant: tenant, db_conn_pid: db_conn_pid} = state
-    Logger.warning("Tenant #{tenant.external_id} is initializing: #{inspect(node())}")
+    Logger.info("Tenant #{tenant.external_id} is initializing: #{inspect(node())}")
 
     with res when res in [:ok, :noop] <- Migrations.run_migrations(tenant),
-         :ok <- Migrations.create_partitions(db_conn_pid) do
+         :ok <- Tenants.create_messages_partitions(db_conn_pid) do
       {:noreply, state, {:continue, :start_replication}}
     else
       error ->

--- a/lib/realtime/tenants/janitor/maintenance_task.ex
+++ b/lib/realtime/tenants/janitor/maintenance_task.ex
@@ -1,8 +1,10 @@
 defmodule Realtime.Tenants.Janitor.MaintenanceTask do
   @moduledoc """
-  Perform maintenance on the messages table.
-  * Delete old messages
-  * Create new partitions
+  Perform maintenance on tenant's database:
+
+    - Delete old messages
+    - Create new partitions
+
   """
 
   @spec run(String.t()) :: :ok | {:error, any}
@@ -10,7 +12,7 @@ defmodule Realtime.Tenants.Janitor.MaintenanceTask do
     with %Realtime.Api.Tenant{} = tenant <- Realtime.Tenants.Cache.get_tenant_by_external_id(tenant_external_id),
          {:ok, conn} <- Realtime.Database.connect(tenant, "realtime_janitor"),
          :ok <- Realtime.Messages.delete_old_messages(conn),
-         :ok <- Realtime.Tenants.Migrations.create_partitions(conn) do
+         :ok <- Realtime.Tenants.create_messages_partitions(conn) do
       GenServer.stop(conn)
       :ok
     end

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -174,6 +174,8 @@ defmodule Realtime.Tenants.Migrations do
           settings: map()
         }
 
+  def migrations(), do: @migrations
+
   @doc """
   Run migrations for the given tenant.
   """
@@ -281,57 +283,4 @@ defmodule Realtime.Tenants.Migrations do
   defp error_code(%Postgrex.Error{postgres: %{code: code}}), do: code
   defp error_code(%DBConnection.ConnectionError{}), do: :connection_error
   defp error_code(_), do: :other
-
-  @doc """
-  Create partitions for `realtime.messages` on tenant database.
-
-  Accepts either an existing tenant database connection or a `Tenant`.
-  """
-  @spec create_partitions(Tenant.t()) :: :ok | {:error, term()}
-  def create_partitions(%Tenant{} = tenant) do
-    case Database.connect(tenant, "realtime_health_check") do
-      {:ok, conn} ->
-        result = create_partitions(conn)
-        GenServer.stop(conn)
-        result
-
-      {:error, error} ->
-        log_error("PartitionCreationFailed", error)
-        {:error, error}
-    end
-  end
-
-  @spec create_partitions(pid()) :: :ok
-  def create_partitions(db_conn_pid) do
-    Logger.info("Creating partitions for realtime.messages")
-    today = Date.utc_today()
-    yesterday = Date.add(today, -1)
-    future = Date.add(today, 3)
-
-    dates = Date.range(yesterday, future)
-
-    Enum.each(dates, fn date ->
-      partition_name = "messages_#{date |> Date.to_iso8601() |> String.replace("-", "_")}"
-      start_timestamp = Date.to_string(date)
-      end_timestamp = Date.to_string(Date.add(date, 1))
-
-      Database.transaction(db_conn_pid, fn conn ->
-        query = """
-        CREATE TABLE IF NOT EXISTS realtime.#{partition_name}
-        PARTITION OF realtime.messages
-        FOR VALUES FROM ('#{start_timestamp}') TO ('#{end_timestamp}');
-        """
-
-        case Postgrex.query(conn, query, []) do
-          {:ok, _} -> Logger.debug("Partition #{partition_name} created")
-          {:error, %Postgrex.Error{postgres: %{code: :duplicate_table}}} -> :ok
-          {:error, error} -> log_error("PartitionCreationFailed", error)
-        end
-      end)
-    end)
-
-    :ok
-  end
-
-  def migrations(), do: @migrations
 end

--- a/priv/repo/tenant_db_baseline.json
+++ b/priv/repo/tenant_db_baseline.json
@@ -3204,22 +3204,22 @@
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.binary_payload",
-      "deptype": "a"
+      "deptype": "n"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.binary_payload",
-      "deptype": "n"
-    },
-    {
-      "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
-      "referenced_stable_id": "column:realtime.messages.payload",
       "deptype": "a"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.payload",
       "deptype": "n"
+    },
+    {
+      "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
+      "referenced_stable_id": "column:realtime.messages.payload",
+      "deptype": "a"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_pkey",

--- a/priv/repo/tenant_db_baseline.json
+++ b/priv/repo/tenant_db_baseline.json
@@ -3204,22 +3204,22 @@
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.binary_payload",
-      "deptype": "n"
+      "deptype": "a"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.binary_payload",
-      "deptype": "a"
-    },
-    {
-      "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
-      "referenced_stable_id": "column:realtime.messages.payload",
       "deptype": "n"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
       "referenced_stable_id": "column:realtime.messages.payload",
       "deptype": "a"
+    },
+    {
+      "dependent_stable_id": "constraint:realtime.messages.messages_payload_exclusive",
+      "referenced_stable_id": "column:realtime.messages.payload",
+      "deptype": "n"
     },
     {
       "dependent_stable_id": "constraint:realtime.messages.messages_pkey",

--- a/test/realtime/tenants/authorization_remote_test.exs
+++ b/test/realtime/tenants/authorization_remote_test.exs
@@ -244,7 +244,7 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
         role: claims.role
       })
 
-    Realtime.Tenants.Migrations.create_partitions(local_db_conn)
+    Realtime.Tenants.create_messages_partitions(local_db_conn)
     create_rls_policies(local_db_conn, context.policies, %{topic: topic})
 
     {:ok, node} = Clustered.start()

--- a/test/realtime/tenants/janitor/maintenance_task_test.exs
+++ b/test/realtime/tenants/janitor/maintenance_task_test.exs
@@ -14,37 +14,61 @@ defmodule Realtime.Tenants.Janitor.MaintenanceTaskTest do
     %{tenant: tenant}
   end
 
-  test "cleans messages older than 72 hours and creates partitions", %{tenant: tenant} do
-    {:ok, conn} = Database.connect(tenant, "realtime_test", :stop)
+  describe "run/1" do
+    setup %{tenant: tenant} do
+      {:ok, conn} = Database.connect(tenant, "realtime_test", :stop)
 
-    utc_now = NaiveDateTime.utc_now()
-    limit = NaiveDateTime.add(utc_now, -72, :hour)
+      date_start = Date.utc_today() |> Date.add(-10)
+      date_end = Date.utc_today()
+      create_messages_partitions(conn, date_start, date_end)
 
-    date_start = Date.utc_today() |> Date.add(-10)
-    date_end = Date.utc_today()
-    create_messages_partitions(conn, date_start, date_end)
+      %{conn: conn}
+    end
 
-    messages =
-      for days <- -5..0 do
-        inserted_at = NaiveDateTime.add(utc_now, days, :day)
-        message_fixture(tenant, %{inserted_at: inserted_at})
-      end
-      |> MapSet.new()
+    test "cleans messages older than 72 hours", %{tenant: tenant, conn: conn} do
+      utc_now = NaiveDateTime.utc_now()
+      limit = NaiveDateTime.add(utc_now, -72, :hour)
 
-    to_keep =
-      messages
-      |> Enum.reject(&(NaiveDateTime.compare(NaiveDateTime.beginning_of_day(limit), &1.inserted_at) == :gt))
-      |> MapSet.new()
+      messages =
+        for days <- -5..0 do
+          inserted_at = NaiveDateTime.add(utc_now, days, :day)
+          message_fixture(tenant, %{inserted_at: inserted_at})
+        end
+        |> MapSet.new()
 
-    assert MaintenanceTask.run(tenant.external_id) == :ok
+      to_keep =
+        messages
+        |> Enum.reject(&(NaiveDateTime.compare(NaiveDateTime.beginning_of_day(limit), &1.inserted_at) == :gt))
+        |> MapSet.new()
 
-    {:ok, res} = Repo.all(conn, from(m in Message), Message)
+      assert MaintenanceTask.run(tenant.external_id) == :ok
 
-    verify_partitions(conn)
+      {:ok, res} = Repo.all(conn, from(m in Message), Message)
+      current = MapSet.new(res)
 
-    current = MapSet.new(res)
+      assert MapSet.difference(current, to_keep) |> MapSet.size() == 0
+    end
 
-    assert MapSet.difference(current, to_keep) |> MapSet.size() == 0
+    test "creates the current messages partitions and drops the old ones", %{tenant: tenant, conn: conn} do
+      assert MaintenanceTask.run(tenant.external_id) == :ok
+
+      today = Date.utc_today()
+      dates = Date.range(Date.add(today, -3), Date.add(today, 3))
+
+      %{rows: rows} =
+        Postgrex.query!(
+          conn,
+          "SELECT tablename from pg_catalog.pg_tables where schemaname = 'realtime' and tablename like 'messages_%'",
+          []
+        )
+
+      partitions = MapSet.new(rows, fn [name] -> name end)
+
+      expected_names =
+        MapSet.new(dates, fn date -> "messages_#{date |> Date.to_iso8601() |> String.replace("-", "_")}" end)
+
+      assert MapSet.equal?(partitions, expected_names)
+    end
   end
 
   test "exits if fails to remove old messages" do
@@ -81,26 +105,5 @@ defmodule Realtime.Tenants.Janitor.MaintenanceTaskTest do
     ref = t.ref
     assert_receive {:EXIT, ^pid, :killed}
     assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
-  end
-
-  defp verify_partitions(conn) do
-    today = Date.utc_today()
-    yesterday = Date.add(today, -3)
-    future = Date.add(today, 3)
-    dates = Date.range(yesterday, future)
-
-    %{rows: rows} =
-      Postgrex.query!(
-        conn,
-        "SELECT tablename from pg_catalog.pg_tables where schemaname = 'realtime' and tablename like 'messages_%'",
-        []
-      )
-
-    partitions = MapSet.new(rows, fn [name] -> name end)
-
-    expected_names =
-      MapSet.new(dates, fn date -> "messages_#{date |> Date.to_iso8601() |> String.replace("-", "_")}" end)
-
-    assert MapSet.equal?(partitions, expected_names)
   end
 end

--- a/test/realtime/tenants/replication_connection_test.exs
+++ b/test/realtime/tenants/replication_connection_test.exs
@@ -535,7 +535,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
       tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
       assert :ok = Endpoint.subscribe(tenant_topic)
 
-      Realtime.Tenants.Migrations.create_partitions(db_conn)
+      Realtime.Tenants.create_messages_partitions(db_conn)
 
       binary = <<0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF>>
       event = "INSERT"
@@ -567,7 +567,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
           tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
           assert :ok = Endpoint.subscribe(tenant_topic)
 
-          Realtime.Tenants.Migrations.create_partitions(db_conn)
+          Realtime.Tenants.create_messages_partitions(db_conn)
 
           binary = :binary.copy(<<0>>, tenant.max_payload_size_in_kb * 1000 + 1000)
           event = "INSERT"
@@ -594,7 +594,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
       tenant_topic = Tenants.tenant_topic(tenant.external_id, topic, false)
       assert :ok = Endpoint.subscribe(tenant_topic)
 
-      Realtime.Tenants.Migrations.create_partitions(db_conn)
+      Realtime.Tenants.create_messages_partitions(db_conn)
 
       event = "INSERT"
 
@@ -614,7 +614,7 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
     end
 
     test "rejects insert with both payload and binary_payload set", %{db_conn: db_conn} do
-      Realtime.Tenants.Migrations.create_partitions(db_conn)
+      Realtime.Tenants.create_messages_partitions(db_conn)
 
       assert {:error, %Postgrex.Error{postgres: %{code: :check_violation, constraint: "messages_payload_exclusive"}}} =
                Postgrex.query(

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -3,6 +3,7 @@ defmodule Realtime.TenantsTest do
   alias Realtime.Tenants.Migrations
   use Realtime.DataCase, async: false
 
+  alias Realtime.Database
   alias Realtime.GenCounter
   alias Realtime.Tenants
   doctest Realtime.Tenants
@@ -91,6 +92,23 @@ defmodule Realtime.TenantsTest do
 
       {:ok, tenant} = Realtime.Api.create_tenant(attrs)
       assert Tenants.region(tenant) == nil
+    end
+  end
+
+  describe "create_messages_partitions/1" do
+    test "running twice keeps the same partitions" do
+      tenant = Containers.checkout_tenant(run_migrations: true)
+      {:ok, conn} = Database.connect(tenant, "realtime_test", :stop)
+
+      assert :ok = Tenants.create_messages_partitions(conn)
+      assert :ok = Tenants.create_messages_partitions(conn)
+
+      assert {:ok, %{rows: [[5]]}} =
+               Postgrex.query(
+                 conn,
+                 "SELECT count(*) FROM pg_inherits WHERE inhparent = 'realtime.messages'::regclass",
+                 []
+               )
     end
   end
 end

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -572,7 +572,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       assert response(conn, 403) == ""
     end
 
-    test "runs migrations and creates partitions", %{conn: conn} do
+    test "runs migrations", %{conn: conn} do
       tenant = Containers.checkout_tenant(run_migrations: false)
 
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
@@ -583,15 +583,6 @@ defmodule RealtimeWeb.TenantControllerTest do
       Process.sleep(1000)
 
       assert {:ok, %{rows: []}} = Postgrex.query(db_conn, "SELECT * FROM realtime.messages", [])
-
-      assert {:ok, %{rows: [[partitions]]}} =
-               Postgrex.query(
-                 db_conn,
-                 "SELECT count(*) FROM pg_inherits WHERE inhparent = 'realtime.messages'::regclass",
-                 []
-               )
-
-      assert partitions > 0
 
       assert %{"healthy" => true, "db_connected" => false, "replication_connected" => false, "connected_cluster" => 0} =
                data

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -3,6 +3,7 @@ defmodule Containers do
   alias Realtime.Tenants.Connect
   alias Containers.Container
   alias Realtime.Database
+  alias Realtime.Tenants
   alias Realtime.Tenants.Migrations
 
   use GenServer
@@ -104,7 +105,7 @@ defmodule Containers do
 
     Migrations.run_migrations(tenant)
     {:ok, pid} = Database.connect(tenant, "realtime_test", :stop)
-    :ok = Migrations.create_partitions(pid)
+    :ok = Tenants.create_messages_partitions(pid)
     Process.exit(pid, :normal)
 
     tenant
@@ -185,7 +186,7 @@ defmodule Containers do
         if run_migrations? do
           case run_migrations(tenant) do
             {:ok, count} ->
-              :ok = Migrations.create_partitions(conn)
+              :ok = Tenants.create_messages_partitions(conn)
 
               {:ok, tenant} =
                 repo_run(mode, fn ->

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -48,7 +48,7 @@ defmodule Generators do
   @spec message_fixture(Realtime.Api.Tenant.t()) :: any()
   def message_fixture(tenant, override \\ %{}) do
     {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
-    Realtime.Tenants.Migrations.create_partitions(db_conn)
+    Realtime.Tenants.create_messages_partitions(db_conn)
 
     create_attrs = %{
       "topic" => random_string(),


### PR DESCRIPTION
Revert https://github.com/supabase/realtime/pull/1939 and move `Migrations.create_partitions/1` to `Tenants.create_messages_partitions/1` because messages partition is not a migration concern.

https://github.com/supabase/realtime/pull/1941 is a companion PR.