### PR TITLE
fix: reject broadcast API from suspended tenants

### DIFF
--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -48,6 +48,10 @@ defmodule Realtime.Tenants.BatchBroadcast do
     broadcast(auth_params, %Tenant{} = tenant, messages, super_user)
   end
 
+  def broadcast(_auth_params, %Tenant{suspend: true}, _messages, _super_user) do
+    {:error, :forbidden, "Tenant is suspended"}
+  end
+
   def broadcast(auth_params, %Tenant{} = tenant, messages, super_user) do
     with %Ecto.Changeset{valid?: true} = changeset <- changeset(%__MODULE__{}, messages, tenant),
          %Ecto.Changeset{changes: %{messages: messages}} = changeset,

--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -61,6 +61,10 @@ defmodule Realtime.Tenants.SingleBroadcast do
           any(),
           content_type()
         ) :: :ok | {:error, term()} | {:error, atom(), String.t()}
+  def broadcast(_auth_params, %Tenant{suspend: true}, _topic, _event, _private, _payload, _content_type) do
+    {:error, :forbidden, "Tenant is suspended"}
+  end
+
   def broadcast(auth_params, %Tenant{} = tenant, topic, event, private, payload, content_type) do
     with %Ecto.Changeset{valid?: true} <- validate_message(topic, event, private, payload, content_type, tenant),
          events_per_second_rate = Tenants.events_per_second_rate(tenant),

--- a/lib/realtime_web/controllers/fallback_controller.ex
+++ b/lib/realtime_web/controllers/fallback_controller.ex
@@ -32,7 +32,7 @@ defmodule RealtimeWeb.FallbackController do
   end
 
   def call(conn, {:error, status, message}) when is_atom(status) and is_binary(message) do
-    log_error("UnprocessableEntity", message)
+    if status == :unprocessable_entity, do: log_error("UnprocessableEntity", message)
 
     conn
     |> put_status(status)

--- a/test/realtime/tenants/batch_broadcast_test.exs
+++ b/test/realtime/tenants/batch_broadcast_test.exs
@@ -494,6 +494,16 @@ defmodule Realtime.Tenants.BatchBroadcastTest do
       assert {:error, :tenant_not_found} = BatchBroadcast.broadcast(nil, nil, messages, false)
     end
 
+    test "does not broadcast when tenant is suspended", %{tenant: tenant} do
+      tenant = %{tenant | suspend: true}
+      messages = %{messages: [%{topic: "topic1", payload: %{"data" => "test"}, event: "event1"}]}
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      assert {:error, :forbidden, "Tenant is suspended"} = BatchBroadcast.broadcast(nil, tenant, messages, false)
+      assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
+    end
+
     test "gracefully handles database connection errors for private messages", %{tenant: tenant} do
       topic = random_string()
       sub = random_string()

--- a/test/realtime/tenants/single_broadcast_test.exs
+++ b/test/realtime/tenants/single_broadcast_test.exs
@@ -280,6 +280,18 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
     end
   end
 
+  describe "suspended tenant" do
+    test "does not broadcast when tenant is suspended", %{tenant: tenant} do
+      tenant = %{tenant | suspend: true}
+      topic = random_string()
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      result = SingleBroadcast.broadcast(%Authorization{}, tenant, topic, "event", false, %{"data" => "test"}, :json)
+      assert {:error, :forbidden, "Tenant is suspended"} = result
+      assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
+    end
+  end
+
   describe "rate limiting" do
     test "rejects broadcast when rate limit is exceeded", %{tenant: tenant} do
       events_per_second_rate = Tenants.events_per_second_rate(tenant)

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -172,6 +172,25 @@ defmodule RealtimeWeb.BroadcastControllerTest do
     end
   end
 
+  describe "suspended tenant" do
+    test "returns 403 and does not broadcast when tenant is suspended", %{conn: conn, tenant: tenant} do
+      Realtime.Tenants.Cache.update_cache(%{tenant | suspend: true})
+
+      reject(&TenantBroadcaster.pubsub_broadcast/5)
+
+      conn =
+        post(conn, Routes.broadcast_path(conn, :broadcast), %{
+          "messages" => [
+            %{"topic" => "sub_topic", "payload" => %{"data" => "data"}, "event" => "event"}
+          ]
+        })
+
+      assert conn.status == 403
+      assert conn.resp_body == Jason.encode!(%{message: "Tenant is suspended"})
+      assert calls(&TenantBroadcaster.pubsub_broadcast/5) == []
+    end
+  end
+
   describe "too many requests" do
     test "batch will exceed rate limit", %{conn: conn, tenant: tenant} do
       requests_rate = Tenants.requests_per_second_rate(tenant)

--- a/test/realtime_web/controllers/broadcast_single_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_single_controller_test.exs
@@ -412,6 +412,28 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
     end
   end
 
+  describe "suspended tenant" do
+    test "returns 403 and does not broadcast when tenant is suspended", %{conn: conn, tenant: tenant} do
+      Realtime.Tenants.Cache.update_cache(%{tenant | suspend: true})
+
+      sub_topic = "room:123"
+      event = "message"
+      topic = Tenants.tenant_topic(tenant, sub_topic)
+
+      subscribe(topic, sub_topic)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(Routes.broadcast_single_path(conn, :broadcast, sub_topic, event), %{"data" => "test"})
+
+      assert conn.status == 403
+      assert Jason.decode!(conn.resp_body)["message"] == "Tenant is suspended"
+
+      refute_receive {:socket_push, _, _}
+    end
+  end
+
   describe "Rate limiting" do
     test "returns 429 when rate limit is exceeded", %{conn: conn, tenant: tenant} do
       request_events_key = Tenants.requests_per_second_key(tenant)

--- a/test/realtime_web/controllers/fallback_controller_test.exs
+++ b/test/realtime_web/controllers/fallback_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule RealtimeWeb.FallbackControllerTest do
   use RealtimeWeb.ConnCase, async: true
 
+  import ExUnit.CaptureLog
+
   alias RealtimeWeb.FallbackController
 
   describe "call/2" do
@@ -24,6 +26,28 @@ defmodule RealtimeWeb.FallbackControllerTest do
       conn = FallbackController.call(conn, {:error, :bad_request, "invalid input"})
 
       assert json_response(conn, 400) == %{"message" => "invalid input"}
+    end
+
+    test "does not log UnprocessableEntity for non-422 statuses", %{conn: conn} do
+      log =
+        capture_log(fn ->
+          conn = FallbackController.call(conn, {:error, :forbidden, "Tenant is suspended"})
+
+          assert json_response(conn, 403) == %{"message" => "Tenant is suspended"}
+        end)
+
+      refute log =~ "UnprocessableEntity"
+    end
+
+    test "logs UnprocessableEntity for 422 status with message", %{conn: conn} do
+      log =
+        capture_log(fn ->
+          conn = FallbackController.call(conn, {:error, :unprocessable_entity, "invalid input"})
+
+          assert json_response(conn, 422) == %{"message" => "invalid input"}
+        end)
+
+      assert log =~ "UnprocessableEntity: invalid input"
     end
 
     test "returns 401 for generic error tuple", %{conn: conn} do


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reject broadcast API from suspended tenants