### PR TITLE
fix: ensure presence.read permission is respected

### DIFF
--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -309,13 +309,12 @@ defmodule Realtime.Tenants.Authorization do
     with {:ok, res} <- Repo.all(conn, query, Message) do
       returned_ids = MapSet.new(res, & &1.id)
 
+      # Only the requested extensions were inserted, so we only set read for those. Extensions that
+      # were not checked are left unevaluated (nil) so callers can tell "denied" (false) apart from
+      # "not checked yet" (nil).
       {:ok,
-       Enum.reduce(@all_extensions, policies, fn extension, acc ->
-         can? =
-           Map.has_key?(messages_by_extension, extension) and
-             MapSet.member?(returned_ids, messages_by_extension[extension])
-
-         Policies.update_policies(acc, extension, :read, can?)
+       Enum.reduce(messages_by_extension, policies, fn {extension, id}, acc ->
+         Policies.update_policies(acc, extension, :read, MapSet.member?(returned_ids, id))
        end)}
     end
   end
@@ -325,7 +324,7 @@ defmodule Realtime.Tenants.Authorization do
       if extension in extensions do
         changeset = Message.changeset(%Message{}, %{topic: authorization_context.topic, extension: extension})
 
-        case Repo.insert(conn, changeset, Message, mode: :savepoint) do
+        case Repo.insert(conn, changeset, Message, mode: :savepoint, returning: false) do
           {:ok, _} ->
             {:cont, {:ok, Policies.update_policies(acc, extension, :write, true)}}
 

--- a/lib/realtime/tenants/repo.ex
+++ b/lib/realtime/tenants/repo.ex
@@ -36,7 +36,7 @@ defmodule Realtime.Tenants.Repo do
   @doc """
   Inserts a given changeset into the database and converts the result into a given struct.
 
-  Mirrors `Ecto.Repo.insert/2`'s `:returning` option. Pass `returning: false` to omit
+  Partially mirrors `Ecto.Repo.insert/2`'s `:returning` option. Pass `returning: false` to omit
   `RETURNING *` and return `{:ok, struct}` built from the fields that were sent, instead
   of the row loaded from the database. This matters for authorization probes: with
   `RETURNING *`, Postgres enforces the SELECT (read) policy on the returned row, which

--- a/lib/realtime/tenants/repo.ex
+++ b/lib/realtime/tenants/repo.ex
@@ -34,7 +34,14 @@ defmodule Realtime.Tenants.Repo do
   end
 
   @doc """
-  Inserts a given changeset into the database and converts the result into a given struct
+  Inserts a given changeset into the database and converts the result into a given struct.
+
+  Mirrors `Ecto.Repo.insert/2`'s `:returning` option. Pass `returning: false` to omit
+  `RETURNING *` and return `{:ok, struct}` built from the fields that were sent, instead
+  of the row loaded from the database. This matters for authorization probes: with
+  `RETURNING *`, Postgres enforces the SELECT (read) policy on the returned row, which
+  would conflate write with read. Without it, a member with write-but-not-read access
+  still inserts successfully.
   """
   @spec insert(
           DBConnection.conn(),
@@ -44,10 +51,16 @@ defmodule Realtime.Tenants.Repo do
         ) ::
           {:ok, struct()} | {:error, any()} | Ecto.Changeset.t()
   def insert(conn, changeset, result_struct, opts \\ []) do
-    with {:ok, {query, args}} <- insert_query_from_changeset(changeset) do
-      conn
-      |> run_query_with_trap(query, args, opts)
-      |> result_to_single_struct(result_struct, changeset)
+    {returning?, opts} = Keyword.pop(opts, :returning, true)
+
+    with {:ok, {query, args}} <- insert_query_from_changeset(changeset, returning: returning?) do
+      result = run_query_with_trap(conn, query, args, opts)
+
+      if returning? do
+        result_to_single_struct(result, result_struct, changeset)
+      else
+        with {:ok, %Postgrex.Result{}} <- result, do: {:ok, Ecto.Changeset.apply_changes(changeset)}
+      end
     end
   end
 
@@ -123,9 +136,9 @@ defmodule Realtime.Tenants.Repo do
     {:ok, Enum.map(rows, &repo_module.load(struct, Enum.zip(columns, &1)))}
   end
 
-  defp insert_query_from_changeset(%{valid?: false} = changeset), do: {:error, changeset}
+  defp insert_query_from_changeset(%{valid?: false} = changeset, _opts), do: {:error, changeset}
 
-  defp insert_query_from_changeset(changeset) do
+  defp insert_query_from_changeset(changeset, opts) do
     schema = changeset.data.__struct__
     source = schema.__schema__(:source)
     prefix = schema.__schema__(:prefix)
@@ -154,7 +167,9 @@ defmodule Realtime.Tenants.Repo do
       |> Enum.with_index(1)
       |> Enum.map_join(",", fn {_, index} -> "$#{index}" end)
 
-    {:ok, {"INSERT INTO #{table} #{header} VALUES (#{arg_index}) RETURNING *", rows}}
+    returning = if Keyword.get(opts, :returning, true), do: " RETURNING *", else: ""
+
+    {:ok, {"INSERT INTO #{table} #{header} VALUES (#{arg_index})#{returning}", rows}}
   end
 
   defp insert_all_query_from_changeset(changesets) do

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -91,6 +91,20 @@ defmodule RealtimeWeb.RealtimeChannel do
            maybe_replay_messages(params["config"], sub_topic, db_conn, tenant_id, socket.assigns.private?) do
       tenant_topic = Tenants.tenant_topic(tenant_id, sub_topic, !socket.assigns.private?)
 
+      # presence.read gate carried in the fastlane metadata so the dispatcher can withhold
+      # presence_diff from members denied presence.read:
+      #   * public channel (no policies) -> true (no presence authorization, always receive diffs)
+      #   * private + presence enabled at join -> the authorized presence.read value (true/false)
+      #   * private + presence not enabled -> nil (read not evaluated yet). The dispatcher routes
+      #     these diffs to the channel process (handle_info) instead of fastlaning, where presence.read
+      #     is consulted at delivery time (it is authorized on-demand when presence is auto-enabled via
+      #     a track message - see PresenceHandler).
+      presence_read? =
+        case socket.assigns.policies do
+          nil -> true
+          %Policies{presence: %{read: read}} -> read
+        end
+
       # fastlane subscription
       metadata =
         MessageDispatcher.fastlane_metadata(
@@ -99,7 +113,8 @@ defmodule RealtimeWeb.RealtimeChannel do
           topic,
           log_level,
           tenant_id,
-          replayed_message_ids
+          replayed_message_ids,
+          presence_read?
         )
 
       RealtimeWeb.Endpoint.subscribe(tenant_topic, metadata: metadata)
@@ -390,6 +405,16 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   def handle_info(:sync_presence, socket), do: {:noreply, socket}
+
+  # presence_diff for a socket whose presence.read was not authorized at join (presence disabled
+  # then) is routed here by the dispatcher instead of fastlaned. Deliver it only if this socket is
+  # authorized for presence.read (authorized on-demand when presence was auto-enabled via track),
+  # otherwise drop it.
+  def handle_info({:authorize_presence_diff, %Phoenix.Socket.Broadcast{} = msg}, socket) do
+    if can_read_presence?(socket), do: push(socket, "presence_diff", msg.payload)
+    {:noreply, socket}
+  end
+
   def handle_info(_, socket), do: {:noreply, socket}
 
   @impl true
@@ -915,6 +940,9 @@ defmodule RealtimeWeb.RealtimeChannel do
   defp presence_enabled?(client_enabled?, %Tenant{presence_enabled: tenant_enabled}) do
     client_enabled? || tenant_enabled
   end
+
+  defp can_read_presence?(%{assigns: %{policies: %Policies{presence: %{read: true}}}}), do: true
+  defp can_read_presence?(_socket), do: false
 
   defp max_heap_size(), do: :persistent_term.get({RealtimeWeb.UserSocket, :websocket_max_heap_size})
 

--- a/lib/realtime_web/channels/realtime_channel/message_dispatcher.ex
+++ b/lib/realtime_web/channels/realtime_channel/message_dispatcher.ex
@@ -7,8 +7,16 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
   alias Phoenix.Socket.Broadcast
   alias RealtimeWeb.Socket.UserBroadcast
 
-  def fastlane_metadata(fastlane_pid, serializer, topic, log_level, tenant_id, replayed_message_ids \\ MapSet.new()) do
-    {:rc_fastlane, fastlane_pid, serializer, topic, log_level, tenant_id, replayed_message_ids}
+  def fastlane_metadata(
+        fastlane_pid,
+        serializer,
+        topic,
+        log_level,
+        tenant_id,
+        replayed_message_ids \\ MapSet.new(),
+        presence_read? \\ true
+      ) do
+    {:rc_fastlane, fastlane_pid, serializer, topic, log_level, tenant_id, replayed_message_ids, presence_read?}
   end
 
   @presence_diff "presence_diff"
@@ -26,7 +34,22 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
         {pid, _}, {cache, count} when pid == from ->
           {cache, count}
 
-        {_pid, {:rc_fastlane, fastlane_pid, serializer, join_topic, log_level, tenant_id, _replayed_message_ids}},
+        # Subscriber is authorized for broadcast.read but denied presence.read: withhold the
+        # presence_diff. Mirrors the can_read_presence?/1 gate on the presence_state push.
+        {_pid, {:rc_fastlane, _fastlane_pid, _serializer, _join_topic, _log_level, _tenant_id, _replayed, false}},
+        {cache, count} ->
+          {cache, count}
+
+        # presence.read not yet authorized (presence was not enabled at join): route to the channel
+        # process so it can consult presence.read at delivery time. Wrapped in a
+        # tuple so it is handled by RealtimeChannel.handle_info rather than intercepted and pushed by
+        # Phoenix.Channel.Server's built-in %Broadcast{} handling.
+        {pid, {:rc_fastlane, _fastlane_pid, _serializer, _join_topic, _log_level, _tenant_id, _replayed, nil}},
+        {cache, count} ->
+          send(pid, {:authorize_presence_diff, msg})
+          {cache, count}
+
+        {_pid, {:rc_fastlane, fastlane_pid, serializer, join_topic, log_level, tenant_id, _replayed_message_ids, true}},
         {cache, count} ->
           maybe_log(log_level, join_topic, msg, tenant_id)
 
@@ -52,7 +75,9 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
         {pid, _}, cache when pid == from ->
           cache
 
-        {pid, {:rc_fastlane, fastlane_pid, serializer, join_topic, log_level, tenant_id, replayed_message_ids}},
+        {pid,
+         {:rc_fastlane, fastlane_pid, serializer, join_topic, log_level, tenant_id, replayed_message_ids,
+          _presence_read?}},
         cache ->
           if already_replayed?(message_id, replayed_message_ids) do
             # skip already replayed message
@@ -123,7 +148,7 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
 
   defp fastlane!(serializer, msg), do: {:ok, serializer.fastlane!(msg)}
 
-  defp tenant_id([{_pid, {:rc_fastlane, _, _, _, _, tenant_id, _}} | _]), do: tenant_id
+  defp tenant_id([{_pid, {:rc_fastlane, _, _, _, _, tenant_id, _, _}} | _]), do: tenant_id
   defp tenant_id(_), do: nil
 
   defp increment_presence_counter(tenant_id, "presence_diff", count) when is_binary(tenant_id) do

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -86,11 +86,15 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
        when is_private?(socket) and is_nil(socket.assigns.policies.presence.write) do
     %{assigns: %{authorization_context: authorization_context, policies: policies}} = socket
 
-    case Authorization.get_write_authorizations(policies, db_conn, authorization_context) do
-      {:ok, policies} ->
-        socket = assign(socket, :policies, policies)
-        handle_presence_event("track", payload, db_conn, socket)
-
+    # presence is being enabled by this track. Authorize presence.read now if it wasn't evaluated at
+    # join (the join skips it when presence was disabled, leaving read nil) so the channel can gate
+    # presence_diff for this socket, then authorize presence.write.
+    with {:ok, policies} <- maybe_authorize_presence_read(policies, db_conn, authorization_context),
+         {:ok, policies} <-
+           Authorization.get_write_authorizations(policies, db_conn, authorization_context, presence_enabled?: true) do
+      socket = assign(socket, :policies, policies)
+      handle_presence_event("track", payload, db_conn, socket)
+    else
       {:error, :rls_policy_error, error} ->
         log_error("RlsPolicyError", error)
         {:error, :rls_policy_error}
@@ -173,6 +177,14 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
         {:error, :unable_to_track_presence}
     end
   end
+
+  # presence.read is left unevaluated (nil) at join when presence is disabled. Authorize it now that
+  # presence is being enabled; otherwise it was already evaluated at join, so reuse it.
+  defp maybe_authorize_presence_read(%{presence: %{read: nil}} = policies, db_conn, authorization_context) do
+    Authorization.get_read_authorizations(policies, db_conn, authorization_context, presence_enabled?: true)
+  end
+
+  defp maybe_authorize_presence_read(policies, _db_conn, _authorization_context), do: {:ok, policies}
 
   defp check_track_payload(_assigns, payload) when not is_map(payload), do: {:error, :invalid_payload}
   defp check_track_payload(%{presence_track_payload: payload}, payload), do: {:error, :no_payload_change}

--- a/test/integration/rt_channel/presence_test.exs
+++ b/test/integration/rt_channel/presence_test.exs
@@ -205,6 +205,106 @@ defmodule Realtime.Integration.RtChannel.PresenceTest do
       assert get_in(join_payload, ["t"]) == payload.payload.t
     end
 
+    @tag policies: [
+           :authenticated_read_broadcast,
+           :authenticated_read_presence_for_sub,
+           :authenticated_write_broadcast_and_presence
+         ],
+         sub: Ecto.UUID.generate()
+    test "presence_diff is withheld from a member denied presence.read",
+         %{tenant: tenant, topic: topic, sub: sub, serializer: serializer} do
+      parent = self()
+      # Forward the other's frames tagged so they don't collide with the main mailbox.
+      other_inbox = spawn_link(fn -> forward_frames(parent, :other) end)
+
+      topic = "realtime:#{topic}"
+      config = %{presence: %{key: "", enabled: true}, private: true}
+
+      # main holds both broadcast.read and presence.read (presence.read is keyed to its sub).
+      {main, _} = get_connection(tenant, serializer, role: "authenticated", claims: %{sub: sub})
+
+      # Other holds broadcast.read but is explicitly denied presence.read (different sub).
+      {:ok, other_token} = token_valid(tenant, "authenticated", %{sub: Ecto.UUID.generate()})
+      other_uri = "#{uri(tenant, serializer)}&log_level=warning"
+
+      {:ok, other} =
+        WebsocketClient.connect(other_inbox, other_uri, serializer, [{"x-api-key", other_token}])
+
+      # Both join successfully: the join gate only enforces broadcast.read.
+      WebsocketClient.join(other, topic, %{config: config})
+      assert_receive {:other, %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}}, 500
+      # Should not receive presence_state
+      refute_receive {:other, %Message{event: "presence_state", topic: ^topic}}, 500
+
+      WebsocketClient.join(main, topic, %{config: config})
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 500
+      assert_receive %Message{event: "presence_state", payload: %{}, topic: ^topic}, 500
+
+      # Main tracks presence metadata an application would treat as restricted.
+      test = %{test: "should not go to other", user_id: sub}
+      WebsocketClient.send_event(main, topic, "presence", %{type: "presence", event: "TRACK", payload: test})
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 500
+
+      # Main sees the diff
+      assert_receive %Message{event: "presence_diff", payload: %{"joins" => joins, "leaves" => %{}}, topic: ^topic}, 500
+      meta = joins |> Map.values() |> hd() |> get_in(["metas"]) |> hd()
+      assert get_in(meta, ["test"]) == "should not go to other"
+
+      # Other can't receive the diff
+      refute_receive {:other, %Message{event: "presence_diff", topic: ^topic}}, 1000
+      refute_receive _any
+    end
+
+    # Same as above but presence is auto-enabled via track (config presence.enabled = false), which
+    # exercises the on-demand presence.read authorization + fastlane metadata refresh path: the gate
+    # must hold even when presence.read is not authorized at join time.
+    @tag policies: [
+           :authenticated_read_broadcast,
+           :authenticated_read_presence_for_sub,
+           :authenticated_write_broadcast_and_presence
+         ],
+         sub: Ecto.UUID.generate()
+    test "presence_diff gate holds when presence is auto-enabled via track",
+         %{tenant: tenant, topic: topic, sub: sub, serializer: serializer} do
+      parent = self()
+      other_inbox = spawn_link(fn -> forward_frames(parent, :other) end)
+
+      topic = "realtime:#{topic}"
+      # presence disabled at join: presence.read is not authorized until the first track.
+      config = %{presence: %{key: "", enabled: false}, private: true}
+      track = fn payload -> %{type: "presence", event: "TRACK", payload: payload} end
+
+      {main, _} = get_connection(tenant, serializer, role: "authenticated", claims: %{sub: sub})
+
+      {:ok, other_token} = token_valid(tenant, "authenticated", %{sub: Ecto.UUID.generate()})
+      other_uri = "#{uri(tenant, serializer)}&log_level=warning"
+
+      {:ok, other} =
+        WebsocketClient.connect(other_inbox, other_uri, serializer, [{"x-api-key", other_token}])
+
+      WebsocketClient.join(other, topic, %{config: config})
+      assert_receive {:other, %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}}, 500
+
+      WebsocketClient.join(main, topic, %{config: config})
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 500
+
+      WebsocketClient.send_event(other, topic, "presence", track.(%{name: "other"}))
+      assert_receive {:other, %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}}, 500
+
+      test = %{test: "should not go to other", user_id: sub}
+      WebsocketClient.send_event(main, topic, "presence", track.(test))
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 500
+
+      # Main sees the diff
+      assert_receive %Message{event: "presence_diff", payload: %{"joins" => joins}, topic: ^topic}, 1000
+      meta = joins |> Map.values() |> hd() |> get_in(["metas"]) |> hd()
+      assert get_in(meta, ["test"]) == "should not go to other"
+
+      # Other can't receive the diff
+      refute_receive {:other, %Message{event: "presence_diff", topic: ^topic}}, 1000
+      refute_receive _any
+    end
+
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "presence enabled if param enabled is set in configuration for private channels", %{
       tenant: tenant,
@@ -312,5 +412,15 @@ defmodule Realtime.Integration.RtChannel.PresenceTest do
 
       refute log =~ ~r/external_id=#{tenant.external_id}.*UnableToHandlePresence/
     end
+  end
+
+  # Forwards every frame received from a WebsocketClient to `parent`, wrapped in `{tag, frame}`,
+  # so a second socket's frames can be asserted on independently of the test process mailbox.
+  defp forward_frames(parent, tag) do
+    receive do
+      frame -> send(parent, {tag, frame})
+    end
+
+    forward_frames(parent, tag)
   end
 end

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -71,9 +71,10 @@ defmodule Realtime.Tenants.AuthorizationTest do
           presence_enabled?: false
         )
 
+      # presence.read is left unevaluated (nil) since presence was not checked; write is false.
       assert %Policies{
                broadcast: %BroadcastPolicies{read: true, write: true},
-               presence: %PresencePolicies{read: false, write: false}
+               presence: %PresencePolicies{read: nil, write: false}
              } == policies
     end
 

--- a/test/realtime/tenants/repo_test.exs
+++ b/test/realtime/tenants/repo_test.exs
@@ -99,6 +99,39 @@ defmodule Realtime.Tenants.RepoTest do
     end
   end
 
+  describe "insert/4 with returning: false" do
+    test "persists the row but returns only the sent fields, not the database row", %{db_conn: db_conn} do
+      changeset = Message.changeset(%Message{}, %{topic: "foo", extension: :presence})
+
+      assert {:ok, %Message{topic: "foo", extension: :presence} = message} =
+               Repo.insert(db_conn, changeset, Message, returning: false)
+
+      # No RETURNING clause, so the struct mirrors the changeset rather than the
+      # loaded row: database-generated fields are absent and it is not marked loaded.
+      assert is_nil(message.id)
+      assert Ecto.get_meta(message, :state) == :built
+
+      # The row is still inserted in the database.
+      assert {:ok, [%Message{topic: "foo", extension: :presence, id: id}]} = Repo.all(db_conn, Message, Message)
+      refute is_nil(id)
+    end
+
+    test "returns changeset if changeset is invalid", %{db_conn: db_conn} do
+      changeset = Message.changeset(%Message{}, %{})
+
+      assert {:error, %Ecto.Changeset{valid?: false}} = Repo.insert(db_conn, changeset, Message, returning: false)
+    end
+
+    test "handles exceptions", %{db_conn: db_conn} do
+      Process.unlink(db_conn)
+      Process.exit(db_conn, :kill)
+
+      changeset = Message.changeset(%Message{}, %{topic: "foo", extension: :presence})
+
+      assert {:error, :postgrex_exception} = Repo.insert(db_conn, changeset, Message, returning: false)
+    end
+  end
+
   describe "insert_all_entries/3" do
     test "inserts a new entries with a given changeset and returns struct", %{db_conn: db_conn} do
       changeset = [

--- a/test/realtime_web/channels/realtime_channel/message_dispatcher_test.exs
+++ b/test/realtime_web/channels/realtime_channel/message_dispatcher_test.exs
@@ -83,8 +83,10 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", MapSet.new(), true}}
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
@@ -126,8 +128,10 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant456", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant456", MapSet.new(), true}}
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant456", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant456", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "presence_diff", payload: %{data: "test"}}
@@ -169,12 +173,14 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
 
       subscribers = [
         # allowed: presence_read? == true -> fastlaned
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant789", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant789", MapSet.new(), true}},
         # denied: presence_read? == false -> withheld
         {subscriber_pid,
          {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant789", MapSet.new(), false}},
         # unknown: presence_read? == nil -> routed to the channel process (raw, unencoded)
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant789", MapSet.new(), nil}}
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant789", MapSet.new(), nil}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "presence_diff", payload: %{data: "test"}}
@@ -295,8 +301,10 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", MapSet.new(), true}}
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "event", payload: "not a map"}
@@ -339,10 +347,14 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
 
       # Four subscribers: same serializer, two different join_topics (two each)
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-a", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-a", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-b", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-b", :info, "tenant123", MapSet.new(), true}}
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic-a", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic-a", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic-b", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic-b", :info, "tenant123", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
@@ -410,9 +422,12 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
         {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
       ]
 
@@ -470,9 +485,12 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
         {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
       ]
 
@@ -560,9 +578,12 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
         {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
       ]
 

--- a/test/realtime_web/channels/realtime_channel/message_dispatcher_test.exs
+++ b/test/realtime_web/channels/realtime_channel/message_dispatcher_test.exs
@@ -16,15 +16,28 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
     end
   end
 
-  describe "fastlane_metadata/5" do
+  describe "fastlane_metadata/7" do
     test "info level" do
       assert MessageDispatcher.fastlane_metadata(self(), Serializer, "realtime:topic", :info, "tenant_id") ==
-               {:rc_fastlane, self(), Serializer, "realtime:topic", :info, "tenant_id", MapSet.new()}
+               {:rc_fastlane, self(), Serializer, "realtime:topic", :info, "tenant_id", MapSet.new(), true}
+    end
+
+    test "presence_read? defaults to true and can be set to false" do
+      assert MessageDispatcher.fastlane_metadata(
+               self(),
+               Serializer,
+               "realtime:topic",
+               :info,
+               "tenant_id",
+               MapSet.new(),
+               false
+             ) ==
+               {:rc_fastlane, self(), Serializer, "realtime:topic", :info, "tenant_id", MapSet.new(), false}
     end
 
     test "non-info level" do
       assert MessageDispatcher.fastlane_metadata(self(), Serializer, "realtime:topic", :warning, "tenant_id") ==
-               {:rc_fastlane, self(), Serializer, "realtime:topic", :warning, "tenant_id", MapSet.new()}
+               {:rc_fastlane, self(), Serializer, "realtime:topic", :warning, "tenant_id", MapSet.new(), true}
     end
 
     test "replayed message ids" do
@@ -36,7 +49,7 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
                "tenant_id",
                MapSet.new([1])
              ) ==
-               {:rc_fastlane, self(), Serializer, "realtime:topic", :warning, "tenant_id", MapSet.new([1])}
+               {:rc_fastlane, self(), Serializer, "realtime:topic", :warning, "tenant_id", MapSet.new([1]), true}
     end
   end
 
@@ -70,8 +83,8 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", MapSet.new()}}
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
@@ -113,8 +126,8 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant456", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant456", MapSet.new()}}
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant456", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant456", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "presence_diff", payload: %{data: "test"}}
@@ -132,6 +145,53 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       assert Agent.get(TestSerializer, & &1) == 1
 
       assert Realtime.GenCounter.get(Realtime.Tenants.presence_events_per_second_key("tenant456")) == 2
+
+      refute_receive _any
+    end
+
+    test "does not dispatch 'presence_diff' messages to subscribers denied presence.read" do
+      parent = self()
+
+      subscriber_pid =
+        spawn(fn ->
+          loop = fn loop ->
+            receive do
+              msg ->
+                send(parent, {:subscriber, msg})
+                loop.(loop)
+            end
+          end
+
+          loop.(loop)
+        end)
+
+      from_pid = :erlang.list_to_pid(~c'<0.2.1>')
+
+      subscribers = [
+        # allowed: presence_read? == true -> fastlaned
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant789", MapSet.new(), true}},
+        # denied: presence_read? == false -> withheld
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant789", MapSet.new(), false}},
+        # unknown: presence_read? == nil -> routed to the channel process (raw, unencoded)
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant789", MapSet.new(), nil}}
+      ]
+
+      msg = %Broadcast{topic: "some:other:topic", event: "presence_diff", payload: %{data: "test"}}
+
+      assert MessageDispatcher.dispatch(subscribers, from_pid, msg) == :ok
+
+      # Only the allowed subscriber is encoded/delivered to its fastlane pid.
+      assert_receive {:encoded, %Broadcast{event: "presence_diff", payload: %{data: "test"}, topic: "realtime:topic"}}
+      assert Agent.get(TestSerializer, & &1) == 1
+
+      # The nil subscriber is routed to its channel process wrapped, for handle_info to gate.
+      assert_receive {:subscriber,
+                      {:authorize_presence_diff,
+                       %Broadcast{event: "presence_diff", payload: %{data: "test"}, topic: "some:other:topic"}}}
+
+      # The presence counter only counts the fastlaned (allowed) subscriber.
+      assert Realtime.GenCounter.get(Realtime.Tenants.presence_events_per_second_key("tenant789")) == 1
 
       refute_receive _any
     end
@@ -157,9 +217,9 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
 
       subscribers = [
         {subscriber_pid,
-         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", replaeyd_message_ids}},
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", replaeyd_message_ids, true}},
         {subscriber_pid,
-         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", replaeyd_message_ids}}
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", replaeyd_message_ids, true}}
       ]
 
       msg = %Broadcast{
@@ -196,9 +256,9 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
 
       subscribers = [
         {subscriber_pid,
-         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", replayed_message_ids}},
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", replayed_message_ids, true}},
         {subscriber_pid,
-         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", replayed_message_ids}}
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", replayed_message_ids, true}}
       ]
 
       msg = %UserBroadcast{
@@ -235,8 +295,8 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", MapSet.new()}}
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic", :warning, "tenant123", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "event", payload: "not a map"}
@@ -279,10 +339,10 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
 
       # Four subscribers: same serializer, two different join_topics (two each)
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-a", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-a", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-b", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-b", :info, "tenant123", MapSet.new()}}
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-a", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-a", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-b", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), TestSerializer, "realtime:topic-b", :info, "tenant123", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
@@ -350,10 +410,10 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new()}}
+        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
       ]
 
       msg = %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
@@ -410,10 +470,10 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new()}}
+        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
       ]
 
       user_payload = Jason.encode!(%{data: "test"})
@@ -500,10 +560,10 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       from_pid = :erlang.list_to_pid(~c'<0.2.1>')
 
       subscribers = [
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new()}},
-        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new()}}
+        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V1.JSONSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid, {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
       ]
 
       user_payload = <<123, 456, 789>>

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -251,8 +251,8 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "only checks write policies once on private channels", %{tenant: tenant, topic: topic, db_conn: db_conn} do
-      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context ->
-        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context])
+      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
+        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
       end)
 
       reject(&Authorization.get_write_authorizations/3)
@@ -279,7 +279,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
     test "increase_connection_pool from write authorization returns error and does not log UnableToSetPolicies",
          %{tenant: tenant, topic: topic, db_conn: db_conn} do
-      stub(Authorization, :get_write_authorizations, fn _, _, _ -> {:error, :increase_connection_pool} end)
+      stub(Authorization, :get_write_authorizations, fn _, _, _, _ -> {:error, :increase_connection_pool} end)
 
       key = random_string()
       socket = socket_fixture(tenant, topic, key)
@@ -299,8 +299,8 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :broken_write_presence]
     test "handle failing rls policy", %{tenant: tenant, topic: topic, db_conn: db_conn} do
-      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context ->
-        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context])
+      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
+        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
       end)
 
       key = random_string()

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -228,6 +228,19 @@ defmodule Generators do
     """
   end
 
+  def policy_query(:authenticated_read_presence_for_sub, %{topic: name, sub: sub}) do
+    """
+    CREATE POLICY "authenticated_read_presence_for_sub_#{name}"
+    ON realtime.messages FOR SELECT
+    TO authenticated
+    USING (
+      realtime.topic() = '#{name}'
+      AND realtime.messages.extension = 'presence'
+      AND ((SELECT auth.uid())::text) = '#{sub}'
+    );
+    """
+  end
+
   def policy_query(:authenticated_read_broadcast_and_presence, %{topic: name}) do
     """
     CREATE POLICY "authenticated_read_presence_#{name}"


### PR DESCRIPTION

* Fix insert to not use `returning` to avoid checking select policy
* Ensure `presence.read` is properly accounted for on RealtimeChannel and MessageDispatcher