### PR TITLE
fix: replication connection increase timeout

### DIFF
--- a/lib/realtime/syn_handler.ex
+++ b/lib/realtime/syn_handler.ex
@@ -12,9 +12,13 @@ defmodule Realtime.SynHandler do
   @postgres_cdc_scope_prefix PostgresCdc.syn_topic_prefix()
 
   @impl true
-  def on_registry_process_updated(Connect, tenant_id, pid, %{conn: conn}, :normal) when is_pid(conn) do
+  def on_registry_process_updated(Connect, tenant_id, pid, %{conn: conn} = meta, :normal) when is_pid(conn) do
     # Update that a database connection is ready
-    Endpoint.local_broadcast(Connect.syn_topic(tenant_id), "ready", %{pid: pid, conn: conn})
+    Endpoint.local_broadcast(Connect.syn_topic(tenant_id), "ready", %{
+      pid: pid,
+      conn: conn,
+      replication_conn: meta[:replication_conn]
+    })
   end
 
   def on_registry_process_updated(scope, tenant_id, _pid, meta, _reason) do

--- a/lib/realtime/tenants/connect.ex
+++ b/lib/realtime/tenants/connect.ex
@@ -36,6 +36,7 @@ defmodule Realtime.Tenants.Connect do
           db_conn_pid: pid(),
           replication_connection_pid: pid(),
           replication_connection_reference: reference(),
+          replication_start_task: reference() | nil,
           backoff: Backoff.t(),
           replication_recovery_started_at: non_neg_integer() | nil,
           check_connected_user_interval: non_neg_integer(),
@@ -49,6 +50,7 @@ defmodule Realtime.Tenants.Connect do
             db_conn_pid: nil,
             replication_connection_pid: nil,
             replication_connection_reference: nil,
+            replication_start_task: nil,
             backoff: nil,
             replication_recovery_started_at: nil,
             check_connected_user_interval: nil,
@@ -313,15 +315,7 @@ defmodule Realtime.Tenants.Connect do
   end
 
   def handle_continue(:start_replication, state) do
-    case start_replication_connection(state) do
-      {:ok, state} ->
-        {:noreply, state, {:continue, :setup_connected_user_events}}
-
-      {:error, error} ->
-        log_error("StartReplicationFailed", error)
-        state = open_replication_recovery(state)
-        {:noreply, state, {:continue, :setup_connected_user_events}}
-    end
+    {:noreply, async_start_replication_connection(state), {:continue, :setup_connected_user_events}}
   end
 
   def handle_continue(:setup_connected_user_events, state) do
@@ -402,6 +396,48 @@ defmodule Realtime.Tenants.Connect do
     {:noreply, open_replication_recovery(state)}
   end
 
+  # Handle the result of the async replication connection start task
+  def handle_info({replication_start_task, result}, %{replication_start_task: replication_start_task} = state) do
+    Process.demonitor(replication_start_task, [:flush])
+    state = %{state | replication_start_task: nil}
+
+    case result do
+      {:ok, replication_connection_pid} ->
+        update_syn_replication_conn(state.tenant_id, replication_connection_pid)
+        replication_connection_reference = Process.monitor(replication_connection_pid)
+
+        {:noreply,
+         %{
+           state
+           | replication_connection_pid: replication_connection_pid,
+             replication_connection_reference: replication_connection_reference,
+             backoff: Backoff.reset(state.backoff),
+             replication_recovery_started_at: nil
+         }}
+
+      {:error, :max_wal_senders_reached} ->
+        log_error("ReplicationMaxWalSendersReached", "Tenant database has reached the maximum number of WAL senders")
+        {:noreply, open_replication_recovery(state)}
+
+      {:error, :replication_connection_timeout} ->
+        log_error("ReplicationConnectionTimeout", "Replication connection timed out during initialization")
+        {:noreply, open_replication_recovery(state)}
+
+      {:error, error} ->
+        log_error("StartReplicationFailed", error)
+        {:noreply, open_replication_recovery(state)}
+    end
+  end
+
+  # Handle a crash of the async replication connection start task
+  def handle_info(
+        {:DOWN, replication_start_task, :process, _, reason},
+        %{replication_start_task: replication_start_task} = state
+      ) do
+    log_error("StartReplicationFailed", reason)
+    {:noreply, open_replication_recovery(%{state | replication_start_task: nil})}
+  end
+
   @replication_connection_query "SELECT 1 from pg_stat_activity where application_name='realtime_replication_connection'"
   @max_replication_recovery_ms :timer.hours(2)
   def handle_info(:recover_replication_connection, %{replication_recovery_started_at: nil} = state) do
@@ -409,33 +445,35 @@ defmodule Realtime.Tenants.Connect do
   end
 
   def handle_info(:recover_replication_connection, state) do
-    %{backoff: backoff, db_conn_pid: db_conn_pid, replication_recovery_started_at: started_at} = state
+    %{db_conn_pid: db_conn_pid, replication_recovery_started_at: started_at} = state
     elapsed = System.monotonic_time(:millisecond) - started_at
 
-    if elapsed > @max_replication_recovery_ms do
-      log_warning(
-        "ReplicationRecoveryWindowExceeded",
-        "Replication recovery window exceeded after #{elapsed}ms, terminating connection"
-      )
+    cond do
+      elapsed > @max_replication_recovery_ms ->
+        log_warning(
+          "ReplicationRecoveryWindowExceeded",
+          "Replication recovery window exceeded after #{elapsed}ms, terminating connection"
+        )
 
-      {:stop, :shutdown, state}
-    else
-      with {:query, {:ok, %{num_rows: 0}}} <- {:query, Postgrex.query(db_conn_pid, @replication_connection_query, [])},
-           {:start, {:ok, state}} <- {:start, start_replication_connection(state)} do
-        {:noreply, %{state | backoff: Backoff.reset(backoff), replication_recovery_started_at: nil}}
-      else
-        {:query, {:ok, %{num_rows: _}}} ->
-          Logger.info("Waiting for old walsender to exit")
-          {:noreply, schedule_replication_retry(state)}
+        {:stop, :shutdown, state}
 
-        {:query, {:error, error}} ->
-          log_error("ReplicationConnectionRecoveryFailed", "DB check failed during recovery: #{inspect(error)}")
-          {:noreply, schedule_replication_retry(state)}
+      # A start is already in flight, don't start another one
+      is_reference(state.replication_start_task) ->
+        {:noreply, state}
 
-        {:start, {:error, error}} ->
-          log_error("ReplicationConnectionRecoveryFailed", "Replication connection recovery failed: #{inspect(error)}")
-          {:noreply, schedule_replication_retry(state)}
-      end
+      true ->
+        case Postgrex.query(db_conn_pid, @replication_connection_query, []) do
+          {:ok, %{num_rows: 0}} ->
+            {:noreply, async_start_replication_connection(state)}
+
+          {:ok, %{num_rows: _}} ->
+            Logger.info("Waiting for old walsender to exit")
+            {:noreply, schedule_replication_retry(state)}
+
+          {:error, error} ->
+            log_error("ReplicationConnectionRecoveryFailed", "DB check failed during recovery: #{inspect(error)}")
+            {:noreply, schedule_replication_retry(state)}
+        end
     end
   end
 
@@ -520,36 +558,19 @@ defmodule Realtime.Tenants.Connect do
     :syn.update_registry(__MODULE__, tenant_id, fn _pid, meta -> %{meta | replication_conn: pid} end)
   end
 
-  defp start_replication_connection(state) do
-    %{tenant: tenant, tenant_id: tenant_id} = state
+  # Starts the replication connection off-process so Connect stays responsive to its mailbox
+  # while Postgrex.ReplicationConnection performs its (up to ~30s) synchronous connect.
+  # The resulting process is supervised by its own DynamicSupervisor and monitors `connect_pid`,
+  # so it self-cleans if Connect dies while the start is in flight. `connect_pid` must be captured
+  # here (the Connect process) and not inside the task, which would pass the task's pid.
+  defp async_start_replication_connection(%{tenant: tenant} = state) do
+    connect_pid = self()
 
-    with {:ok, replication_connection_pid} <- ReplicationConnection.start(tenant, self()),
-         {:ok, _} <- update_syn_replication_conn(tenant_id, replication_connection_pid) do
-      replication_connection_reference = Process.monitor(replication_connection_pid)
+    %Task{ref: ref} =
+      Task.Supervisor.async_nolink(Realtime.TaskSupervisor, fn ->
+        ReplicationConnection.start(tenant, connect_pid)
+      end)
 
-      state = %{
-        state
-        | replication_connection_pid: replication_connection_pid,
-          replication_connection_reference: replication_connection_reference
-      }
-
-      {:ok, state}
-    else
-      {:error, :max_wal_senders_reached} ->
-        log_error("ReplicationMaxWalSendersReached", "Tenant database has reached the maximum number of WAL senders")
-        {:error, :max_wal_senders_reached}
-
-      {:error, :replication_connection_timeout} ->
-        log_error("ReplicationConnectionTimeout", "Replication connection timed out during initialization")
-        {:error, :replication_connection_timeout}
-
-      {:error, error} ->
-        log_error("StartReplicationFailed", error)
-        {:error, error}
-    end
-  rescue
-    error ->
-      log_error("StartReplicationFailed", error)
-      {:error, error}
+    %{state | replication_start_task: ref}
   end
 end

--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -46,9 +46,8 @@ defmodule Realtime.Tenants.ReplicationConnection do
             :disconnected
             | :check_replication_slot
             | :create_publication
-            | :check_publication
             | :validate_publication
-            | :create_slot
+            | :create_replication_slot
             | :start_replication_slot
             | :streaming,
           publication_name: String.t(),
@@ -225,20 +224,6 @@ defmodule Realtime.Tenants.ReplicationConnection do
   end
 
   def handle_result([%Postgrex.Result{num_rows: 0}], %__MODULE__{step: :check_replication_slot} = state) do
-    %__MODULE__{
-      output_plugin: output_plugin,
-      replication_slot_name: replication_slot_name,
-      step: :check_replication_slot
-    } = state
-
-    Logger.info("Create replication slot #{replication_slot_name} using plugin #{output_plugin}")
-
-    query = "CREATE_REPLICATION_SLOT #{replication_slot_name} TEMPORARY LOGICAL #{output_plugin} NOEXPORT_SNAPSHOT"
-
-    {:query, query, [timeout: state.query_timeout], %{state | step: :check_publication}}
-  end
-
-  def handle_result([%Postgrex.Result{}], %__MODULE__{step: :check_publication} = state) do
     %__MODULE__{publication_name: publication_name} = state
 
     Logger.info("Check publication #{publication_name} for table #{@schema}.#{@table} exists")
@@ -253,7 +238,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
     Logger.info("Create publication #{publication_name} for table #{@schema}.#{@table}")
     query = "CREATE PUBLICATION #{publication_name} FOR TABLE #{@schema}.#{@table}"
 
-    {:query, query, [timeout: state.query_timeout], %{state | step: :start_replication_slot}}
+    {:query, query, [timeout: state.query_timeout], %{state | step: :create_replication_slot}}
   end
 
   def handle_result([%Postgrex.Result{num_rows: 1}], %__MODULE__{step: :create_publication} = state) do
@@ -279,14 +264,46 @@ defmodule Realtime.Tenants.ReplicationConnection do
       end)
 
     if valid_tables and rows != [] do
-      {:query, "SELECT 1", [timeout: state.query_timeout], %{state | step: :start_replication_slot}}
+      {:query, "SELECT 1", [timeout: state.query_timeout], %{state | step: :create_replication_slot}}
     else
       query =
         "DROP PUBLICATION IF EXISTS #{publication_name}; CREATE PUBLICATION #{publication_name} FOR TABLE #{@schema}.#{@table}"
 
       Logger.warning("Publication #{publication_name} contains unexpected tables. Recreating...")
-      {:query, query, [timeout: state.query_timeout], %{state | step: :start_replication_slot}}
+      {:query, query, [timeout: state.query_timeout], %{state | step: :create_replication_slot}}
     end
+  end
+
+  def handle_result(%Postgrex.Error{postgres: %{message: message}}, %__MODULE__{step: :create_replication_slot}) do
+    {:disconnect, "Error creating publication: #{message}"}
+  end
+
+  def handle_result(%Postgrex.Error{message: message}, %__MODULE__{step: :create_replication_slot}) do
+    {:disconnect, "Error creating publication: #{message}"}
+  end
+
+  def handle_result(results, %__MODULE__{step: :create_replication_slot} = state) do
+    %__MODULE__{
+      output_plugin: output_plugin,
+      replication_slot_name: replication_slot_name
+    } = state
+
+    case Enum.find(results, &match?(%Postgrex.Error{}, &1)) do
+      %Postgrex.Error{} = error ->
+        {:disconnect, "Error creating publication: #{error.message}"}
+
+      nil ->
+        Logger.info("Create replication slot #{replication_slot_name} using plugin #{output_plugin}")
+
+        query = "CREATE_REPLICATION_SLOT #{replication_slot_name} TEMPORARY LOGICAL #{output_plugin} NOEXPORT_SNAPSHOT"
+
+        {:query, query, [timeout: state.query_timeout], %{state | step: :start_replication_slot}}
+    end
+  end
+
+  def handle_result(%Postgrex.Error{postgres: %{pg_code: pg_code}}, %__MODULE__{step: :start_replication_slot})
+      when pg_code in ~w(53300 53400) do
+    {:disconnect, :max_wal_senders_reached}
   end
 
   def handle_result(%Postgrex.Error{postgres: %{message: message}}, %__MODULE__{step: :start_replication_slot} = _state) do
@@ -298,7 +315,6 @@ defmodule Realtime.Tenants.ReplicationConnection do
   end
 
   def handle_result(results, %__MODULE__{step: :start_replication_slot} = state) do
-    dbg(results)
     error = Enum.find(results, fn res -> match?(%Postgrex.Error{}, res) end)
 
     if error do

--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -32,6 +32,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
   alias Realtime.Telemetry
   alias Realtime.Tenants
   alias Realtime.Tenants.Cache
+  alias Realtime.Tenants.Connect
   alias RealtimeWeb.RealtimeChannel
   alias RealtimeWeb.Socket.UserBroadcast
   alias RealtimeWeb.TenantBroadcaster
@@ -124,6 +125,26 @@ defmodule Realtime.Tenants.ReplicationConnection do
       [{pid, _}] -> pid
       [] -> nil
     end
+  end
+
+  def ready?(tenant_id) do
+    RealtimeWeb.Endpoint.subscribe(Connect.syn_topic(tenant_id))
+    # We do a lookup after subscribing because we could've missed a message while subscribing
+    case Connect.replication_status(tenant_id) do
+      {:ok, _} ->
+        true
+
+      _ ->
+        # Wait for up to 5 seconds for the ready event
+        receive do
+          %{event: "ready", payload: %{replication_conn: conn}} when is_pid(conn) ->
+            true
+        after
+          5_000 -> false
+        end
+    end
+  after
+    RealtimeWeb.Endpoint.unsubscribe(Connect.syn_topic(tenant_id))
   end
 
   @spec health_check(pid(), timeout()) :: :ok | no_return()

--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -298,6 +298,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
   end
 
   def handle_result(results, %__MODULE__{step: :start_replication_slot} = state) do
+    dbg(results)
     error = Enum.find(results, fn res -> match?(%Postgrex.Error{}, res) end)
 
     if error do
@@ -310,7 +311,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
       } = state
 
       Logger.info(
-        "Starting stream replication for slot #{replication_slot_name} using publication #{publication_name} and protocol version #{proto_version}"
+        "#{inspect(self())} Starting stream replication for slot #{replication_slot_name} using publication #{publication_name} and protocol version #{proto_version}"
       )
 
       query =

--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -36,7 +36,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
   alias RealtimeWeb.Socket.UserBroadcast
   alias RealtimeWeb.TenantBroadcaster
 
-  @default_query_timeout 30_000
+  @default_query_timeout :timer.minutes(4)
 
   @type t :: %__MODULE__{
           tenant_id: String.t(),

--- a/test/integration/measure_traffic_test.exs
+++ b/test/integration/measure_traffic_test.exs
@@ -192,15 +192,7 @@ defmodule Realtime.Integration.MeasureTrafficTest do
       # Wait for join to complete
       assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 1000
 
-      Enum.reduce_while(1..30, nil, fn _, _ ->
-        if ReplicationConnection.whereis(tenant.external_id),
-          do: {:halt, :ok},
-          else:
-            (
-              Process.sleep(500)
-              {:cont, nil}
-            )
-      end)
+      assert ReplicationConnection.ready?(tenant.external_id)
 
       for _ <- 1..5 do
         event = random_string()

--- a/test/integration/rt_channel/broadcast_test.exs
+++ b/test/integration/rt_channel/broadcast_test.exs
@@ -14,6 +14,7 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
   alias Realtime.Database
   alias Realtime.Integration.WebsocketClient
   alias Realtime.Tenants.Connect
+  alias Realtime.Tenants.ReplicationConnection
 
   @moduletag :capture_log
 
@@ -272,6 +273,8 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
 
       assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}}, 500
 
+      assert ReplicationConnection.ready?(tenant.external_id)
+
       value = random_string()
       Postgrex.query!(db_conn, "INSERT INTO #{table_name} (details) VALUES ($1)", [value])
 
@@ -399,6 +402,8 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
 
       value = random_string()
       event = random_string()
+
+      assert ReplicationConnection.ready?(tenant.external_id)
 
       Postgrex.query!(
         db_conn,

--- a/test/integration/rt_channel/broadcast_test.exs
+++ b/test/integration/rt_channel/broadcast_test.exs
@@ -481,6 +481,8 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
       value = random_string()
       event = random_string()
 
+      assert ReplicationConnection.ready?(tenant.external_id)
+
       Postgrex.query!(
         db_conn,
         "SELECT realtime.send (json_build_object ('value', $1 :: text)::jsonb, $2 :: text, $3 :: text, FALSE::bool);",

--- a/test/integration/rt_channel/broadcast_test.exs
+++ b/test/integration/rt_channel/broadcast_test.exs
@@ -319,6 +319,8 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
 
       new_value = random_string()
 
+      assert ReplicationConnection.ready?(tenant.external_id)
+
       Postgrex.query!(db_conn, "INSERT INTO #{table_name} (details) VALUES ($1)", [value])
       Postgrex.query!(db_conn, "UPDATE #{table_name} SET details = $1 WHERE details = $2", [new_value, value])
 
@@ -361,6 +363,8 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
       assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}}, 500
 
       value = random_string()
+
+      assert ReplicationConnection.ready?(tenant.external_id)
 
       Postgrex.query!(db_conn, "INSERT INTO #{table_name} (details) VALUES ($1)", [value])
       Postgrex.query!(db_conn, "DELETE FROM #{table_name} WHERE details = $1", [value])
@@ -442,6 +446,8 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
 
       binary = <<0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF, 0x01, 0x02>>
       event = random_string()
+
+      assert ReplicationConnection.ready?(tenant.external_id)
 
       Postgrex.query!(
         db_conn,

--- a/test/integration/rt_channel/wal_bloat_test.exs
+++ b/test/integration/rt_channel/wal_bloat_test.exs
@@ -83,9 +83,11 @@ defmodule Realtime.Integration.RtChannel.WalBloatTest do
 
       {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
       original_connect_pid = Connect.whereis(tenant.external_id)
-      original_replication_pid = ReplicationConnection.whereis(tenant.external_id)
+      # Replication now starts asynchronously, so wait for the slot to be active before
+      # reading the replication pid (it would otherwise race and return nil).
       await_replication_slot_active(db_conn, 30, 500)
       original_db_pid = active_replication_slot_pid!(db_conn)
+      original_replication_pid = ReplicationConnection.whereis(tenant.external_id)
 
       replication_ref = Process.monitor(original_replication_pid)
 

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -445,18 +445,18 @@ defmodule Realtime.Tenants.ConnectTest do
       assert {:ok, _db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Connect.ready?(tenant.external_id)
 
-      replication_connection_before = ReplicationConnection.whereis(tenant.external_id)
+      replication_connection_before = assert_pid(fn -> ReplicationConnection.whereis(tenant.external_id) end)
       assert Process.alive?(replication_connection_before)
 
-      assert {:ok, replication_conn_pid_before} = Connect.replication_status(tenant.external_id)
+      assert {:ok, replication_conn_pid_before} = assert_replication_status(tenant.external_id)
 
       assert {:ok, _db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
 
-      replication_connection_after = ReplicationConnection.whereis(tenant.external_id)
+      replication_connection_after = assert_pid(fn -> ReplicationConnection.whereis(tenant.external_id) end)
       assert Process.alive?(replication_connection_after)
       assert replication_connection_before == replication_connection_after
 
-      assert {:ok, replication_conn_pid_after} = Connect.replication_status(tenant.external_id)
+      assert {:ok, replication_conn_pid_after} = assert_replication_status(tenant.external_id)
       assert replication_conn_pid_before == replication_conn_pid_after
     end
 
@@ -464,13 +464,13 @@ defmodule Realtime.Tenants.ConnectTest do
       assert {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Connect.ready?(tenant.external_id)
 
-      replication_connection_pid = ReplicationConnection.whereis(tenant.external_id)
+      replication_connection_pid = assert_pid(fn -> ReplicationConnection.whereis(tenant.external_id) end)
       Process.monitor(replication_connection_pid)
 
       assert Process.alive?(replication_connection_pid)
       pid = Connect.whereis(tenant.external_id)
 
-      assert {:ok, replication_conn_before} = Connect.replication_status(tenant.external_id)
+      assert {:ok, replication_conn_before} = assert_replication_status(tenant.external_id)
 
       Postgrex.query!(
         db_conn,
@@ -497,12 +497,12 @@ defmodule Realtime.Tenants.ConnectTest do
       assert {:ok, _db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Connect.ready?(tenant.external_id)
 
-      replication_connection_pid = ReplicationConnection.whereis(tenant.external_id)
+      replication_connection_pid = assert_pid(fn -> ReplicationConnection.whereis(tenant.external_id) end)
       Process.monitor(replication_connection_pid)
       assert Process.alive?(replication_connection_pid)
       pid = Connect.whereis(tenant.external_id)
 
-      assert {:ok, replication_conn_before} = Connect.replication_status(tenant.external_id)
+      assert {:ok, replication_conn_before} = assert_replication_status(tenant.external_id)
 
       Process.exit(replication_connection_pid, :kill)
       assert_receive {:DOWN, _, :process, ^replication_connection_pid, _}
@@ -692,12 +692,12 @@ defmodule Realtime.Tenants.ConnectTest do
       assert Process.alive?(db_conn)
       assert Connect.ready?(tenant.external_id)
       connect_pid = Connect.whereis(tenant.external_id)
-      replication_connection_pid = ReplicationConnection.whereis(tenant.external_id)
+      replication_connection_pid = assert_pid(fn -> ReplicationConnection.whereis(tenant.external_id) end)
       assert Process.alive?(connect_pid)
       assert Process.alive?(replication_connection_pid)
 
       assert {_, %{conn: ^db_conn}} = :syn.lookup(Connect, tenant.external_id)
-      assert {:ok, _replication_conn_pid} = Connect.replication_status(tenant.external_id)
+      assert {:ok, _replication_conn_pid} = assert_replication_status(tenant.external_id)
 
       Connect.shutdown(tenant.external_id)
       assert_process_down(connect_pid)
@@ -737,6 +737,9 @@ defmodule Realtime.Tenants.ConnectTest do
     test "recovery stops when elapsed time exceeds 2-hour window", %{tenant: tenant} do
       assert {:ok, _db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Connect.ready?(tenant.external_id)
+      # Replication starts asynchronously; wait for it to settle so the async result handler
+      # doesn't clobber the state we inject below.
+      assert {:ok, _} = assert_replication_status(tenant.external_id)
 
       pid = Connect.whereis(tenant.external_id)
       ref = Process.monitor(pid)
@@ -756,6 +759,9 @@ defmodule Realtime.Tenants.ConnectTest do
     test "recovery preserves replication_recovery_started_at across multiple crashes", %{tenant: tenant} do
       assert {:ok, _db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
       assert Connect.ready?(tenant.external_id)
+      # Replication starts asynchronously; wait for it to settle so the async result handler
+      # doesn't clobber the state we inject below.
+      assert {:ok, _} = assert_replication_status(tenant.external_id)
 
       pid = Connect.whereis(tenant.external_id)
       original_ts = System.monotonic_time(:millisecond) - 1000
@@ -786,7 +792,7 @@ defmodule Realtime.Tenants.ConnectTest do
 
       pid = Connect.whereis(tenant.external_id)
 
-      replication_pid = ReplicationConnection.whereis(tenant.external_id)
+      replication_pid = assert_pid(fn -> ReplicationConnection.whereis(tenant.external_id) end)
       Process.monitor(replication_pid)
       Process.exit(replication_pid, :kill)
       assert_receive {:DOWN, _, :process, ^replication_pid, _}, 1000

--- a/test/realtime/tenants/replication_connection_test.exs
+++ b/test/realtime/tenants/replication_connection_test.exs
@@ -765,6 +765,38 @@ defmodule Realtime.Tenants.ReplicationConnectionTest do
       refute logs =~ "Recreating"
     end
 
+    test "disconnects when the publication cannot be created", %{tenant: tenant, db_conn: db_conn} do
+      publication_name = "supabase_realtime_messages_publication"
+
+      # No publication yet (forces the CREATE PUBLICATION path) and no table to publish,
+      # so `CREATE PUBLICATION ... FOR TABLE realtime.messages` fails with undefined_table.
+      Postgrex.query!(db_conn, "DROP PUBLICATION IF EXISTS #{publication_name}", [])
+      Postgrex.query!(db_conn, "DROP TABLE IF EXISTS realtime.messages CASCADE", [])
+
+      capture_log(fn ->
+        assert {:error, "Error creating publication:" <> _} = ReplicationConnection.start(tenant, self())
+      end)
+    end
+
+    test "disconnects when the publication cannot be recreated", %{tenant: tenant, db_conn: db_conn} do
+      publication_name = "supabase_realtime_messages_publication"
+
+      # Publication exists but with the wrong table, so validation triggers the
+      # `DROP ...; CREATE ...` recreate path. With realtime.messages gone, the CREATE half
+      # of that multi-statement fails, exercising the list-of-results error branch.
+      Postgrex.query!(db_conn, "DROP PUBLICATION IF EXISTS #{publication_name}", [])
+      Postgrex.query!(db_conn, "CREATE TABLE IF NOT EXISTS public.wrong_table (id int)", [])
+      Postgrex.query!(db_conn, "CREATE PUBLICATION #{publication_name} FOR TABLE public.wrong_table", [])
+      Postgrex.query!(db_conn, "DROP TABLE IF EXISTS realtime.messages CASCADE", [])
+
+      logs =
+        capture_log(fn ->
+          assert {:error, "Error creating publication:" <> _} = ReplicationConnection.start(tenant, self())
+        end)
+
+      assert logs =~ "Recreating"
+    end
+
     test "if includes unexpected tables, recreates publication", %{tenant: tenant, db_conn: db_conn} do
       publication_name = "supabase_realtime_messages_publication"
 

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -291,6 +291,7 @@ defmodule RealtimeWeb.TenantControllerTest do
       {:ok, _pid} = Connect.lookup_or_start_connection(tenant.external_id)
 
       assert Connect.ready?(tenant.external_id)
+      assert Realtime.Tenants.ReplicationConnection.ready?(tenant.external_id)
 
       assert Cache.get_tenant_by_external_id(tenant.external_id)
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Increase default ReplicationConnection timeout from 30 seconds to 4 minutes to give more times for really busy databases to establish a replication slot

Also move creating the replication slot to happen after the publication is there.
