### PR TITLE
chore(ci): bump create-gh-app-token

### DIFF
--- a/.github/workflows/dispatch_deploy.yml
+++ b/.github/workflows/dispatch_deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.GH_APP_MANAGER_ID }}
           private-key: ${{ secrets.GH_APP_MANAGER_PRIVATE_KEY }}


### PR DESCRIPTION
To support the recommended client-id

