### PR TITLE
fix: disconnect when read access flips

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -541,13 +541,17 @@ defmodule RealtimeWeb.RealtimeChannel do
       }
     } = socket
 
+    # Keep track of the policies evaluated with the previous token so we can detect revoked permissions
+    previous_policies = socket.assigns.policies
+
     # Update token and reset policies
     socket = assign(socket, %{access_token: refresh_token, policies: nil})
 
     with {:ok, claims, confirm_token_ref} <- confirm_token(socket),
          socket = assign_authorization_context(socket, channel_name, claims),
          {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant_id),
-         {:ok, socket} <- maybe_assign_policies(channel_name, db_conn, socket) do
+         {:ok, socket} <- maybe_assign_policies(channel_name, db_conn, socket),
+         :ok <- check_read_permissions_revoked(previous_policies, socket.assigns.policies) do
       Helpers.cancel_timer(pg_sub_ref)
       pg_change_params = Enum.map(pg_change_params, &Map.put(&1, :claims, claims))
 
@@ -567,6 +571,9 @@ defmodule RealtimeWeb.RealtimeChannel do
     else
       {:error, reason, msg} when reason in ~w(unauthorized expired_token token_malformed)a ->
         shutdown_response(socket, msg)
+
+      {:error, :read_permissions_revoked} ->
+        shutdown_response(socket, "You no longer have permission to read from this Channel topic: #{channel_name}")
 
       {:error, :missing_claims} ->
         shutdown_response(socket, "Fields `role` and `exp` are required in JWT")
@@ -929,6 +936,20 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   defp maybe_assign_policies(_, _, socket), do: {:ok, assign(socket, policies: nil)}
+
+  # Detects read permissions that were granted under the previous token but are no longer allowed
+  # after re-evaluating the policies with the new token. When that happens we disconnect the channel.
+  defp check_read_permissions_revoked(%Policies{} = previous, %Policies{} = current) do
+    if read_revoked?(previous.broadcast.read, current.broadcast.read) or
+         read_revoked?(previous.presence.read, current.presence.read),
+       do: {:error, :read_permissions_revoked},
+       else: :ok
+  end
+
+  defp check_read_permissions_revoked(_previous, _current), do: :ok
+
+  defp read_revoked?(true, false), do: true
+  defp read_revoked?(_previous, _current), do: false
 
   defp only_private?(tenant, %{assigns: %{private?: private?}}) do
     if tenant.private_only and !private? do

--- a/test/integration/rt_channel/presence_test.exs
+++ b/test/integration/rt_channel/presence_test.exs
@@ -359,6 +359,68 @@ defmodule Realtime.Integration.RtChannel.PresenceTest do
     end
   end
 
+  describe "presence authorization on access_token refresh" do
+    setup [:rls_context]
+
+    @tag policies: [
+           :authenticated_read_broadcast,
+           :authenticated_write_broadcast_and_presence,
+           :authenticated_read_presence_based_on_claim
+         ]
+    test "disconnects when presence read permission changes from true to false on new access_token",
+         %{tenant: tenant, topic: topic, serializer: serializer} do
+      # Token whose claims satisfy the presence read policy
+      {socket, _} = get_connection(tenant, serializer, role: "authenticated", claims: %{presence_read: true})
+
+      config = %{presence: %{key: "", enabled: true}, private: true}
+      realtime_topic = "realtime:#{topic}"
+
+      WebsocketClient.join(socket, realtime_topic, %{config: config})
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^realtime_topic}, 500
+      assert_receive %Message{event: "presence_state", topic: ^realtime_topic}, 500
+
+      # New token whose claims no longer satisfy the presence read policy
+      {:ok, new_token} =
+        generate_token(tenant, %{
+          exp: System.system_time(:second) + 1000,
+          role: "authenticated",
+          presence_read: false
+        })
+
+      WebsocketClient.send_event(socket, realtime_topic, "access_token", %{"access_token" => new_token})
+
+      assert_receive %Message{event: "phx_close", topic: ^realtime_topic}, 500
+    end
+
+    @tag policies: [
+           :authenticated_read_broadcast,
+           :authenticated_write_broadcast_and_presence,
+           :authenticated_read_presence_based_on_claim
+         ]
+    test "stays connected when presence read permission remains true on new access_token",
+         %{tenant: tenant, topic: topic, serializer: serializer} do
+      {socket, _} = get_connection(tenant, serializer, role: "authenticated", claims: %{presence_read: true})
+
+      config = %{presence: %{key: "", enabled: true}, private: true}
+      realtime_topic = "realtime:#{topic}"
+
+      WebsocketClient.join(socket, realtime_topic, %{config: config})
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^realtime_topic}, 500
+      assert_receive %Message{event: "presence_state", topic: ^realtime_topic}, 500
+
+      {:ok, new_token} =
+        generate_token(tenant, %{
+          exp: System.system_time(:second) + 1000,
+          role: "authenticated",
+          presence_read: true
+        })
+
+      WebsocketClient.send_event(socket, realtime_topic, "access_token", %{"access_token" => new_token})
+
+      refute_receive %Message{event: "phx_close", topic: ^realtime_topic}, 500
+    end
+  end
+
   describe "database connection errors" do
     setup [:rls_context]
 

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -942,6 +942,47 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       assert_process_down(socket.channel_pid)
     end
 
+    @tag policies: [:authenticated_all_topic_read]
+    test "disconnects when only presence read permission is revoked on new access_token", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{"log_level" => "warning"}, conn_opts(tenant, jwt))
+
+      assert socket =
+               subscribe_and_join!(socket, "realtime:test", %{
+                 "config" => %{"private" => true, "presence" => %{"enabled" => true}}
+               })
+
+      assert socket.assigns.policies == %Realtime.Tenants.Authorization.Policies{
+               broadcast: %Realtime.Tenants.Authorization.Policies.BroadcastPolicies{read: true, write: nil},
+               presence: %Realtime.Tenants.Authorization.Policies.PresencePolicies{read: true, write: nil}
+             }
+
+      new_token =
+        Generators.generate_jwt_token(tenant, %{
+          exp: System.system_time(:second) + 10_000,
+          role: "authenticated",
+          sub: "123"
+        })
+
+      assert new_token != jwt
+
+      # Replace policies so broadcast read is still allowed but presence read is revoked
+      {:ok, db_conn} = Realtime.Database.connect(tenant, "realtime_test")
+      clean_table(db_conn, "realtime", "messages")
+      create_rls_policies(db_conn, [:authenticated_read_broadcast], %{topic: "test"})
+
+      push(socket, "access_token", %{"access_token" => new_token})
+
+      assert_push "system", %{
+        extension: "system",
+        status: "error",
+        message: "You no longer have permission to read from this Channel topic: test"
+      }
+
+      # Channel closes
+      assert_process_down(socket.channel_pid)
+    end
+
     test "new valid access_token but Connect timed out", %{tenant: tenant} do
       jwt = Generators.generate_jwt_token(tenant)
       {:ok, %Socket{} = socket} = connect(UserSocket, %{"log_level" => "warning"}, conn_opts(tenant, jwt))

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -261,6 +261,19 @@ defmodule Generators do
     """
   end
 
+  def policy_query(:authenticated_read_presence_based_on_claim, %{topic: name}) do
+    """
+    CREATE POLICY "authenticated_read_presence_claim_#{name}"
+    ON realtime.messages FOR SELECT
+    TO authenticated
+    USING (
+      realtime.topic() = '#{name}'
+      AND realtime.messages.extension = 'presence'
+      AND coalesce(((current_setting('request.jwt.claims', true))::jsonb ->> 'presence_read')::boolean, false)
+    );
+    """
+  end
+
   def policy_query(:broken_read_presence, _) do
     """
     CREATE POLICY "authenticated_read_presence"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Follow-up from https://github.com/supabase/realtime/pull/1969

We will now disconnect if presence.read went from true to false when a new access token is pushed.

Just like we already disconnect if `broadcast` is `false` when a new access token is pushed.