### PR TITLE
fix: rate limit logs set with info

### DIFF
--- a/lib/realtime/rate_counter/rate_counter.ex
+++ b/lib/realtime/rate_counter/rate_counter.ex
@@ -226,7 +226,7 @@ defmodule Realtime.RateCounter do
   def handle_info(:idle_shutdown, state) do
     if Enum.all?(state.bucket, &(&1 == 0)) do
       # All the buckets are empty, so we can assume this RateCounter has not been useful recently
-      Logger.warning("#{__MODULE__} idle_shutdown reached for: #{inspect(state.id)}")
+      Logger.info("#{__MODULE__} idle_shutdown reached for: #{inspect(state.id)}")
       shutdown(state)
     else
       Process.cancel_timer(state.idle_shutdown_ref)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently this logs create a lot of noise, moving to info
