### PR TITLE
Skip empty DNS cluster queries

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,7 +34,7 @@ db_ssl = Env.get_boolean("DB_SSL", false)
 db_ssl_ca_cert = System.get_env("DB_SSL_CA_CERT")
 db_user = System.get_env("DB_USER", "supabase_realtime_admin")
 disable_healthcheck_logging = Env.get_boolean("DISABLE_HEALTHCHECK_LOGGING", false)
-dns_nodes = System.get_env("DNS_NODES")
+dns_nodes = Env.get_non_empty_binary("DNS_NODES")
 gen_rpc_compress = Env.get_integer("GEN_RPC_COMPRESS", 0)
 gen_rpc_compression_threshold_in_bytes = Env.get_integer("GEN_RPC_COMPRESSION_THRESHOLD_IN_BYTES", 1000)
 gen_rpc_connect_timeout_in_ms = Env.get_integer("GEN_RPC_CONNECT_TIMEOUT_IN_MS", 10_000)
@@ -245,12 +245,16 @@ cluster_topologies =
     |> String.trim()
     |> then(fn
       "DNS" ->
-        [
-          dns: [
-            strategy: Cluster.Strategy.DNSPoll,
-            config: [polling_interval: 5_000, query: dns_nodes, node_basename: app_name]
-          ]
-        ] ++ acc
+        if dns_nodes do
+          [
+            dns: [
+              strategy: Cluster.Strategy.DNSPoll,
+              config: [polling_interval: 5_000, query: dns_nodes, node_basename: app_name]
+            ]
+          ] ++ acc
+        else
+          acc
+        end
 
       "POSTGRES" ->
         [

--- a/lib/realtime/env.ex
+++ b/lib/realtime/env.ex
@@ -65,6 +65,23 @@ defmodule Realtime.Env do
 
   def get_binary(env, default), do: System.get_env(env, default)
 
+  @spec get_non_empty_binary(binary()) :: binary() | nil
+  def get_non_empty_binary(env) do
+    case System.get_env(env) do
+      nil ->
+        nil
+
+      value ->
+        value = String.trim(value)
+
+        if value in ["", "''", ~s("")] do
+          nil
+        else
+          value
+        end
+    end
+  end
+
   @spec get_list(binary(), [binary()]) :: [binary()]
   def get_list(env, default) when is_list(default) do
     value = System.get_env(env)

--- a/test/realtime/env_test.exs
+++ b/test/realtime/env_test.exs
@@ -136,6 +136,33 @@ defmodule Realtime.EnvTest do
     end
   end
 
+  describe "get_non_empty_binary/1" do
+    test "returns nil when env is unset", %{env: env} do
+      assert Env.get_non_empty_binary(env) == nil
+    end
+
+    test "returns trimmed env values", %{env: env} do
+      System.put_env(env, " realtime.internal ")
+      assert Env.get_non_empty_binary(env) == "realtime.internal"
+    end
+
+    test "returns nil for empty values", %{env: env} do
+      System.put_env(env, "")
+      assert Env.get_non_empty_binary(env) == nil
+
+      System.put_env(env, "   ")
+      assert Env.get_non_empty_binary(env) == nil
+    end
+
+    test "returns nil for quoted empty placeholders", %{env: env} do
+      System.put_env(env, "''")
+      assert Env.get_non_empty_binary(env) == nil
+
+      System.put_env(env, ~s(""))
+      assert Env.get_non_empty_binary(env) == nil
+    end
+  end
+
   describe "get_list/2" do
     test "returns the default when env is unset", %{env: env} do
       assert Env.get_list(env, ["a", "b"]) == ["a", "b"]


### PR DESCRIPTION
Fixes supabase/realtime#1429.

`DNS_NODES` can be set to Docker's quoted-empty placeholder (`''`), which Realtime previously passed through to `Cluster.Strategy.DNSPoll` as a real query name. This normalizes empty and quoted-empty values to `nil`, then skips the DNS topology when there is no actual DNS node name to poll.

Validation:
- `git diff --check`
