### PR TITLE
feat: opt-in channel-scoped PostgreSQL temp table state store

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -145,6 +145,7 @@ defmodule Realtime.Application do
          strategy: :one_for_one,
          name: Connect.DynamicSupervisor,
          partitions: connect_partition_slots},
+        {DynamicSupervisor, name: Realtime.Tenants.TempStateStore.DynamicSupervisor, strategy: :one_for_one},
         {RealtimeWeb.RealtimeChannel.Tracker, check_interval_in_ms: no_channel_timeout_in_ms},
         RealtimeWeb.Endpoint,
         {RealtimeWeb.Presence,

--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -124,8 +124,12 @@ defmodule Realtime.Database do
       with {:ok, base_settings} <- from_settings(settings, "realtime_connect", :stop),
            check_settings = %{base_settings | max_restarts: 0},
            {:ok, conn} <- connect_db(check_settings),
-           {:ok, [available_connections, migrations_ran]} <- query_connection_info(conn) do
-        requirement = ceil(required_pool * @available_connection_factor)
+           {:ok, [available_connections, max_connections, migrations_ran]} <- query_connection_info(conn) do
+        # Temp state store sessions (dedicated, per-channel) are not part of any pool, so their
+        # cap is reserved explicitly on top of the pooled requirements.
+        requirement =
+          ceil(required_pool * @available_connection_factor) +
+            Realtime.Tenants.TempStateStore.capacity_limit(max_connections)
 
         if requirement < available_connections do
           {:ok, conn, migrations_ran}
@@ -152,19 +156,20 @@ defmodule Realtime.Database do
   """
 
   @connections_query """
-  SELECT (current_setting('max_connections')::int - count(*))::int
+  SELECT (current_setting('max_connections')::int - count(*))::int,
+         current_setting('max_connections')::int
   FROM pg_stat_activity
   WHERE application_name != 'realtime_connect'
   """
 
   defp query_connection_info(conn) do
-    %{rows: [[available_connections]]} = Postgrex.query!(conn, @connections_query, [])
+    %{rows: [[available_connections, max_connections]]} = Postgrex.query!(conn, @connections_query, [])
     %{rows: [[table_exists]]} = Postgrex.query!(conn, @migrations_table_exists_query, [])
 
     %{rows: [[migrations_ran]]} =
       if table_exists, do: Postgrex.query!(conn, @migrations_count_query, []), else: %{rows: [[0]]}
 
-    {:ok, [available_connections, migrations_ran]}
+    {:ok, [available_connections, max_connections, migrations_ran]}
   rescue
     e ->
       GenServer.stop(conn)

--- a/lib/realtime/tenants/temp_state_store.ex
+++ b/lib/realtime/tenants/temp_state_store.ex
@@ -6,7 +6,9 @@ defmodule Realtime.Tenants.TempStateStore do
   (`config.state.enabled = true`) and a dedicated process is started for that channel. It is only
   honoured on private (authenticated) channels because it opens a dedicated session against the
   tenant database; allowing it on public channels would let anyone spin up sessions and write to
-  the tenant database.
+  the tenant database. Note that beyond the private-channel gate there is no per-feature
+  authorization: any user allowed to join the private channel gets full access to their own
+  store (state is per-connection scratch space, never shared across users).
 
   ## Ownership model
 
@@ -20,21 +22,37 @@ defmodule Realtime.Tenants.TempStateStore do
   two independent stores, connections and temp tables. This is per-connection scratch space, not
   shared state broadcast to a topic's subscribers.
 
-  On connect the session is configured and the `TEMP TABLE` is created via Postgrex's
-  `:after_connect` hook. The connection uses `backoff_type: :stop`, so a dropped connection is not
-  retried: the store stops instead and the channel re-creates one on its next join if it still
-  wants state. The temp table therefore tracks the lifetime of a single session.
+  `start/3` returns as soon as the store process is registered; the database connection, session
+  setup and `TEMP TABLE` creation happen asynchronously in a `handle_continue` so channel joins
+  never block on the tenant database and a slow tenant cannot stall the shared supervisor.
+  Commands sent before setup completes simply queue behind it. If the connection cannot be
+  established (or the capacity check below fails) the store stops; the channel monitors the
+  store and notifies the client that state is unavailable.
+
+  The connection uses `backoff_type: :stop`, so a dropped connection is not retried: the store
+  stops instead and the channel re-creates one on its next join if it still wants state. The
+  store also monitors the tenant's `Realtime.Tenants.Connect` process and stops when it goes
+  down, so tenant-level teardown (rebalancing, database settings changes) also closes these
+  sessions instead of leaving them behind. The temp table therefore tracks the lifetime of a
+  single session.
 
   ## Per-tenant limit
 
   Because each store holds a dedicated tenant-database session, the number of live stores is
-  capped. The cap is driven by the database itself rather than by Realtime bookkeeping: before
-  starting a store, `start/4` counts the live `realtime_temp_state` sessions in the tenant
-  database (`pg_stat_activity`) and compares them against a fraction of that database's
-  `max_connections` (and the `max_per_tenant/0` ceiling). This is authoritative and naturally
-  cluster-wide — every node's sessions appear in `pg_stat_activity` — so it guarantees the limit
-  tracks real database capacity. `start/4` returns `{:error, :too_many_state_stores}` once the
-  limit is reached; the channel treats that as "no store" and joins without one.
+  capped in two layers, both bounded by `capacity_limit/1` (`min(max_per_tenant(),
+  max_connection_fraction() * max_connections)`):
+
+    * a node-local gate: store starts are serialized through the DynamicSupervisor and counted
+      in `Realtime.Registry`, so on a single node the cap is exact and `start/3` returns
+      `{:error, :too_many_state_stores}` synchronously;
+    * a cluster-wide backstop: after connecting, the store counts the live
+      `realtime_temp_state` sessions in the tenant database (`pg_stat_activity`, which includes
+      its own session) and stops itself if the limit is exceeded.
+
+  The backstop is check-after-connect rather than check-then-act, so a cross-node burst can
+  transiently open more sessions than the cap, but the surplus stores terminate themselves and
+  the steady state converges to the limit. This capacity is also reserved in
+  `Realtime.Database.check_tenant_connection/1` so tenant provisioning accounts for it.
 
   Because the table is a `TEMP TABLE` it lives in `pg_temp` and is therefore:
 
@@ -44,17 +62,20 @@ defmodule Realtime.Tenants.TempStateStore do
 
   The supported SQL surface is intentionally tiny and only ever touches the channel's own
   temp table by primary key: `put`, `insert`, `update`, `delete`, `get`, `clear` and `count`.
-  No joins, no sorts, no aggregation beyond a single `count(*)` health check, and no access to
-  any other table.
+  No joins, no sorts, no aggregation beyond the `count(*)` health check, and no access to
+  any other table. Values are bound as JSON text and cast server-side (`::text::jsonb`), so
+  they are stored as real jsonb documents and the size limit measures exactly what is stored.
 
   ## Input limits
 
   To keep unbounded data out of the tenant's temp space, writes are bounded in the application:
 
-    * keys larger than 1024 bytes are rejected (`:key_too_large`)
-    * values larger than `max_value_bytes/0` are rejected (`:value_too_large`)
+    * keys must be strings of at most 1024 bytes (`:invalid_key` / `:key_too_large`)
+    * values larger than `max_value_bytes/0` (JSON-encoded) are rejected (`:value_too_large`)
     * a store holds at most `max_keys/0` keys; a new key past that returns `:limit_reached`
-      (updates to existing keys are still allowed)
+      (updates to existing keys are still allowed). The key count is tracked in the owner
+      process — exact, because all mutations are serialized through it — so writes pay no
+      extra SQL for limit enforcement.
 
   These are enforced regardless of the session guardrails below, which cannot be fully relied on.
 
@@ -71,6 +92,7 @@ defmodule Realtime.Tenants.TempStateStore do
 
   alias Realtime.Api.Tenant
   alias Realtime.Database
+  alias Realtime.Tenants.Connect
 
   @application_name "realtime_temp_state"
   @default_max_per_tenant 10
@@ -79,10 +101,18 @@ defmodule Realtime.Tenants.TempStateStore do
   @default_max_keys 10_000
   @max_key_bytes 1024
 
+  # Query timeout for every statement; the GenServer.call timeout must exceed it so a slow
+  # query is reported as its real outcome instead of a caller timeout for a write that
+  # actually committed.
+  @query_timeout 15_000
+  @call_timeout @query_timeout + 5_000
+  @idle_interval 30_000
+
+  # Runs on the store's own session, so the count includes this session.
   @capacity_query """
-  SELECT
-    (SELECT count(*) FROM pg_stat_activity WHERE application_name = $1 AND datname = current_database()),
-    current_setting('max_connections')::int
+  SELECT count(*), current_setting('max_connections')::int
+  FROM pg_stat_activity
+  WHERE application_name = $1 AND datname = current_database()
   """
 
   @session_settings [
@@ -94,16 +124,7 @@ defmodule Realtime.Tenants.TempStateStore do
   @type version :: non_neg_integer()
   @type expected :: version() | nil
 
-  @type command ::
-          {:put, key :: String.t(), value :: term()}
-          | {:insert, key :: String.t(), value :: term()}
-          | {:update, key :: String.t(), value :: term(), expected()}
-          | {:delete, key :: String.t(), expected()}
-          | {:get, key :: String.t()}
-          | :clear
-          | :count
-
-  defstruct [:conn, :table, :channel_name, :monitored_pid]
+  defstruct [:tenant, :conn, :table, :monitored_pid, :channel_ref, :connect_ref, key_count: 0]
 
   ## Public API
 
@@ -111,28 +132,19 @@ defmodule Realtime.Tenants.TempStateStore do
   Starts a temp state store for a channel under the dedicated DynamicSupervisor.
 
   `monitored_pid` is the channel process: when it goes down the store stops and the session
-  (and therefore the temp table) is torn down. `db_conn` is the tenant's shared connection, used
-  to read live capacity from the database before opening a new session.
+  (and therefore the temp table) is torn down. Returns `{:error, :too_many_state_stores}` when
+  the node-local cap is already reached; the database connection itself is established
+  asynchronously after this returns.
   """
-  @spec start(Tenant.t(), pid(), String.t(), pid()) :: {:ok, pid()} | {:error, term()}
-  def start(%Tenant{} = tenant, monitored_pid, channel_name, db_conn) do
-    with :ok <- within_capacity(db_conn) do
-      opts = [tenant: tenant, monitored_pid: monitored_pid, channel_name: channel_name]
-      DynamicSupervisor.start_child(__MODULE__.DynamicSupervisor, {__MODULE__, opts})
-    end
+  @spec start(Tenant.t(), pid(), String.t()) :: {:ok, pid()} | {:error, term()}
+  def start(%Tenant{} = tenant, monitored_pid, channel_name) do
+    opts = [tenant: tenant, monitored_pid: monitored_pid, channel_name: channel_name]
+    DynamicSupervisor.start_child(__MODULE__.DynamicSupervisor, {__MODULE__, opts})
   end
 
-  defp within_capacity(db_conn) do
-    case Postgrex.query(db_conn, @capacity_query, [@application_name]) do
-      {:ok, %{rows: [[used, max_connections]]}} ->
-        if used >= capacity_limit(max_connections), do: {:error, :too_many_state_stores}, else: :ok
-
-      {:error, _} ->
-        {:error, :cap_check_failed}
-    end
-  end
-
-  defp capacity_limit(max_connections) do
+  @doc "Effective cap on live stores for a database with the given `max_connections`."
+  @spec capacity_limit(pos_integer()) :: pos_integer()
+  def capacity_limit(max_connections) do
     from_database = max(1, floor(max_connections * max_connection_fraction()))
     min(max_per_tenant(), from_database)
   end
@@ -205,48 +217,94 @@ defmodule Realtime.Tenants.TempStateStore do
   def count(pid), do: call(pid, :count)
 
   defp call(pid, command) do
-    GenServer.call(pid, {:command, command})
+    GenServer.call(pid, {:command, command}, @call_timeout)
   catch
     :exit, _ -> {:error, :unavailable}
   end
 
   ## GenServer callbacks
 
+  # init stays IO-free so store starts never block the shared DynamicSupervisor: it only
+  # applies the node-local cap (exact, because starts are serialized through the supervisor
+  # and registrations are cleaned up on process death) and registers monitors. The database
+  # work happens in handle_continue.
   @impl true
   def init(opts) do
     Process.flag(:trap_exit, true)
     tenant = Keyword.fetch!(opts, :tenant)
     monitored_pid = Keyword.fetch!(opts, :monitored_pid)
     channel_name = Keyword.fetch!(opts, :channel_name)
-    table = table_name(channel_name)
 
     Logger.metadata(external_id: tenant.external_id, project: tenant.external_id)
 
+    registry_key = {__MODULE__, tenant.external_id}
+
+    if Registry.count_match(Realtime.Registry, registry_key, :_) >= max_per_tenant() do
+      {:stop, :too_many_state_stores}
+    else
+      {:ok, _} = Registry.register(Realtime.Registry, registry_key, nil)
+      channel_ref = Process.monitor(monitored_pid)
+
+      state = %__MODULE__{
+        tenant: tenant,
+        table: table_name(channel_name),
+        monitored_pid: monitored_pid,
+        channel_ref: channel_ref
+      }
+
+      {:ok, state, {:continue, :connect}}
+    end
+  end
+
+  @impl true
+  def handle_continue(:connect, %{tenant: tenant, table: table} = state) do
     case connect(tenant, table) do
       {:ok, conn} ->
-        Process.monitor(monitored_pid)
+        # conn goes into state before the capacity check so terminate/2 closes the session
+        # on every failure path from here on.
+        state = %{state | conn: conn, tenant: nil}
 
-        {:ok,
-         %__MODULE__{
-           conn: conn,
-           table: table,
-           channel_name: channel_name,
-           monitored_pid: monitored_pid
-         }}
+        case within_capacity(conn) do
+          :ok ->
+            # Tie the session to the tenant's Connect lifecycle so tenant-level teardown
+            # (rebalancing, db settings changes) also closes it. Lenient when Connect is not
+            # registered (e.g. unit tests exercising the store directly).
+            connect_ref =
+              case Connect.whereis(tenant.external_id) do
+                pid when is_pid(pid) -> Process.monitor(pid)
+                _ -> nil
+              end
+
+            {:noreply, %{state | connect_ref: connect_ref}}
+
+          {:error, :too_many_state_stores} ->
+            log_warning("TempStateStoreLimitReached", "Per-tenant temp state store limit reached")
+            {:stop, :normal, state}
+
+          {:error, error} ->
+            log_error("TempStateStoreConnectionError", error)
+            {:stop, :normal, state}
+        end
 
       {:error, error} ->
         log_error("TempStateStoreConnectionError", error)
-        {:stop, :normal}
+        {:stop, :normal, state}
     end
   end
 
   @impl true
   def handle_call({:command, command}, _from, state) do
-    {:reply, run(command, state), state}
+    {reply, state} = run(command, state)
+    {:reply, reply, state}
   end
 
   @impl true
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, %{monitored_pid: pid} = state) do
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{channel_ref: ref} = state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{connect_ref: ref} = state) do
+    Logger.info("Tenant connection process terminated, stopping temp state store")
     {:stop, :normal, state}
   end
 
@@ -266,140 +324,168 @@ defmodule Realtime.Tenants.TempStateStore do
   def terminate(_reason, _state), do: :ok
 
   ## Commands
+  #
+  # Every clause returns {reply, state}. key_count is exact: this process serializes all
+  # mutations, so counting inserted/deleted keys app-side replaces a count(*) scan per write.
 
-  defp run({:put, key, value}, %{conn: conn, table: table}) do
-    sql = """
-    INSERT INTO #{table} (key, value)
-    SELECT $1, $2::jsonb
-    WHERE (SELECT count(*) FROM #{table}) < $3
-       OR EXISTS (SELECT 1 FROM #{table} WHERE key = $1)
-    ON CONFLICT (key)
-    DO UPDATE SET value = EXCLUDED.value,
-                  version = #{table}.version + 1,
-                  updated_at = clock_timestamp()
-    RETURNING version
-    """
-
-    with {:ok, value} <- encode_and_validate(key, value),
-         {:ok, result} <- query(conn, sql, [key, value, max_keys()]) do
-      case result do
-        %{rows: [[version]]} -> {:ok, version}
-        %{num_rows: 0} -> {:error, :limit_reached}
-      end
-    end
-  end
-
-  defp run({:insert, key, value}, %{conn: conn, table: table}) do
-    sql = """
-    INSERT INTO #{table} (key, value)
-    SELECT $1, $2::jsonb
-    WHERE (SELECT count(*) FROM #{table}) < $3
-       OR EXISTS (SELECT 1 FROM #{table} WHERE key = $1)
-    RETURNING version
-    """
-
+  defp run({:put, key, value}, %{conn: conn, table: table, key_count: key_count} = state) do
     with {:ok, value} <- encode_and_validate(key, value) do
-      case query(conn, sql, [key, value, max_keys()]) do
-        {:ok, %{rows: [[version]]}} -> {:ok, version}
-        {:ok, %{num_rows: 0}} -> {:error, :limit_reached}
-        {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} -> {:error, :already_exists}
-        {:error, _} = error -> error
+      if key_count < max_keys() do
+        sql = """
+        INSERT INTO #{table} (key, value)
+        VALUES ($1, $2::text::jsonb)
+        ON CONFLICT (key)
+        DO UPDATE SET value = EXCLUDED.value,
+                      version = #{table}.version + 1,
+                      updated_at = clock_timestamp()
+        RETURNING version
+        """
+
+        case query(conn, sql, [key, value]) do
+          # version 1 can only come from a fresh insert; conflicting rows always bump past it
+          {:ok, %{rows: [[1]]}} -> {{:ok, 1}, %{state | key_count: key_count + 1}}
+          {:ok, %{rows: [[version]]}} -> {{:ok, version}, state}
+          {:error, _} = error -> {error, state}
+        end
+      else
+        # At the key cap only updates to existing keys are allowed
+        case update_row(conn, table, key, value, nil) do
+          {:ok, %{rows: [[version]]}} -> {{:ok, version}, state}
+          {:ok, %{num_rows: 0}} -> {{:error, :limit_reached}, state}
+          {:error, _} = error -> {error, state}
+        end
       end
+    else
+      error -> {error, state}
     end
   end
 
-  defp run({:update, key, value, expected}, %{conn: conn, table: table}) do
-    {sql, params_tail} =
-      case expected do
-        nil ->
-          {"UPDATE #{table} SET value = $2::jsonb, version = version + 1, updated_at = clock_timestamp() WHERE key = $1 RETURNING version",
-           []}
-
-        version ->
-          {"UPDATE #{table} SET value = $2::jsonb, version = version + 1, updated_at = clock_timestamp() WHERE key = $1 AND version = $3 RETURNING version",
-           [version]}
-      end
-
+  defp run({:insert, key, value}, %{conn: conn, table: table, key_count: key_count} = state) do
     with {:ok, value} <- encode_and_validate(key, value) do
-      case query(conn, sql, [key, value | params_tail]) do
-        {:ok, %{rows: [[version]]}} -> {:ok, version}
-        {:ok, %{num_rows: 0}} when is_nil(expected) -> {:error, :not_found}
-        {:ok, %{num_rows: 0}} -> version_conflict(conn, table, key)
-        {:error, _} = error -> error
+      if key_count < max_keys() do
+        sql = "INSERT INTO #{table} (key, value) VALUES ($1, $2::text::jsonb) RETURNING version"
+
+        case query(conn, sql, [key, value]) do
+          {:ok, %{rows: [[version]]}} -> {{:ok, version}, %{state | key_count: key_count + 1}}
+          {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} -> {{:error, :already_exists}, state}
+          {:error, _} = error -> {error, state}
+        end
+      else
+        {{:error, :limit_reached}, state}
       end
+    else
+      error -> {error, state}
     end
   end
 
-  defp run({:delete, key, expected}, %{conn: conn, table: table}) do
-    {sql, params} =
-      case expected do
-        nil -> {"DELETE FROM #{table} WHERE key = $1", [key]}
-        version -> {"DELETE FROM #{table} WHERE key = $1 AND version = $2", [key, version]}
+  defp run({:update, key, value, expected}, %{conn: conn, table: table} = state) do
+    with {:ok, value} <- encode_and_validate(key, value) do
+      case update_row(conn, table, key, value, expected) do
+        {:ok, %{rows: [[version]]}} -> {{:ok, version}, state}
+        {:ok, %{num_rows: 0}} when is_nil(expected) -> {{:error, :not_found}, state}
+        {:ok, %{num_rows: 0}} -> {version_conflict(conn, table, key), state}
+        {:error, _} = error -> {error, state}
       end
-
-    case query(conn, sql, params) do
-      {:ok, %{num_rows: 0}} when is_nil(expected) -> {:error, :not_found}
-      {:ok, %{num_rows: 0}} -> version_conflict(conn, table, key)
-      {:ok, _} -> {:ok, :deleted}
-      {:error, _} = error -> error
+    else
+      error -> {error, state}
     end
   end
 
-  defp run({:get, key}, %{conn: conn, table: table}) do
-    sql = "SELECT value, version, updated_at FROM #{table} WHERE key = $1"
+  defp run({:delete, key, expected}, %{conn: conn, table: table, key_count: key_count} = state) do
+    with :ok <- validate_key(key) do
+      {sql, params} =
+        case expected do
+          nil -> {"DELETE FROM #{table} WHERE key = $1", [key]}
+          version -> {"DELETE FROM #{table} WHERE key = $1 AND version = $2", [key, version]}
+        end
 
-    case query(conn, sql, [key]) do
-      {:ok, %{rows: [[value, version, updated_at]]}} ->
-        {:ok, %{value: decode(value), version: version, updated_at: updated_at}}
-
-      {:ok, %{num_rows: 0}} ->
-        {:error, :not_found}
-
-      {:error, _} = error ->
-        error
+      case query(conn, sql, params) do
+        {:ok, %{num_rows: 0}} when is_nil(expected) -> {{:error, :not_found}, state}
+        {:ok, %{num_rows: 0}} -> {version_conflict(conn, table, key), state}
+        {:ok, _} -> {{:ok, :deleted}, %{state | key_count: max(key_count - 1, 0)}}
+        {:error, _} = error -> {error, state}
+      end
+    else
+      error -> {error, state}
     end
   end
 
-  defp run(:clear, %{conn: conn, table: table}) do
+  defp run({:get, key}, %{conn: conn, table: table} = state) do
+    with :ok <- validate_key(key) do
+      sql = "SELECT value, version, updated_at FROM #{table} WHERE key = $1"
+
+      case query(conn, sql, [key]) do
+        {:ok, %{rows: [[value, version, updated_at]]}} ->
+          {{:ok, %{value: value, version: version, updated_at: updated_at}}, state}
+
+        {:ok, %{num_rows: 0}} ->
+          {{:error, :not_found}, state}
+
+        {:error, _} = error ->
+          {error, state}
+      end
+    else
+      error -> {error, state}
+    end
+  end
+
+  defp run(:clear, %{conn: conn, table: table} = state) do
     case query(conn, "TRUNCATE #{table}", []) do
-      {:ok, _} -> :ok
-      {:error, _} = error -> error
+      {:ok, _} -> {:ok, %{state | key_count: 0}}
+      {:error, _} = error -> {error, state}
     end
   end
 
-  defp run(:count, %{conn: conn, table: table}) do
+  defp run(:count, %{conn: conn, table: table} = state) do
     case query(conn, "SELECT count(*) FROM #{table}", []) do
-      {:ok, %{rows: [[count]]}} -> {:ok, count}
-      {:error, _} = error -> error
+      {:ok, %{rows: [[count]]}} -> {{:ok, count}, state}
+      {:error, _} = error -> {error, state}
     end
   end
 
   ## Private
 
+  defp update_row(conn, table, key, value, expected) do
+    {sql_tail, params_tail} =
+      case expected do
+        nil -> {"", []}
+        version -> {" AND version = $3", [version]}
+      end
+
+    sql = """
+    UPDATE #{table}
+    SET value = $2::text::jsonb, version = version + 1, updated_at = clock_timestamp()
+    WHERE key = $1#{sql_tail}
+    RETURNING version
+    """
+
+    query(conn, sql, [key, value | params_tail])
+  end
+
   defp query(conn, sql, params) do
-    Postgrex.query(conn, sql, params)
+    Postgrex.query(conn, sql, params, timeout: @query_timeout)
   end
 
   defp encode_and_validate(key, value) do
-    cond do
-      byte_size(key) > @max_key_bytes ->
-        {:error, :key_too_large}
-
-      true ->
-        with {:ok, encoded} <- encode(value) do
-          if byte_size(encoded) > max_value_bytes(), do: {:error, :value_too_large}, else: {:ok, encoded}
-        end
+    with :ok <- validate_key(key),
+         {:ok, encoded} <- encode(value) do
+      if byte_size(encoded) > max_value_bytes(), do: {:error, :value_too_large}, else: {:ok, encoded}
     end
   end
 
-  defp encode(value) do
-    {:ok, Jason.encode!(value)}
-  rescue
-    error -> {:error, error}
-  end
+  defp validate_key(key) when is_binary(key) and byte_size(key) <= @max_key_bytes, do: :ok
+  defp validate_key(key) when is_binary(key), do: {:error, :key_too_large}
+  defp validate_key(_key), do: {:error, :invalid_key}
 
-  defp decode(value) when is_binary(value), do: Jason.decode!(value)
-  defp decode(value), do: value
+  defp encode(value) do
+    case Jason.encode(value) do
+      {:ok, encoded} -> {:ok, encoded}
+      {:error, _} -> {:error, :invalid_value}
+    end
+  rescue
+    # Jason raises Protocol.UndefinedError for unencodable structs
+    _ -> {:error, :invalid_value}
+  end
 
   defp version_conflict(conn, table, key) do
     case query(conn, "SELECT version FROM #{table} WHERE key = $1", [key]) do
@@ -409,35 +495,36 @@ defmodule Realtime.Tenants.TempStateStore do
     end
   end
 
-  defp connect(tenant, table) do
-    with {:ok, settings} <- Database.from_tenant(tenant, @application_name, :stop),
-         {:ok, conn} <-
-           Postgrex.start_link(
-             hostname: settings.hostname,
-             port: settings.port,
-             database: settings.database,
-             username: settings.username,
-             password: settings.password,
-             pool_size: 1,
-             parameters: [application_name: @application_name],
-             socket_options: settings.socket_options,
-             ssl: settings.ssl,
-             backoff_type: :stop,
-             after_connect: {__MODULE__, :setup_session, [table]}
-           ),
-         {:ok, _} <- ready(conn) do
-      {:ok, conn}
+  # The capacity query doubles as the readiness check: it blocks until the connection is
+  # established (or fails), and its result enforces the cluster-wide cap from the session's
+  # own point of view — the count includes this session, so strictly greater means over cap.
+  defp within_capacity(conn) do
+    case Postgrex.query(conn, @capacity_query, [@application_name], timeout: @query_timeout) do
+      {:ok, %{rows: [[used, max_connections]]}} ->
+        if used > capacity_limit(max_connections), do: {:error, :too_many_state_stores}, else: :ok
+
+      {:error, _} = error ->
+        error
     end
   end
 
-  defp ready(conn) do
-    case Postgrex.query(conn, "SELECT 1", []) do
-      {:ok, _} = ok ->
-        ok
-
-      {:error, _} = error ->
-        Process.exit(conn, :shutdown)
-        error
+  defp connect(tenant, table) do
+    with {:ok, settings} <- Database.from_tenant(tenant, @application_name, :stop) do
+      Postgrex.start_link(
+        hostname: settings.hostname,
+        port: settings.port,
+        database: settings.database,
+        username: settings.username,
+        password: settings.password,
+        pool_size: 1,
+        queue_target: settings.queue_target,
+        idle_interval: @idle_interval,
+        parameters: [application_name: @application_name],
+        socket_options: settings.socket_options,
+        ssl: settings.ssl,
+        backoff_type: :stop,
+        after_connect: {__MODULE__, :setup_session, [table]}
+      )
     end
   end
 

--- a/lib/realtime/tenants/temp_state_store.ex
+++ b/lib/realtime/tenants/temp_state_store.ex
@@ -1,0 +1,482 @@
+defmodule Realtime.Tenants.TempStateStore do
+  @moduledoc """
+  Session-local, channel-scoped key/value state backed by a PostgreSQL temporary table.
+
+  This is an opt-in feature: a private channel asks for it through the join payload
+  (`config.state.enabled = true`) and a dedicated process is started for that channel. It is only
+  honoured on private (authenticated) channels because it opens a dedicated session against the
+  tenant database; allowing it on public channels would let anyone spin up sessions and write to
+  the tenant database.
+
+  ## Ownership model
+
+      one process owns one connection
+      one connection owns one temp table
+      all mutations go through that owner
+
+  Each opted-in channel gets its own `Realtime.Tenants.TempStateStore` process that owns a
+  dedicated Postgrex connection (pool size 1) against the tenant database. The scope is the
+  *channel process* (one socket join), not the topic: two clients on the same private topic get
+  two independent stores, connections and temp tables. This is per-connection scratch space, not
+  shared state broadcast to a topic's subscribers.
+
+  On connect the session is configured and the `TEMP TABLE` is created via Postgrex's
+  `:after_connect` hook. The connection uses `backoff_type: :stop`, so a dropped connection is not
+  retried: the store stops instead and the channel re-creates one on its next join if it still
+  wants state. The temp table therefore tracks the lifetime of a single session.
+
+  ## Per-tenant limit
+
+  Because each store holds a dedicated tenant-database session, the number of live stores is
+  capped. The cap is driven by the database itself rather than by Realtime bookkeeping: before
+  starting a store, `start/4` counts the live `realtime_temp_state` sessions in the tenant
+  database (`pg_stat_activity`) and compares them against a fraction of that database's
+  `max_connections` (and the `max_per_tenant/0` ceiling). This is authoritative and naturally
+  cluster-wide — every node's sessions appear in `pg_stat_activity` — so it guarantees the limit
+  tracks real database capacity. `start/4` returns `{:error, :too_many_state_stores}` once the
+  limit is reached; the channel treats that as "no store" and joins without one.
+
+  Because the table is a `TEMP TABLE` it lives in `pg_temp` and is therefore:
+
+    * connection-local
+    * disposable and rebuildable
+    * gone when the session ends
+
+  The supported SQL surface is intentionally tiny and only ever touches the channel's own
+  temp table by primary key: `put`, `insert`, `update`, `delete`, `get`, `clear` and `count`.
+  No joins, no sorts, no aggregation beyond a single `count(*)` health check, and no access to
+  any other table.
+
+  ## Input limits
+
+  To keep unbounded data out of the tenant's temp space, writes are bounded in the application:
+
+    * keys larger than 1024 bytes are rejected (`:key_too_large`)
+    * values larger than `max_value_bytes/0` are rejected (`:value_too_large`)
+    * a store holds at most `max_keys/0` keys; a new key past that returns `:limit_reached`
+      (updates to existing keys are still allowed)
+
+  These are enforced regardless of the session guardrails below, which cannot be fully relied on.
+
+  > #### Not guaranteed RAM-only {: .warning}
+  >
+  > PostgreSQL temp tables are not strictly guaranteed to be memory-only. We raise `temp_buffers`
+  > and keep the workload to primary-key access. We also *attempt* a low `temp_file_limit`, but
+  > that parameter is superuser-only (`SUSET`) and is silently skipped for the least-privilege
+  > tenant role used at runtime — so it is not a reliable guard. The application-level input limits
+  > above are what actually bound storage; core PostgreSQL provides no hard "RAM-only" mode.
+  """
+  use GenServer, restart: :temporary
+  use Realtime.Logs
+
+  alias Realtime.Api.Tenant
+  alias Realtime.Database
+
+  @application_name "realtime_temp_state"
+  @default_max_per_tenant 10
+  @default_max_connection_fraction 0.1
+  @default_max_value_bytes 256_000
+  @default_max_keys 10_000
+  @max_key_bytes 1024
+
+  @capacity_query """
+  SELECT
+    (SELECT count(*) FROM pg_stat_activity WHERE application_name = $1 AND datname = current_database()),
+    current_setting('max_connections')::int
+  """
+
+  @session_settings [
+    "SET temp_buffers = '32MB'",
+    "SET work_mem = '4MB'",
+    "SET temp_file_limit = '1MB'"
+  ]
+
+  @type version :: non_neg_integer()
+  @type expected :: version() | nil
+
+  @type command ::
+          {:put, key :: String.t(), value :: term()}
+          | {:insert, key :: String.t(), value :: term()}
+          | {:update, key :: String.t(), value :: term(), expected()}
+          | {:delete, key :: String.t(), expected()}
+          | {:get, key :: String.t()}
+          | :clear
+          | :count
+
+  defstruct [:conn, :table, :channel_name, :monitored_pid]
+
+  ## Public API
+
+  @doc """
+  Starts a temp state store for a channel under the dedicated DynamicSupervisor.
+
+  `monitored_pid` is the channel process: when it goes down the store stops and the session
+  (and therefore the temp table) is torn down. `db_conn` is the tenant's shared connection, used
+  to read live capacity from the database before opening a new session.
+  """
+  @spec start(Tenant.t(), pid(), String.t(), pid()) :: {:ok, pid()} | {:error, term()}
+  def start(%Tenant{} = tenant, monitored_pid, channel_name, db_conn) do
+    with :ok <- within_capacity(db_conn) do
+      opts = [tenant: tenant, monitored_pid: monitored_pid, channel_name: channel_name]
+      DynamicSupervisor.start_child(__MODULE__.DynamicSupervisor, {__MODULE__, opts})
+    end
+  end
+
+  defp within_capacity(db_conn) do
+    case Postgrex.query(db_conn, @capacity_query, [@application_name]) do
+      {:ok, %{rows: [[used, max_connections]]}} ->
+        if used >= capacity_limit(max_connections), do: {:error, :too_many_state_stores}, else: :ok
+
+      {:error, _} ->
+        {:error, :cap_check_failed}
+    end
+  end
+
+  defp capacity_limit(max_connections) do
+    from_database = max(1, floor(max_connections * max_connection_fraction()))
+    min(max_per_tenant(), from_database)
+  end
+
+  @doc "Absolute ceiling on live stores per tenant database, regardless of `max_connections`."
+  @spec max_per_tenant() :: pos_integer()
+  def max_per_tenant do
+    Application.get_env(:realtime, :temp_state_store_max_per_tenant, @default_max_per_tenant)
+  end
+
+  @doc "Fraction of the tenant database's `max_connections` that temp state stores may use."
+  @spec max_connection_fraction() :: float()
+  def max_connection_fraction do
+    Application.get_env(:realtime, :temp_state_store_max_connection_fraction, @default_max_connection_fraction)
+  end
+
+  @doc "Maximum byte size of a single (JSON-encoded) value."
+  @spec max_value_bytes() :: pos_integer()
+  def max_value_bytes do
+    Application.get_env(:realtime, :temp_state_store_max_value_bytes, @default_max_value_bytes)
+  end
+
+  @doc "Maximum number of keys a single store may hold."
+  @spec max_keys() :: pos_integer()
+  def max_keys do
+    Application.get_env(:realtime, :temp_state_store_max_keys, @default_max_keys)
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc "Upsert a key. Returns `{:ok, version}`."
+  @spec put(pid(), String.t(), term()) :: {:ok, integer()} | {:error, term()}
+  def put(pid, key, value), do: call(pid, {:put, key, value})
+
+  @doc "Insert a key that must not exist yet. Returns `{:ok, version}` or `{:error, :already_exists}`."
+  @spec insert(pid(), String.t(), term()) :: {:ok, integer()} | {:error, term()}
+  def insert(pid, key, value), do: call(pid, {:insert, key, value})
+
+  @doc """
+  Update a key that must already exist. Returns `{:ok, version}` or `{:error, :not_found}`.
+
+  Pass `expected` (the version last read) for an optimistic, compare-and-set update: it only
+  applies when the current version matches, otherwise returns `{:error, {:version_mismatch, current}}`
+  so the caller can re-read and retry. With `nil` (the default) it is a last-write-wins update.
+  """
+  @spec update(pid(), String.t(), term(), expected()) :: {:ok, version()} | {:error, term()}
+  def update(pid, key, value, expected \\ nil), do: call(pid, {:update, key, value, expected})
+
+  @doc """
+  Delete a key. Returns `{:ok, :deleted}` or `{:error, :not_found}`.
+
+  Pass `expected` for a compare-and-set delete: it only applies when the current version matches,
+  otherwise returns `{:error, {:version_mismatch, current}}`.
+  """
+  @spec delete(pid(), String.t(), expected()) :: {:ok, :deleted} | {:error, term()}
+  def delete(pid, key, expected \\ nil), do: call(pid, {:delete, key, expected})
+
+  @doc "Read a key by primary key. Returns `{:ok, %{value, version, updated_at}}` or `{:error, :not_found}`."
+  @spec get(pid(), String.t()) :: {:ok, map()} | {:error, term()}
+  def get(pid, key), do: call(pid, {:get, key})
+
+  @doc "Remove all rows via `TRUNCATE`."
+  @spec clear(pid()) :: :ok | {:error, term()}
+  def clear(pid), do: call(pid, :clear)
+
+  @doc "Health-check count of rows in the temp table. Not for the hot path."
+  @spec count(pid()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def count(pid), do: call(pid, :count)
+
+  defp call(pid, command) do
+    GenServer.call(pid, {:command, command})
+  catch
+    :exit, _ -> {:error, :unavailable}
+  end
+
+  ## GenServer callbacks
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    tenant = Keyword.fetch!(opts, :tenant)
+    monitored_pid = Keyword.fetch!(opts, :monitored_pid)
+    channel_name = Keyword.fetch!(opts, :channel_name)
+    table = table_name(channel_name)
+
+    Logger.metadata(external_id: tenant.external_id, project: tenant.external_id)
+
+    case connect(tenant, table) do
+      {:ok, conn} ->
+        Process.monitor(monitored_pid)
+
+        {:ok,
+         %__MODULE__{
+           conn: conn,
+           table: table,
+           channel_name: channel_name,
+           monitored_pid: monitored_pid
+         }}
+
+      {:error, error} ->
+        log_error("TempStateStoreConnectionError", error)
+        {:stop, :normal}
+    end
+  end
+
+  @impl true
+  def handle_call({:command, command}, _from, state) do
+    {:reply, run(command, state), state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, %{monitored_pid: pid} = state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:EXIT, conn, reason}, %{conn: conn} = state) do
+    log_warning("TempStateStoreConnectionDown", reason)
+    {:stop, :normal, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, %{conn: conn}) when is_pid(conn) do
+    Process.exit(conn, :shutdown)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  ## Commands
+
+  defp run({:put, key, value}, %{conn: conn, table: table}) do
+    sql = """
+    INSERT INTO #{table} (key, value)
+    SELECT $1, $2::jsonb
+    WHERE (SELECT count(*) FROM #{table}) < $3
+       OR EXISTS (SELECT 1 FROM #{table} WHERE key = $1)
+    ON CONFLICT (key)
+    DO UPDATE SET value = EXCLUDED.value,
+                  version = #{table}.version + 1,
+                  updated_at = clock_timestamp()
+    RETURNING version
+    """
+
+    with {:ok, value} <- encode_and_validate(key, value),
+         {:ok, result} <- query(conn, sql, [key, value, max_keys()]) do
+      case result do
+        %{rows: [[version]]} -> {:ok, version}
+        %{num_rows: 0} -> {:error, :limit_reached}
+      end
+    end
+  end
+
+  defp run({:insert, key, value}, %{conn: conn, table: table}) do
+    sql = """
+    INSERT INTO #{table} (key, value)
+    SELECT $1, $2::jsonb
+    WHERE (SELECT count(*) FROM #{table}) < $3
+       OR EXISTS (SELECT 1 FROM #{table} WHERE key = $1)
+    RETURNING version
+    """
+
+    with {:ok, value} <- encode_and_validate(key, value) do
+      case query(conn, sql, [key, value, max_keys()]) do
+        {:ok, %{rows: [[version]]}} -> {:ok, version}
+        {:ok, %{num_rows: 0}} -> {:error, :limit_reached}
+        {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} -> {:error, :already_exists}
+        {:error, _} = error -> error
+      end
+    end
+  end
+
+  defp run({:update, key, value, expected}, %{conn: conn, table: table}) do
+    {sql, params_tail} =
+      case expected do
+        nil ->
+          {"UPDATE #{table} SET value = $2::jsonb, version = version + 1, updated_at = clock_timestamp() WHERE key = $1 RETURNING version",
+           []}
+
+        version ->
+          {"UPDATE #{table} SET value = $2::jsonb, version = version + 1, updated_at = clock_timestamp() WHERE key = $1 AND version = $3 RETURNING version",
+           [version]}
+      end
+
+    with {:ok, value} <- encode_and_validate(key, value) do
+      case query(conn, sql, [key, value | params_tail]) do
+        {:ok, %{rows: [[version]]}} -> {:ok, version}
+        {:ok, %{num_rows: 0}} when is_nil(expected) -> {:error, :not_found}
+        {:ok, %{num_rows: 0}} -> version_conflict(conn, table, key)
+        {:error, _} = error -> error
+      end
+    end
+  end
+
+  defp run({:delete, key, expected}, %{conn: conn, table: table}) do
+    {sql, params} =
+      case expected do
+        nil -> {"DELETE FROM #{table} WHERE key = $1", [key]}
+        version -> {"DELETE FROM #{table} WHERE key = $1 AND version = $2", [key, version]}
+      end
+
+    case query(conn, sql, params) do
+      {:ok, %{num_rows: 0}} when is_nil(expected) -> {:error, :not_found}
+      {:ok, %{num_rows: 0}} -> version_conflict(conn, table, key)
+      {:ok, _} -> {:ok, :deleted}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp run({:get, key}, %{conn: conn, table: table}) do
+    sql = "SELECT value, version, updated_at FROM #{table} WHERE key = $1"
+
+    case query(conn, sql, [key]) do
+      {:ok, %{rows: [[value, version, updated_at]]}} ->
+        {:ok, %{value: decode(value), version: version, updated_at: updated_at}}
+
+      {:ok, %{num_rows: 0}} ->
+        {:error, :not_found}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp run(:clear, %{conn: conn, table: table}) do
+    case query(conn, "TRUNCATE #{table}", []) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
+  defp run(:count, %{conn: conn, table: table}) do
+    case query(conn, "SELECT count(*) FROM #{table}", []) do
+      {:ok, %{rows: [[count]]}} -> {:ok, count}
+      {:error, _} = error -> error
+    end
+  end
+
+  ## Private
+
+  defp query(conn, sql, params) do
+    Postgrex.query(conn, sql, params)
+  end
+
+  defp encode_and_validate(key, value) do
+    cond do
+      byte_size(key) > @max_key_bytes ->
+        {:error, :key_too_large}
+
+      true ->
+        with {:ok, encoded} <- encode(value) do
+          if byte_size(encoded) > max_value_bytes(), do: {:error, :value_too_large}, else: {:ok, encoded}
+        end
+    end
+  end
+
+  defp encode(value) do
+    {:ok, Jason.encode!(value)}
+  rescue
+    error -> {:error, error}
+  end
+
+  defp decode(value) when is_binary(value), do: Jason.decode!(value)
+  defp decode(value), do: value
+
+  defp version_conflict(conn, table, key) do
+    case query(conn, "SELECT version FROM #{table} WHERE key = $1", [key]) do
+      {:ok, %{rows: [[version]]}} -> {:error, {:version_mismatch, version}}
+      {:ok, %{num_rows: 0}} -> {:error, :not_found}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp connect(tenant, table) do
+    with {:ok, settings} <- Database.from_tenant(tenant, @application_name, :stop),
+         {:ok, conn} <-
+           Postgrex.start_link(
+             hostname: settings.hostname,
+             port: settings.port,
+             database: settings.database,
+             username: settings.username,
+             password: settings.password,
+             pool_size: 1,
+             parameters: [application_name: @application_name],
+             socket_options: settings.socket_options,
+             ssl: settings.ssl,
+             backoff_type: :stop,
+             after_connect: {__MODULE__, :setup_session, [table]}
+           ),
+         {:ok, _} <- ready(conn) do
+      {:ok, conn}
+    end
+  end
+
+  defp ready(conn) do
+    case Postgrex.query(conn, "SELECT 1", []) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, _} = error ->
+        Process.exit(conn, :shutdown)
+        error
+    end
+  end
+
+  @doc false
+  def setup_session(conn, table) do
+    Enum.each(@session_settings, fn setting ->
+      case Postgrex.query(conn, setting, []) do
+        {:ok, _} -> :ok
+        {:error, error} -> log_warning("TempStateStoreSettingSkipped", %{setting: setting, error: error})
+      end
+    end)
+
+    Postgrex.query!(
+      conn,
+      """
+      CREATE TEMP TABLE IF NOT EXISTS #{table} (
+        key text PRIMARY KEY,
+        value jsonb NOT NULL,
+        version bigint NOT NULL DEFAULT 1,
+        updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+      ) ON COMMIT PRESERVE ROWS
+      """,
+      []
+    )
+
+    :ok
+  end
+
+  @doc false
+  def table_name(channel_name) do
+    sanitized =
+      channel_name
+      |> String.downcase()
+      |> String.replace(~r/[^a-z0-9]+/, "_")
+      |> String.slice(0, 30)
+      |> String.trim("_")
+
+    hash = :crypto.hash(:sha256, channel_name) |> Base.encode16(case: :lower) |> String.slice(0, 8)
+
+    "realtime_state_#{sanitized}_#{hash}"
+  end
+end

--- a/lib/realtime_web/channels/payloads/config.ex
+++ b/lib/realtime_web/channels/payloads/config.ex
@@ -8,11 +8,13 @@ defmodule RealtimeWeb.Channels.Payloads.Config do
   alias RealtimeWeb.Channels.Payloads.Broadcast
   alias RealtimeWeb.Channels.Payloads.Presence
   alias RealtimeWeb.Channels.Payloads.PostgresChange
+  alias RealtimeWeb.Channels.Payloads.State
   alias RealtimeWeb.Channels.Payloads.FlexibleBoolean
 
   embedded_schema do
     embeds_one :broadcast, Broadcast
     embeds_one :presence, Presence
+    embeds_one :state, State
     embeds_many :postgres_changes, PostgresChange
     field :private, FlexibleBoolean, default: false
   end
@@ -31,6 +33,7 @@ defmodule RealtimeWeb.Channels.Payloads.Config do
     |> cast(attrs, [:private], message: &Join.error_message/2)
     |> cast_embed(:broadcast, invalid_message: "unable to parse, expected a map")
     |> cast_embed(:presence, invalid_message: "unable to parse, expected a map")
+    |> cast_embed(:state, invalid_message: "unable to parse, expected a map")
     |> cast_embed(:postgres_changes, invalid_message: "unable to parse, expected an array of maps")
   end
 end

--- a/lib/realtime_web/channels/payloads/join.ex
+++ b/lib/realtime_web/channels/payloads/join.ex
@@ -46,10 +46,12 @@ defmodule RealtimeWeb.Channels.Payloads.Join do
   def self_broadcast?(%__MODULE__{config: %Config{broadcast: %Broadcast{self: self}}}), do: self
   def self_broadcast?(_), do: false
 
-  def private?(%__MODULE__{config: %Config{private: private}}), do: private
+  # `== true` and not the bare field: an explicit JSON null survives Ecto cast as nil
+  # (field defaults only apply to absent keys), and these values feed strict boolean operators.
+  def private?(%__MODULE__{config: %Config{private: private}}), do: private == true
   def private?(_), do: false
 
-  def state_enabled?(%__MODULE__{config: %Config{state: %State{enabled: enabled}}}), do: enabled
+  def state_enabled?(%__MODULE__{config: %Config{state: %State{enabled: enabled}}}), do: enabled == true
   def state_enabled?(_), do: false
 
   def error_message(_field, meta) do

--- a/lib/realtime_web/channels/payloads/join.ex
+++ b/lib/realtime_web/channels/payloads/join.ex
@@ -7,6 +7,7 @@ defmodule RealtimeWeb.Channels.Payloads.Join do
   alias RealtimeWeb.Channels.Payloads.Config
   alias RealtimeWeb.Channels.Payloads.Broadcast
   alias RealtimeWeb.Channels.Payloads.Presence
+  alias RealtimeWeb.Channels.Payloads.State
 
   embedded_schema do
     embeds_one :config, Config
@@ -47,6 +48,9 @@ defmodule RealtimeWeb.Channels.Payloads.Join do
 
   def private?(%__MODULE__{config: %Config{private: private}}), do: private
   def private?(_), do: false
+
+  def state_enabled?(%__MODULE__{config: %Config{state: %State{enabled: enabled}}}), do: enabled
+  def state_enabled?(_), do: false
 
   def error_message(_field, meta) do
     type = Keyword.get(meta, :type)

--- a/lib/realtime_web/channels/payloads/state.ex
+++ b/lib/realtime_web/channels/payloads/state.ex
@@ -1,0 +1,23 @@
+defmodule RealtimeWeb.Channels.Payloads.State do
+  @moduledoc """
+  Validate the `state` field of the join payload.
+
+  Opts the channel into a session-local, channel-scoped temporary state store backed by a
+  PostgreSQL `TEMP TABLE`. See `Realtime.Tenants.TempStateStore`.
+
+  Only honoured on private channels: it opens a dedicated session against the tenant database, so
+  enabling it on a public (unauthenticated) channel is ignored to avoid abuse.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias RealtimeWeb.Channels.Payloads.Join
+  alias RealtimeWeb.Channels.Payloads.FlexibleBoolean
+
+  embedded_schema do
+    field :enabled, FlexibleBoolean, default: false
+  end
+
+  def changeset(state, attrs) do
+    cast(state, attrs, [:enabled], message: &Join.error_message/2)
+  end
+end

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -149,7 +149,7 @@ defmodule RealtimeWeb.RealtimeChannel do
         tenant_topic: tenant_topic,
         channel_name: sub_topic,
         presence_enabled?: presence_enabled?,
-        temp_state_store: maybe_start_temp_state_store(join, tenant, sub_topic, socket, db_conn)
+        temp_state_store: maybe_start_temp_state_store(join, tenant, sub_topic, socket)
       }
 
       assigns =
@@ -351,7 +351,7 @@ defmodule RealtimeWeb.RealtimeChannel do
       channel_name
     )
 
-    {:noreply, socket}
+    {:noreply, assign(socket, :temp_state_store, nil)}
   end
 
   def handle_info(_msg, %{assigns: %{policies: %Policies{broadcast: %BroadcastPolicies{read: false}}}} = socket) do
@@ -560,6 +560,7 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   def handle_in("state", _payload, socket) do
+    count(socket)
     {:reply, {:error, %{reason: "State store is not enabled for this channel"}}, socket}
   end
 
@@ -1034,29 +1035,32 @@ defmodule RealtimeWeb.RealtimeChannel do
   defp maybe_replay_messages(_, _, _, _, _), do: {:ok, MapSet.new()}
 
   # Maps the constrained client command protocol onto a single TempStateStore operation.
-  defp handle_state_command(store, %{"command" => "put", "key" => key, "value" => value}) do
+  # Keys must be strings: a non-binary key falls through to :invalid_state_command instead of
+  # reaching the store, where it could only fail.
+  defp handle_state_command(store, %{"command" => "put", "key" => key, "value" => value}) when is_binary(key) do
     with {:ok, version} <- TempStateStore.put(store, key, value), do: {:ok, %{version: version}}
   end
 
-  defp handle_state_command(store, %{"command" => "insert", "key" => key, "value" => value}) do
+  defp handle_state_command(store, %{"command" => "insert", "key" => key, "value" => value}) when is_binary(key) do
     with {:ok, version} <- TempStateStore.insert(store, key, value), do: {:ok, %{version: version}}
   end
 
-  defp handle_state_command(store, %{"command" => "update", "key" => key, "value" => value} = payload) do
+  defp handle_state_command(store, %{"command" => "update", "key" => key, "value" => value} = payload)
+       when is_binary(key) do
     with {:ok, expected} <- expected_version(payload),
          {:ok, version} <- TempStateStore.update(store, key, value, expected) do
       {:ok, %{version: version}}
     end
   end
 
-  defp handle_state_command(store, %{"command" => "delete", "key" => key} = payload) do
+  defp handle_state_command(store, %{"command" => "delete", "key" => key} = payload) when is_binary(key) do
     with {:ok, expected} <- expected_version(payload),
          {:ok, :deleted} <- TempStateStore.delete(store, key, expected) do
       {:ok, %{deleted: true}}
     end
   end
 
-  defp handle_state_command(store, %{"command" => "get", "key" => key}) do
+  defp handle_state_command(store, %{"command" => "get", "key" => key}) when is_binary(key) do
     TempStateStore.get(store, key)
   end
 
@@ -1066,9 +1070,11 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   defp handle_state_command(_store, _payload), do: {:error, :invalid_state_command}
 
+  # JSON null for the optional expected version means the same as omitting it.
   defp expected_version(payload) do
     case Map.fetch(payload, "expected") do
       :error -> {:ok, nil}
+      {:ok, nil} -> {:ok, nil}
       {:ok, version} when is_integer(version) -> {:ok, version}
       {:ok, _} -> {:error, :invalid_expected}
     end
@@ -1081,8 +1087,10 @@ defmodule RealtimeWeb.RealtimeChannel do
   # to the tenant database. On a public channel the request is ignored with a warning.
   #
   # Best-effort otherwise: a failure to start the dedicated session must not prevent the channel
-  # from joining, so we log and continue without a store rather than failing the join.
-  defp maybe_start_temp_state_store(join, tenant, sub_topic, socket, db_conn) do
+  # from joining, so we log and continue without a store rather than failing the join. The store
+  # connects asynchronously; if the connection (or the cluster-wide capacity backstop) fails
+  # after this returns, the monitor below fires and the client is notified via a system message.
+  defp maybe_start_temp_state_store(join, tenant, sub_topic, socket) do
     cond do
       not Join.state_enabled?(join) ->
         nil
@@ -1092,7 +1100,7 @@ defmodule RealtimeWeb.RealtimeChannel do
         nil
 
       true ->
-        case TempStateStore.start(tenant, self(), sub_topic, db_conn) do
+        case TempStateStore.start(tenant, self(), sub_topic) do
           {:ok, pid} ->
             Process.monitor(pid)
             pid

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -20,6 +20,7 @@ defmodule RealtimeWeb.RealtimeChannel do
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
   alias Realtime.Tenants.Cache
   alias Realtime.Tenants.Connect
+  alias Realtime.Tenants.TempStateStore
   alias Realtime.UsersCounter
 
   alias RealtimeWeb.Channels.Payloads.Join
@@ -147,7 +148,8 @@ defmodule RealtimeWeb.RealtimeChannel do
         self_broadcast: Join.self_broadcast?(join),
         tenant_topic: tenant_topic,
         channel_name: sub_topic,
-        presence_enabled?: presence_enabled?
+        presence_enabled?: presence_enabled?,
+        temp_state_store: maybe_start_temp_state_store(join, tenant, sub_topic, socket, db_conn)
       }
 
       assigns =
@@ -337,6 +339,21 @@ defmodule RealtimeWeb.RealtimeChannel do
     end
   end
 
+  def handle_info(
+        {:DOWN, _ref, :process, pid, _reason},
+        %{assigns: %{temp_state_store: pid, channel_name: channel_name}} = socket
+      ) do
+    push_system_message(
+      "state",
+      socket,
+      "error",
+      "State store is no longer available, rejoin to re-enable it",
+      channel_name
+    )
+
+    {:noreply, socket}
+  end
+
   def handle_info(_msg, %{assigns: %{policies: %Policies{broadcast: %BroadcastPolicies{read: false}}}} = socket) do
     Logger.warning("Broadcast message ignored")
     {:noreply, socket}
@@ -515,6 +532,35 @@ defmodule RealtimeWeb.RealtimeChannel do
         log_error(socket, "UnableToHandlePresence", error)
         {:reply, :error, socket}
     end
+  end
+
+  def handle_in("state", payload, %{assigns: %{temp_state_store: store}} = socket) when is_pid(store) do
+    count(socket)
+
+    case RateCounter.get(socket.assigns.rate_counter) do
+      {:ok, %{limit: %{triggered: true}}} ->
+        {:reply, {:error, %{reason: "Rate limit exceeded"}}, socket}
+
+      _ ->
+        case handle_state_command(store, payload) do
+          {:ok, reply} ->
+            {:reply, {:ok, reply}, socket}
+
+          {:error, {:version_mismatch, version}} ->
+            {:reply, {:error, %{reason: "version_mismatch", version: version}}, socket}
+
+          {:error, reason} when is_atom(reason) ->
+            {:reply, {:error, %{reason: to_string(reason)}}, socket}
+
+          {:error, reason} ->
+            log_error(socket, "UnableToHandleStateCommand", reason)
+            {:reply, {:error, %{reason: "Unable to handle state command"}}, socket}
+        end
+    end
+  end
+
+  def handle_in("state", _payload, socket) do
+    {:reply, {:error, %{reason: "State store is not enabled for this channel"}}, socket}
   end
 
   def handle_in("access_token", %{"access_token" => "sb_" <> _}, socket) do
@@ -986,6 +1032,81 @@ defmodule RealtimeWeb.RealtimeChannel do
   end
 
   defp maybe_replay_messages(_, _, _, _, _), do: {:ok, MapSet.new()}
+
+  # Maps the constrained client command protocol onto a single TempStateStore operation.
+  defp handle_state_command(store, %{"command" => "put", "key" => key, "value" => value}) do
+    with {:ok, version} <- TempStateStore.put(store, key, value), do: {:ok, %{version: version}}
+  end
+
+  defp handle_state_command(store, %{"command" => "insert", "key" => key, "value" => value}) do
+    with {:ok, version} <- TempStateStore.insert(store, key, value), do: {:ok, %{version: version}}
+  end
+
+  defp handle_state_command(store, %{"command" => "update", "key" => key, "value" => value} = payload) do
+    with {:ok, expected} <- expected_version(payload),
+         {:ok, version} <- TempStateStore.update(store, key, value, expected) do
+      {:ok, %{version: version}}
+    end
+  end
+
+  defp handle_state_command(store, %{"command" => "delete", "key" => key} = payload) do
+    with {:ok, expected} <- expected_version(payload),
+         {:ok, :deleted} <- TempStateStore.delete(store, key, expected) do
+      {:ok, %{deleted: true}}
+    end
+  end
+
+  defp handle_state_command(store, %{"command" => "get", "key" => key}) do
+    TempStateStore.get(store, key)
+  end
+
+  defp handle_state_command(store, %{"command" => "clear"}) do
+    with :ok <- TempStateStore.clear(store), do: {:ok, %{cleared: true}}
+  end
+
+  defp handle_state_command(_store, _payload), do: {:error, :invalid_state_command}
+
+  defp expected_version(payload) do
+    case Map.fetch(payload, "expected") do
+      :error -> {:ok, nil}
+      {:ok, version} when is_integer(version) -> {:ok, version}
+      {:ok, _} -> {:error, :invalid_expected}
+    end
+  end
+
+  # Opt-in, channel-scoped temporary state store backed by a PostgreSQL TEMP TABLE.
+  #
+  # Restricted to private channels: it opens a dedicated session against the tenant database, so
+  # allowing it on public (unauthenticated) channels would let anyone spin up sessions and write
+  # to the tenant database. On a public channel the request is ignored with a warning.
+  #
+  # Best-effort otherwise: a failure to start the dedicated session must not prevent the channel
+  # from joining, so we log and continue without a store rather than failing the join.
+  defp maybe_start_temp_state_store(join, tenant, sub_topic, socket, db_conn) do
+    cond do
+      not Join.state_enabled?(join) ->
+        nil
+
+      not socket.assigns.private? ->
+        log_warning(socket, "TempStateStoreRequiresPrivateChannel", "State store is only available on private channels")
+        nil
+
+      true ->
+        case TempStateStore.start(tenant, self(), sub_topic, db_conn) do
+          {:ok, pid} ->
+            Process.monitor(pid)
+            pid
+
+          {:error, :too_many_state_stores} ->
+            log_warning(socket, "TempStateStoreLimitReached", "Per-tenant temp state store limit reached")
+            nil
+
+          error ->
+            log_error(socket, "TempStateStoreStartError", error)
+            nil
+        end
+    end
+  end
 
   defp presence_enabled?(client_enabled?, %Tenant{presence_enabled: tenant_enabled}) do
     client_enabled? || tenant_enabled

--- a/phx_join.schema.json
+++ b/phx_join.schema.json
@@ -46,6 +46,13 @@
                         "key": ""
                     }
                 },
+                "state": {
+                    "title": "state",
+                    "$ref": "#/$defs/phx_join_state",
+                    "default": {
+                        "enabled": false
+                    }
+                },
                 "postgres_changes": {
                     "type": "array",
                     "title": "phx_join_postgres_changes",
@@ -77,6 +84,20 @@
                     "type": "boolean",
                     "description": "Boolean, e.g. true",
                     "title": "ack",
+                    "default": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "phx_join_state": {
+            "type": "object",
+            "description": "",
+            "title": "phx_join_state",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Boolean, e.g. true",
+                    "title": "enabled",
                     "default": false
                 }
             },

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -78,14 +78,15 @@ defmodule Realtime.DatabaseTest do
       GenServer.stop(conn)
     end
 
-    # Connection limit for docker tenant db is 100
+    # Connection limit for docker tenant db is 100; requirement includes the temp state store
+    # reservation (capacity_limit(100) = 10) on top of the pooled requirements.
     @tag db_pool: 50,
          subs_pool_size: 73
     test "restricts connection if tenant database cannot receive more connections based on tenant pool",
          %{tenant: tenant} do
       assert capture_log(fn ->
                assert {:error, :tenant_db_too_many_connections} = Database.check_tenant_connection(tenant)
-             end) =~ ~r/Only \d+ available connections\. At least 125 connections are required/
+             end) =~ ~r/Only \d+ available connections\. At least 135 connections are required/
     end
   end
 

--- a/test/realtime/tenants/temp_state_store_cap_test.exs
+++ b/test/realtime/tenants/temp_state_store_cap_test.exs
@@ -16,20 +16,28 @@ defmodule Realtime.Tenants.TempStateStoreCapTest do
     end)
 
     tenant = Containers.checkout_tenant(run_migrations: true)
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
-    %{tenant: tenant, db_conn: db_conn}
+    {:ok, _db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    %{tenant: tenant}
   end
 
-  test "rejects new stores once the limit is reached", %{tenant: tenant, db_conn: db_conn} do
-    assert {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
-    assert {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+  test "rejects new stores once the limit is reached", %{tenant: tenant} do
+    assert {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string())
+    assert {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string())
 
-    assert {:error, :too_many_state_stores} =
-             TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+    assert {:error, :too_many_state_stores} = TempStateStore.start(tenant, self(), "room:" <> random_string())
+  end
+
+  test "capacity_limit/1 is bounded by both the ceiling and the connection fraction" do
+    # max_per_tenant is 2 in this suite; fraction default is 0.1
+    assert TempStateStore.capacity_limit(1000) == 2
+    assert TempStateStore.capacity_limit(20) == 2
+    assert TempStateStore.capacity_limit(10) == 1
+    # tiny databases still get one slot
+    assert TempStateStore.capacity_limit(1) == 1
   end
 
   describe "input limits" do
-    setup %{tenant: tenant, db_conn: db_conn} do
+    setup %{tenant: tenant} do
       Application.put_env(:realtime, :temp_state_store_max_value_bytes, 100)
       Application.put_env(:realtime, :temp_state_store_max_keys, 2)
 
@@ -38,7 +46,7 @@ defmodule Realtime.Tenants.TempStateStoreCapTest do
         Application.delete_env(:realtime, :temp_state_store_max_keys)
       end)
 
-      {:ok, store} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+      {:ok, store} = TempStateStore.start(tenant, self(), "room:" <> random_string())
       %{store: store}
     end
 
@@ -59,21 +67,34 @@ defmodule Realtime.Tenants.TempStateStoreCapTest do
 
       assert {:ok, 2} = TempStateStore.put(store, "a", %{"updated" => true})
     end
+
+    test "deleting a key frees a slot for a new key", %{store: store} do
+      assert {:ok, _} = TempStateStore.put(store, "a", %{})
+      assert {:ok, _} = TempStateStore.put(store, "b", %{})
+      assert {:error, :limit_reached} = TempStateStore.put(store, "c", %{})
+
+      assert {:ok, :deleted} = TempStateStore.delete(store, "a")
+      assert {:ok, 1} = TempStateStore.put(store, "c", %{})
+    end
   end
 
-  test "a store that stops frees a slot", %{tenant: tenant, db_conn: db_conn} do
-    {:ok, store} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
-    {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+  test "a store that stops frees a slot", %{tenant: tenant} do
+    {:ok, store} = TempStateStore.start(tenant, self(), "room:" <> random_string())
+    {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string())
 
-    assert {:error, :too_many_state_stores} =
-             TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+    assert {:error, :too_many_state_stores} = TempStateStore.start(tenant, self(), "room:" <> random_string())
 
     ref = Process.monitor(store)
     GenServer.stop(store)
     assert_receive {:DOWN, ^ref, :process, ^store, _reason}, 2000
 
+    # start/3 is async, so {:ok, pid} alone does not prove the database backstop passed;
+    # a successful write does.
     assert eventually(fn ->
-             match?({:ok, _}, TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn))
+             case TempStateStore.start(tenant, self(), "room:" <> random_string()) do
+               {:ok, pid} -> match?({:ok, _}, TempStateStore.put(pid, "k", %{}))
+               _ -> false
+             end
            end)
   end
 end

--- a/test/realtime/tenants/temp_state_store_cap_test.exs
+++ b/test/realtime/tenants/temp_state_store_cap_test.exs
@@ -1,0 +1,79 @@
+defmodule Realtime.Tenants.TempStateStoreCapTest do
+  use Realtime.DataCase, async: false
+
+  alias Realtime.Tenants.Connect
+  alias Realtime.Tenants.TempStateStore
+
+  setup do
+    prev = Application.get_env(:realtime, :temp_state_store_max_per_tenant)
+    Application.put_env(:realtime, :temp_state_store_max_per_tenant, 2)
+
+    on_exit(fn ->
+      case prev do
+        nil -> Application.delete_env(:realtime, :temp_state_store_max_per_tenant)
+        value -> Application.put_env(:realtime, :temp_state_store_max_per_tenant, value)
+      end
+    end)
+
+    tenant = Containers.checkout_tenant(run_migrations: true)
+    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    %{tenant: tenant, db_conn: db_conn}
+  end
+
+  test "rejects new stores once the limit is reached", %{tenant: tenant, db_conn: db_conn} do
+    assert {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+    assert {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+
+    assert {:error, :too_many_state_stores} =
+             TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+  end
+
+  describe "input limits" do
+    setup %{tenant: tenant, db_conn: db_conn} do
+      Application.put_env(:realtime, :temp_state_store_max_value_bytes, 100)
+      Application.put_env(:realtime, :temp_state_store_max_keys, 2)
+
+      on_exit(fn ->
+        Application.delete_env(:realtime, :temp_state_store_max_value_bytes)
+        Application.delete_env(:realtime, :temp_state_store_max_keys)
+      end)
+
+      {:ok, store} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+      %{store: store}
+    end
+
+    test "rejects values over the configured byte limit", %{store: store} do
+      assert {:error, :value_too_large} = TempStateStore.put(store, "k", %{"blob" => String.duplicate("x", 200)})
+      assert {:ok, _} = TempStateStore.put(store, "k", %{"small" => 1})
+    end
+
+    test "rejects keys over the byte limit", %{store: store} do
+      assert {:error, :key_too_large} = TempStateStore.put(store, String.duplicate("k", 2000), %{})
+    end
+
+    test "rejects new keys past max_keys but still allows updating existing keys", %{store: store} do
+      assert {:ok, _} = TempStateStore.put(store, "a", %{})
+      assert {:ok, _} = TempStateStore.put(store, "b", %{})
+      assert {:error, :limit_reached} = TempStateStore.put(store, "c", %{})
+      assert {:error, :limit_reached} = TempStateStore.insert(store, "c", %{})
+
+      assert {:ok, 2} = TempStateStore.put(store, "a", %{"updated" => true})
+    end
+  end
+
+  test "a store that stops frees a slot", %{tenant: tenant, db_conn: db_conn} do
+    {:ok, store} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+    {:ok, _} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+
+    assert {:error, :too_many_state_stores} =
+             TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+
+    ref = Process.monitor(store)
+    GenServer.stop(store)
+    assert_receive {:DOWN, ^ref, :process, ^store, _reason}, 2000
+
+    assert eventually(fn ->
+             match?({:ok, _}, TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn))
+           end)
+  end
+end

--- a/test/realtime/tenants/temp_state_store_test.exs
+++ b/test/realtime/tenants/temp_state_store_test.exs
@@ -6,10 +6,10 @@ defmodule Realtime.Tenants.TempStateStoreTest do
 
   setup do
     tenant = Containers.checkout_tenant(run_migrations: true)
-    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    {:ok, _db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
     channel_name = "room:" <> random_string()
-    {:ok, store} = TempStateStore.start(tenant, self(), channel_name, db_conn)
-    %{tenant: tenant, store: store, channel_name: channel_name, db_conn: db_conn}
+    {:ok, store} = TempStateStore.start(tenant, self(), channel_name)
+    %{tenant: tenant, store: store, channel_name: channel_name}
   end
 
   describe "put/3" do
@@ -85,8 +85,30 @@ defmodule Realtime.Tenants.TempStateStoreTest do
       assert %{value: %{"nested" => [1, 2, 3]}, version: 1, updated_at: %DateTime{}} = result
     end
 
+    test "scalar values round-trip unchanged", %{store: store} do
+      # regression: values used to be double-JSON-encoded, corrupting scalars
+      assert {:ok, 1} = TempStateStore.put(store, "string", "hello")
+      assert {:ok, %{value: "hello"}} = TempStateStore.get(store, "string")
+
+      assert {:ok, 1} = TempStateStore.put(store, "numeric string", "123")
+      assert {:ok, %{value: "123"}} = TempStateStore.get(store, "numeric string")
+
+      assert {:ok, 1} = TempStateStore.put(store, "int", 42)
+      assert {:ok, %{value: 42}} = TempStateStore.get(store, "int")
+    end
+
     test "returns :not_found when the key is missing", %{store: store} do
       assert {:error, :not_found} = TempStateStore.get(store, "missing")
+    end
+  end
+
+  describe "key validation" do
+    test "rejects non-string keys without crashing the store", %{store: store} do
+      assert {:error, :invalid_key} = TempStateStore.put(store, 123, %{})
+      assert {:error, :invalid_key} = TempStateStore.get(store, 123)
+      assert {:error, :invalid_key} = TempStateStore.delete(store, %{"key" => "k"})
+      assert Process.alive?(store)
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{})
     end
   end
 
@@ -122,12 +144,23 @@ defmodule Realtime.Tenants.TempStateStoreTest do
   end
 
   describe "lifecycle" do
-    test "the store stops when the monitored process goes down", %{tenant: tenant, db_conn: db_conn} do
+    test "the store stops when the monitored process goes down", %{tenant: tenant} do
       monitored = spawn(fn -> Process.sleep(:infinity) end)
-      {:ok, store} = TempStateStore.start(tenant, monitored, "room:" <> random_string(), db_conn)
+      {:ok, store} = TempStateStore.start(tenant, monitored, "room:" <> random_string())
       ref = Process.monitor(store)
 
       Process.exit(monitored, :kill)
+
+      assert_receive {:DOWN, ^ref, :process, ^store, _reason}, 2000
+    end
+
+    test "the store stops when the tenant Connect process goes down", %{tenant: tenant} do
+      {:ok, store} = TempStateStore.start(tenant, self(), "room:" <> random_string())
+      # wait for the async connect (which monitors Connect) to complete
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{})
+      ref = Process.monitor(store)
+
+      Connect.shutdown(tenant.external_id)
 
       assert_receive {:DOWN, ^ref, :process, ^store, _reason}, 2000
     end
@@ -140,9 +173,9 @@ defmodule Realtime.Tenants.TempStateStoreTest do
       assert {:error, :unavailable} = TempStateStore.put(store, "k", %{})
     end
 
-    test "two channels get isolated state", %{tenant: tenant, db_conn: db_conn} do
-      {:ok, store_a} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
-      {:ok, store_b} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+    test "two channels get isolated state", %{tenant: tenant} do
+      {:ok, store_a} = TempStateStore.start(tenant, self(), "room:" <> random_string())
+      {:ok, store_b} = TempStateStore.start(tenant, self(), "room:" <> random_string())
 
       assert {:ok, 1} = TempStateStore.put(store_a, "k", %{"who" => "a"})
       assert {:error, :not_found} = TempStateStore.get(store_b, "k")

--- a/test/realtime/tenants/temp_state_store_test.exs
+++ b/test/realtime/tenants/temp_state_store_test.exs
@@ -1,0 +1,166 @@
+defmodule Realtime.Tenants.TempStateStoreTest do
+  use Realtime.DataCase, async: true
+
+  alias Realtime.Tenants.Connect
+  alias Realtime.Tenants.TempStateStore
+
+  setup do
+    tenant = Containers.checkout_tenant(run_migrations: true)
+    {:ok, db_conn} = Connect.lookup_or_start_connection(tenant.external_id)
+    channel_name = "room:" <> random_string()
+    {:ok, store} = TempStateStore.start(tenant, self(), channel_name, db_conn)
+    %{tenant: tenant, store: store, channel_name: channel_name, db_conn: db_conn}
+  end
+
+  describe "put/3" do
+    test "inserts a new key and returns version 1", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"a" => 1})
+    end
+
+    test "upserts an existing key and bumps the version", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"a" => 1})
+      assert {:ok, 2} = TempStateStore.put(store, "k", %{"a" => 2})
+      assert {:ok, %{value: %{"a" => 2}, version: 2}} = TempStateStore.get(store, "k")
+    end
+  end
+
+  describe "insert/3" do
+    test "inserts a key that does not exist", %{store: store} do
+      assert {:ok, 1} = TempStateStore.insert(store, "k", %{"a" => 1})
+    end
+
+    test "returns :already_exists when the key is present", %{store: store} do
+      assert {:ok, 1} = TempStateStore.insert(store, "k", %{"a" => 1})
+      assert {:error, :already_exists} = TempStateStore.insert(store, "k", %{"a" => 2})
+    end
+  end
+
+  describe "update/3" do
+    test "updates an existing key and bumps the version", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"a" => 1})
+      assert {:ok, 2} = TempStateStore.update(store, "k", %{"a" => 2})
+    end
+
+    test "returns :not_found when the key is missing", %{store: store} do
+      assert {:error, :not_found} = TempStateStore.update(store, "missing", %{"a" => 1})
+    end
+
+    test "compare-and-set applies when the expected version matches", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"a" => 1})
+      assert {:ok, 2} = TempStateStore.update(store, "k", %{"a" => 2}, 1)
+    end
+
+    test "compare-and-set returns the current version on mismatch", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"a" => 1})
+      assert {:ok, 2} = TempStateStore.update(store, "k", %{"a" => 2})
+      assert {:error, {:version_mismatch, 2}} = TempStateStore.update(store, "k", %{"a" => 3}, 1)
+    end
+
+    test "compare-and-set on a missing key returns :not_found", %{store: store} do
+      assert {:error, :not_found} = TempStateStore.update(store, "missing", %{"a" => 1}, 1)
+    end
+  end
+
+  describe "delete/3 compare-and-set" do
+    test "deletes when the expected version matches", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"a" => 1})
+      assert {:ok, :deleted} = TempStateStore.delete(store, "k", 1)
+    end
+
+    test "returns the current version on mismatch", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"a" => 1})
+      assert {:ok, 2} = TempStateStore.update(store, "k", %{"a" => 2})
+      assert {:error, {:version_mismatch, 2}} = TempStateStore.delete(store, "k", 1)
+    end
+
+    test "returns :not_found when the key is missing", %{store: store} do
+      assert {:error, :not_found} = TempStateStore.delete(store, "missing", 1)
+    end
+  end
+
+  describe "get/2" do
+    test "returns the stored value, version and updated_at", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"nested" => [1, 2, 3]})
+      assert {:ok, result} = TempStateStore.get(store, "k")
+      assert %{value: %{"nested" => [1, 2, 3]}, version: 1, updated_at: %DateTime{}} = result
+    end
+
+    test "returns :not_found when the key is missing", %{store: store} do
+      assert {:error, :not_found} = TempStateStore.get(store, "missing")
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes an existing key", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "k", %{"a" => 1})
+      assert {:ok, :deleted} = TempStateStore.delete(store, "k")
+      assert {:error, :not_found} = TempStateStore.get(store, "k")
+    end
+
+    test "returns :not_found when the key is missing", %{store: store} do
+      assert {:error, :not_found} = TempStateStore.delete(store, "missing")
+    end
+  end
+
+  describe "count/1" do
+    test "returns 0 on an empty store and the row count after inserts", %{store: store} do
+      assert {:ok, 0} = TempStateStore.count(store)
+      assert {:ok, 1} = TempStateStore.put(store, "a", %{})
+      assert {:ok, 1} = TempStateStore.put(store, "b", %{})
+      assert {:ok, 2} = TempStateStore.count(store)
+    end
+  end
+
+  describe "clear/1" do
+    test "removes all rows", %{store: store} do
+      assert {:ok, 1} = TempStateStore.put(store, "a", %{})
+      assert {:ok, 1} = TempStateStore.put(store, "b", %{})
+      assert {:ok, 2} = TempStateStore.count(store)
+      assert :ok = TempStateStore.clear(store)
+      assert {:ok, 0} = TempStateStore.count(store)
+    end
+  end
+
+  describe "lifecycle" do
+    test "the store stops when the monitored process goes down", %{tenant: tenant, db_conn: db_conn} do
+      monitored = spawn(fn -> Process.sleep(:infinity) end)
+      {:ok, store} = TempStateStore.start(tenant, monitored, "room:" <> random_string(), db_conn)
+      ref = Process.monitor(store)
+
+      Process.exit(monitored, :kill)
+
+      assert_receive {:DOWN, ^ref, :process, ^store, _reason}, 2000
+    end
+
+    test "calls to a stopped store return {:error, :unavailable}", %{store: store} do
+      ref = Process.monitor(store)
+      GenServer.stop(store)
+      assert_receive {:DOWN, ^ref, :process, ^store, _reason}, 2000
+
+      assert {:error, :unavailable} = TempStateStore.put(store, "k", %{})
+    end
+
+    test "two channels get isolated state", %{tenant: tenant, db_conn: db_conn} do
+      {:ok, store_a} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+      {:ok, store_b} = TempStateStore.start(tenant, self(), "room:" <> random_string(), db_conn)
+
+      assert {:ok, 1} = TempStateStore.put(store_a, "k", %{"who" => "a"})
+      assert {:error, :not_found} = TempStateStore.get(store_b, "k")
+    end
+  end
+
+  describe "table_name/1" do
+    test "is deterministic, a valid identifier and within Postgres' 63 byte limit" do
+      name = TempStateStore.table_name("room:Lobby #1")
+
+      assert name == TempStateStore.table_name("room:Lobby #1")
+      assert String.starts_with?(name, "realtime_state_")
+      assert byte_size(name) <= 63
+      assert name =~ ~r/\A[a-z0-9_]+\z/
+    end
+
+    test "different channels produce different table names" do
+      refute TempStateStore.table_name("room:a") == TempStateStore.table_name("room:b")
+    end
+  end
+end

--- a/test/realtime_web/channels/payloads/join_test.exs
+++ b/test/realtime_web/channels/payloads/join_test.exs
@@ -324,6 +324,17 @@ defmodule RealtimeWeb.Channels.Payloads.JoinTest do
       assert Join.state_enabled?(%Join{config: %Config{state: %State{enabled: true}}})
     end
 
+    test "treats an explicit null enabled as false" do
+      # a JSON null survives Ecto cast as nil; state_enabled? must still return a boolean
+      assert {:ok, join} = Join.validate(%{"config" => %{"state" => %{"enabled" => nil}}})
+      assert Join.state_enabled?(join) == false
+    end
+
+    test "private? treats an explicit null as false" do
+      assert {:ok, join} = Join.validate(%{"config" => %{"private" => nil}})
+      assert Join.private?(join) == false
+    end
+
     test "defaults to false when state config is nil" do
       refute Join.state_enabled?(%Join{config: %Config{state: nil}})
     end

--- a/test/realtime_web/channels/payloads/join_test.exs
+++ b/test/realtime_web/channels/payloads/join_test.exs
@@ -9,6 +9,7 @@ defmodule RealtimeWeb.Channels.Payloads.JoinTest do
   alias RealtimeWeb.Channels.Payloads.Broadcast.Replay
   alias RealtimeWeb.Channels.Payloads.Presence
   alias RealtimeWeb.Channels.Payloads.PostgresChange
+  alias RealtimeWeb.Channels.Payloads.State
 
   describe "validate/1" do
     test "valid payload allows join" do
@@ -286,6 +287,53 @@ defmodule RealtimeWeb.Channels.Payloads.JoinTest do
 
     test "defaults to false when config is nil" do
       refute Join.self_broadcast?(%Join{config: nil})
+    end
+  end
+
+  describe "state config" do
+    test "parses the state opt-in" do
+      config = %{"config" => %{"state" => %{"enabled" => true}}}
+
+      assert {:ok, %Join{config: %Config{state: %State{enabled: true}}} = join} = Join.validate(config)
+      assert Join.state_enabled?(join)
+    end
+
+    test "accepts string 'true' for the enabled field" do
+      config = %{"config" => %{"state" => %{"enabled" => "true"}}}
+
+      assert {:ok, %Join{config: %Config{state: %State{enabled: true}}}} = Join.validate(config)
+    end
+
+    test "defaults enabled to false when omitted" do
+      config = %{"config" => %{"state" => %{}}}
+
+      assert {:ok, %Join{config: %Config{state: %State{enabled: false}}}} = Join.validate(config)
+    end
+
+    test "rejects an invalid boolean string" do
+      config = %{"config" => %{"state" => %{"enabled" => "maybe"}}}
+
+      assert {:error, :invalid_join_payload, %{config: %{state: %{enabled: ["unable to parse, expected boolean"]}}}} =
+               Join.validate(config)
+    end
+  end
+
+  describe "state_enabled?/1" do
+    test "returns enabled value from config" do
+      refute Join.state_enabled?(%Join{config: %Config{state: %State{enabled: false}}})
+      assert Join.state_enabled?(%Join{config: %Config{state: %State{enabled: true}}})
+    end
+
+    test "defaults to false when state config is nil" do
+      refute Join.state_enabled?(%Join{config: %Config{state: nil}})
+    end
+
+    test "defaults to false when config is nil" do
+      refute Join.state_enabled?(%Join{config: nil})
+    end
+
+    test "defaults to false for non-Join struct" do
+      refute Join.state_enabled?(nil)
     end
   end
 

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -1726,6 +1726,40 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       ref = push(socket, "state", %{"command" => "update", "key" => "k", "value" => %{"a" => 2}, "expected" => "1"})
       assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "invalid_expected"}}, 2000
     end
+
+    test "treats a null expected version as last-write-wins", %{tenant: tenant} do
+      socket = join_state_socket(tenant)
+
+      ref = push(socket, "state", %{"command" => "put", "key" => "k", "value" => %{"a" => 1}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok}, 2000
+
+      ref = push(socket, "state", %{"command" => "update", "key" => "k", "value" => %{"a" => 2}, "expected" => nil})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok, payload: %{version: 2}}, 2000
+    end
+
+    test "rejects a non-string key without touching the store", %{tenant: tenant} do
+      socket = join_state_socket(tenant)
+      store = socket.assigns.temp_state_store
+
+      ref = push(socket, "state", %{"command" => "put", "key" => 123, "value" => %{"a" => 1}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "invalid_state_command"}}, 2000
+
+      ref = push(socket, "state", %{"command" => "get", "key" => 123})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "invalid_state_command"}}, 2000
+
+      # the store must have survived the malformed commands
+      assert Process.alive?(store)
+    end
+
+    test "a null enabled flag joins without a store instead of erroring", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      assert {:ok, _, %Socket{} = socket} =
+               subscribe_and_join(socket, "realtime:test", %{config: %{private: true, state: %{enabled: nil}}})
+
+      assert socket.assigns.temp_state_store == nil
+    end
   end
 
   defp join_state_socket(tenant) do

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -1553,6 +1553,191 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     end
   end
 
+  describe "channel-scoped temp state store" do
+    @describetag policies: [:authenticated_all_topic_read]
+
+    test "opting in on a private channel starts a store and supports put/get round-trips", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      assert {:ok, _, %Socket{} = socket} =
+               subscribe_and_join(socket, "realtime:test", %{config: %{private: true, state: %{enabled: true}}})
+
+      assert is_pid(socket.assigns.temp_state_store)
+
+      ref = push(socket, "state", %{"command" => "put", "key" => "k", "value" => %{"a" => 1}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok, payload: %{version: 1}}, 2000
+
+      ref = push(socket, "state", %{"command" => "get", "key" => "k"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok, payload: %{value: %{"a" => 1}, version: 1}}, 2000
+    end
+
+    test "get on a missing key replies not_found", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      assert {:ok, _, %Socket{} = socket} =
+               subscribe_and_join(socket, "realtime:test", %{config: %{private: true, state: %{enabled: true}}})
+
+      ref = push(socket, "state", %{"command" => "get", "key" => "missing"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "not_found"}}, 2000
+    end
+
+    test "state is ignored on public channels and commands are rejected", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      # state.enabled is set but the channel is public, so no store must be started
+      assert {:ok, _, %Socket{} = socket} =
+               subscribe_and_join(socket, "realtime:test", %{config: %{private: false, state: %{enabled: true}}})
+
+      assert socket.assigns.temp_state_store == nil
+
+      ref = push(socket, "state", %{"command" => "get", "key" => "k"})
+
+      assert_receive %Socket.Reply{
+                       ref: ^ref,
+                       status: :error,
+                       payload: %{reason: "State store is not enabled for this channel"}
+                     },
+                     2000
+    end
+
+    test "without opt-in there is no store and state commands are rejected", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      assert {:ok, _, %Socket{} = socket} =
+               subscribe_and_join(socket, "realtime:test", %{config: %{private: true}})
+
+      assert socket.assigns.temp_state_store == nil
+
+      ref = push(socket, "state", %{"command" => "get", "key" => "k"})
+
+      assert_receive %Socket.Reply{
+                       ref: ^ref,
+                       status: :error,
+                       payload: %{reason: "State store is not enabled for this channel"}
+                     },
+                     2000
+    end
+
+    test "the store is torn down when the channel terminates", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      assert {:ok, _, %Socket{} = socket} =
+               subscribe_and_join(socket, "realtime:test", %{config: %{private: true, state: %{enabled: true}}})
+
+      store = socket.assigns.temp_state_store
+      assert is_pid(store)
+      ref = Process.monitor(store)
+
+      Process.unlink(socket.channel_pid)
+      Process.exit(socket.channel_pid, :kill)
+
+      assert_receive {:DOWN, ^ref, :process, ^store, _reason}, 2000
+    end
+
+    test "supports compare-and-set updates and replies version_mismatch on conflict", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      assert {:ok, _, %Socket{} = socket} =
+               subscribe_and_join(socket, "realtime:test", %{config: %{private: true, state: %{enabled: true}}})
+
+      ref = push(socket, "state", %{"command" => "put", "key" => "k", "value" => %{"a" => 1}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok, payload: %{version: 1}}, 2000
+
+      ref = push(socket, "state", %{"command" => "update", "key" => "k", "value" => %{"a" => 2}, "expected" => 1})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok, payload: %{version: 2}}, 2000
+
+      ref = push(socket, "state", %{"command" => "update", "key" => "k", "value" => %{"a" => 3}, "expected" => 1})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "version_mismatch", version: 2}}, 2000
+    end
+
+    test "pushes a system message and returns unavailable when the store dies", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+      assert {:ok, _, %Socket{} = socket} =
+               subscribe_and_join(socket, "realtime:test", %{config: %{private: true, state: %{enabled: true}}})
+
+      store = socket.assigns.temp_state_store
+      assert is_pid(store)
+
+      GenServer.stop(store)
+
+      assert_receive %Socket.Message{event: "system", payload: %{extension: "state", status: "error"}}, 2000
+
+      ref = push(socket, "state", %{"command" => "get", "key" => "k"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "unavailable"}}, 2000
+    end
+
+    test "insert replies with a version and rejects a duplicate key", %{tenant: tenant} do
+      socket = join_state_socket(tenant)
+
+      ref = push(socket, "state", %{"command" => "insert", "key" => "k", "value" => %{"a" => 1}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok, payload: %{version: 1}}, 2000
+
+      ref = push(socket, "state", %{"command" => "insert", "key" => "k", "value" => %{"a" => 2}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "already_exists"}}, 2000
+    end
+
+    test "delete replies deleted and not_found for a missing key", %{tenant: tenant} do
+      socket = join_state_socket(tenant)
+
+      ref = push(socket, "state", %{"command" => "put", "key" => "k", "value" => %{"a" => 1}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok}, 2000
+
+      ref = push(socket, "state", %{"command" => "delete", "key" => "k"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok, payload: %{deleted: true}}, 2000
+
+      ref = push(socket, "state", %{"command" => "delete", "key" => "k"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "not_found"}}, 2000
+    end
+
+    test "clear replies cleared", %{tenant: tenant} do
+      socket = join_state_socket(tenant)
+
+      ref = push(socket, "state", %{"command" => "put", "key" => "k", "value" => %{"a" => 1}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok}, 2000
+
+      ref = push(socket, "state", %{"command" => "clear"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok, payload: %{cleared: true}}, 2000
+
+      ref = push(socket, "state", %{"command" => "get", "key" => "k"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "not_found"}}, 2000
+    end
+
+    test "rejects an unknown command", %{tenant: tenant} do
+      socket = join_state_socket(tenant)
+
+      ref = push(socket, "state", %{"command" => "nope", "key" => "k"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "invalid_state_command"}}, 2000
+    end
+
+    test "rejects a non-integer expected version", %{tenant: tenant} do
+      socket = join_state_socket(tenant)
+
+      ref = push(socket, "state", %{"command" => "put", "key" => "k", "value" => %{"a" => 1}})
+      assert_receive %Socket.Reply{ref: ^ref, status: :ok}, 2000
+
+      ref = push(socket, "state", %{"command" => "update", "key" => "k", "value" => %{"a" => 2}, "expected" => "1"})
+      assert_receive %Socket.Reply{ref: ^ref, status: :error, payload: %{reason: "invalid_expected"}}, 2000
+    end
+  end
+
+  defp join_state_socket(tenant) do
+    jwt = Generators.generate_jwt_token(tenant)
+    {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+
+    {:ok, _, %Socket{} = socket} =
+      subscribe_and_join(socket, "realtime:test", %{config: %{private: true, state: %{enabled: true}}})
+
+    socket
+  end
+
   defp conn_opts(tenant, token) do
     [
       connect_info: %{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a per-channel key/value store backed by a PostgreSQL TEMP TABLE, opted into via `config.state.enabled` on private channels. Each channel gets a dedicated session/temp table exposed over a new "state" message (put/insert/update/delete/get/clear) with optimistic versioning. Bounded by input limits and a per-tenant cap; best-effort so it never blocks the join.
