### PR TITLE
fix: improve parity with Postgrest filters

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -375,26 +375,33 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
     end
   end
 
-  # Split on commas that are NOT inside parentheses, so an `in.(a,b)` value stays a single
-  # segment. An unmatched `)` is tolerated and kept as a literal in the value (PostgREST
-  # behaviour), which is why depth floors at 0.
-  defp split_top_level(filter), do: split_top_level(filter, 0, "", [])
+  defp split_top_level(filter), do: split_top_level(filter, 0, false, 0, "", [])
 
-  defp split_top_level(<<>>, _depth, current, acc), do: Enum.reverse([current | acc])
+  defp split_top_level(<<>>, _depth, _quoted, _prev, current, acc), do: Enum.reverse([current | acc])
 
-  defp split_top_level(<<"(", rest::binary>>, depth, current, acc),
-    do: split_top_level(rest, depth + 1, current <> "(", acc)
+  defp split_top_level(<<"\\", next, rest::binary>>, depth, true, _prev, current, acc),
+    do: split_top_level(rest, depth, true, next, current <> "\\" <> <<next>>, acc)
 
-  defp split_top_level(<<")", rest::binary>>, depth, current, acc),
-    do: split_top_level(rest, max(0, depth - 1), current <> ")", acc)
+  defp split_top_level(<<"\"", rest::binary>>, depth, true, _prev, current, acc),
+    do: split_top_level(rest, depth, false, ?", current <> "\"", acc)
 
-  # A comma at depth 0 ends the current segment.
-  defp split_top_level(<<",", rest::binary>>, 0, current, acc),
-    do: split_top_level(rest, 0, "", [current | acc])
+  defp split_top_level(<<char, rest::binary>>, depth, true, _prev, current, acc),
+    do: split_top_level(rest, depth, true, char, current <> <<char>>, acc)
 
-  # Any other byte (including a comma inside parentheses) extends the current segment.
-  defp split_top_level(<<char, rest::binary>>, depth, current, acc),
-    do: split_top_level(rest, depth, current <> <<char>>, acc)
+  defp split_top_level(<<"\"", rest::binary>>, depth, false, prev, current, acc) when prev in [?., ?(, ?,],
+    do: split_top_level(rest, depth, true, ?", current <> "\"", acc)
+
+  defp split_top_level(<<"(", rest::binary>>, depth, false, _prev, current, acc),
+    do: split_top_level(rest, depth + 1, false, ?(, current <> "(", acc)
+
+  defp split_top_level(<<")", rest::binary>>, depth, false, _prev, current, acc),
+    do: split_top_level(rest, max(0, depth - 1), false, ?), current <> ")", acc)
+
+  defp split_top_level(<<",", rest::binary>>, 0, false, _prev, current, acc),
+    do: split_top_level(rest, 0, false, 0, "", [current | acc])
+
+  defp split_top_level(<<char, rest::binary>>, depth, false, _prev, current, acc),
+    do: split_top_level(rest, depth, false, char, current <> <<char>>, acc)
 
   # Parse each segment, short-circuiting on the first error.
   defp parse_segments(segments) do
@@ -445,5 +452,20 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
     end
   end
 
-  defp format_filter_value(_filter, value), do: {:ok, value}
+  defp format_filter_value(_filter, value), do: {:ok, unquote_value(value)}
+
+  defp unquote_value(<<"\"", rest::binary>> = original) do
+    case take_quoted(rest, "") do
+      {:ok, unquoted} -> unquoted
+      :error -> original
+    end
+  end
+
+  defp unquote_value(value), do: value
+
+  defp take_quoted(<<"\"">>, acc), do: {:ok, acc}
+  defp take_quoted(<<"\"", _rest::binary>>, _acc), do: :error
+  defp take_quoted(<<"\\", char, rest::binary>>, acc), do: take_quoted(rest, acc <> <<char>>)
+  defp take_quoted(<<char, rest::binary>>, acc), do: take_quoted(rest, acc <> <<char>>)
+  defp take_quoted(<<>>, _acc), do: :error
 end

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -145,6 +145,136 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
                })
     end
 
+    test "a double-quoted value can contain a literal comma without splitting the filter" do
+      assert {:ok, {"*", "public", "test", [{"name", "eq", "a,b", false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=eq."a,b"|
+               })
+    end
+
+    test "a double-quoted value does not split a multi-filter expression on its inner comma" do
+      assert {:ok, {"*", "public", "test", filters, _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=eq."a,b",id=gt.0|
+               })
+
+      assert [{"name", "eq", "a,b", false}, {"id", "gt", "0", false}] = filters
+    end
+
+    test "double quotes let a value contain other reserved characters (period, colon, parens)" do
+      assert {:ok, {"*", "public", "test", [{"name", "eq", "a.b:c(d)", false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=eq."a.b:c(d)"|
+               })
+    end
+
+    test "an escaped double quote inside a quoted value becomes a literal quote" do
+      assert {:ok, {"*", "public", "test", [{"name", "eq", ~s|she said "hi"|, false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=eq."she said \\"hi\\""|
+               })
+    end
+
+    test "an escaped backslash inside a quoted value becomes a single backslash" do
+      assert {:ok, {"*", "public", "test", [{"path", "eq", ~S|C:\tmp|, false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~S|path=eq."C:\\tmp"|
+               })
+    end
+
+    test "a quoted value combines with the not. negation prefix" do
+      assert {:ok, {"*", "public", "test", [{"name", "neq", "a,b", true}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=not.neq."a,b"|
+               })
+    end
+
+    test "a backslash inside a quoted value escapes the next character, whatever it is" do
+      assert {:ok, {"*", "public", "test", [{"path", "eq", "C:new", false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~S|path=eq."C:\new"|
+               })
+    end
+
+    test "an empty quoted value matches the empty string" do
+      assert {:ok, {"*", "public", "test", [{"name", "eq", "", false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=eq.""|
+               })
+    end
+
+    test "whitespace inside a quoted value is preserved verbatim" do
+      assert {:ok, {"*", "public", "test", [{"name", "eq", " a ", false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=eq." a "|
+               })
+    end
+
+    test "in-list elements can be double-quoted to contain commas" do
+      assert {:ok, {"*", "public", "test", [{"tags", "in", ~s|{"a,b",c}|, false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|tags=in.("a,b",c)|
+               })
+    end
+
+    test "multiple in-list elements can each be double-quoted" do
+      assert {:ok, {"*", "public", "test", [{"tags", "in", ~s|{"a,b","c,d"}|, false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|tags=in.("a,b","c,d")|
+               })
+    end
+
+    test "an unterminated quoted value falls back to a literal value (PostgREST behaviour)" do
+      assert {:ok, {"*", "public", "test", [{"name", "eq", ~s|"unterminated|, false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=eq."unterminated|
+               })
+    end
+
+    test "characters after a closing quote make the whole value literal (PostgREST backtracks)" do
+      assert {:ok, {"*", "public", "test", [{"name", "eq", ~s|"ab"cd|, false}], _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|name=eq."ab"cd|
+               })
+    end
+
+    test "a double quote that is not at the start of a value does not protect a following comma" do
+      assert {:ok, {"*", "public", "test", filters, _}} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "test",
+                 "filter" => ~s|desc=eq.5" tall,id=gt.0|
+               })
+
+      assert [{"desc", "eq", ~s|5" tall|, false}, {"id", "gt", "0", false}] = filters
+    end
+
     test "user gets a clear error when the filter string ends with a stray comma" do
       assert {:error, msg} =
                Subscriptions.parse_subscription_params(%{


### PR DESCRIPTION


## What kind of change does this PR introduce?

We now handle special chars closer to what PostgRest does so we have a clear direction on how we want to support filters going forward
