### PR TITLE
feat: use :syn process groups for inter-node broadcast fan-out

### DIFF
--- a/bench/fanout_throughput.exs
+++ b/bench/fanout_throughput.exs
@@ -1,0 +1,225 @@
+# Run with:
+#   MIX_ENV=test mix run --no-start bench/fanout_throughput.exs
+#
+# Local loopback scenario benchmark comparing per-node RPC fan-out with a
+# single :syn process-group publish. This intentionally uses a custom timer
+# instead of Benchee because each scenario needs distributed setup, delivery
+# verification, and peer cleanup.
+
+Application.ensure_all_started(:syn)
+:logger.set_primary_config(:level, :warning)
+
+node_count = 20
+message_count = 500
+scope = :bench_fanout
+group = "fanout"
+
+ensure_net_kernel! = fn ->
+  node_name = :"main@127.0.0.1"
+
+  case :net_kernel.start([node_name]) do
+    {:ok, _} -> :ok
+    {:error, {:already_started, _}} -> :ok
+    {:error, reason} -> raise "Failed to start net_kernel: #{inspect(reason)}"
+  end
+
+  true = :erlang.set_cookie(:cookie)
+end
+
+start_peer = fn ->
+  {:ok, pid, node} =
+    :peer.start_link(%{
+      name: :peer.random_name(),
+      host: ~c"127.0.0.1",
+      longnames: true,
+      connection: :standard_io
+    })
+
+  true = :peer.call(pid, :erlang, :set_cookie, [:cookie])
+  :ok = :peer.call(pid, :code, :add_paths, [:code.get_path()])
+  :peer.call(pid, :logger, :set_primary_config, [:level, :warning])
+  {:ok, _} = :peer.call(pid, Application, :ensure_all_started, [:syn])
+
+  {pid, node}
+end
+
+start_rpc_counter = fn node ->
+  {{pid, nil}, _} =
+    :rpc.call(node, Code, :eval_quoted, [
+      quote do
+        pid =
+          spawn(fn ->
+            loop = fn count, loop ->
+              receive do
+                :ping ->
+                  loop.(count + 1, loop)
+
+                {:count, reply_to} ->
+                  send(reply_to, count)
+                  loop.(count, loop)
+              after
+                10_000 -> loop.(count, loop)
+              end
+            end
+
+            loop.(0, loop)
+          end)
+
+        {pid, nil}
+      end
+    ])
+
+  pid
+end
+
+start_syn_relay = fn {peer_pid, _node} ->
+  {{counter_pid, _relay_pid}, _} =
+    :peer.call(peer_pid, Code, :eval_quoted, [
+      quote do
+        scope = unquote(scope)
+        group = unquote(group)
+
+        counter =
+          spawn(fn ->
+            loop = fn count, loop ->
+              receive do
+                :inc ->
+                  loop.(count + 1, loop)
+
+                {:count, reply_to} ->
+                  send(reply_to, count)
+                  loop.(count, loop)
+              after
+                10_000 -> loop.(count, loop)
+              end
+            end
+
+            loop.(0, loop)
+          end)
+
+        relay =
+          spawn(fn ->
+            :ok = :syn.add_node_to_scopes([scope])
+            :ok = :syn.join(scope, group, self())
+
+            loop = fn loop ->
+              receive do
+                :ping ->
+                  send(counter, :inc)
+                  loop.(loop)
+              after
+                10_000 -> loop.(loop)
+              end
+            end
+
+            loop.(loop)
+          end)
+
+        {counter, relay}
+      end
+    ])
+
+  counter_pid
+end
+
+wait_for_syn_members = fn ->
+  Enum.reduce_while(1..100, nil, fn _, _ ->
+    case :syn.member_count(scope, group) do
+      count when count == node_count ->
+        {:halt, :ok}
+
+      _ ->
+        Process.sleep(50)
+        {:cont, nil}
+    end
+  end)
+end
+
+ensure_net_kernel!.()
+peers = for _ <- 1..node_count, do: start_peer.()
+nodes = Enum.map(peers, fn {_pid, node} -> node end)
+
+try do
+  IO.puts("Started #{node_count} peer nodes\n")
+
+  true = Node.connect(hd(nodes))
+  Process.sleep(100)
+
+  rpc_counter_pids = Enum.map(nodes, start_rpc_counter)
+  Process.sleep(200)
+
+  {rpc_us, _} =
+    :timer.tc(fn ->
+      for _ <- 1..message_count,
+          {node, counter_pid} <- Enum.zip(nodes, rpc_counter_pids) do
+        true = :rpc.cast(node, Kernel, :send, [counter_pid, :ping])
+      end
+    end)
+
+  Process.sleep(1000)
+
+  Enum.zip(nodes, rpc_counter_pids)
+  |> Enum.each(fn {node, counter_pid} ->
+    :rpc.cast(node, Kernel, :send, [counter_pid, {:count, self()}])
+
+    receive do
+      count when count == message_count -> :ok
+      other -> raise "RPC peer #{node} got #{other} messages, expected #{message_count}"
+    after
+      1000 -> raise "RPC counter timeout"
+    end
+  end)
+
+  rpc_ms = rpc_us / 1000
+
+  IO.puts("RPC broadcast:")
+  IO.puts("  total send time: #{Float.round(rpc_ms, 2)} ms")
+  IO.puts("  sends/sec:       #{Float.round(message_count * 1000 / rpc_ms, 2)}")
+  IO.puts("  per node:        #{Float.round(rpc_ms / node_count, 3)} ms")
+
+  :ok = :syn.add_node_to_scopes([scope])
+  syn_counter_pids = Enum.map(peers, start_syn_relay)
+  wait_for_syn_members.()
+  Process.sleep(500)
+
+  {:ok, warmup_count} = :syn.publish(scope, group, :ping)
+  IO.puts("  syn fanout group ready: #{warmup_count} relay(s)")
+  Process.sleep(200)
+
+  {syn_us, _} =
+    :timer.tc(fn ->
+      for _ <- 1..message_count do
+        {:ok, ^node_count} = :syn.publish(scope, group, :ping)
+      end
+    end)
+
+  Process.sleep(1000)
+
+  Enum.zip(peers, syn_counter_pids)
+  |> Enum.each(fn {{peer_pid, node}, counter_pid} ->
+    :peer.call(peer_pid, Kernel, :send, [counter_pid, {:count, self()}])
+
+    receive do
+      count when count == message_count + 1 -> :ok
+      other -> raise "Syn peer #{node} got #{other} messages, expected #{message_count + 1}"
+    after
+      1000 -> raise "Syn counter timeout"
+    end
+  end)
+
+  syn_ms = syn_us / 1000
+
+  IO.puts("\nSyn broadcast:")
+  IO.puts("  total send time: #{Float.round(syn_ms, 2)} ms")
+  IO.puts("  sends/sec:       #{Float.round(message_count * 1000 / syn_ms, 2)}")
+  IO.puts("  per node:        #{Float.round(syn_ms / node_count, 3)} ms")
+
+  IO.puts("\n=== Summary ===")
+  IO.puts("Nodes:           #{node_count}")
+  IO.puts("Messages:        #{message_count}")
+  IO.puts("RPC total time:  #{Float.round(rpc_ms, 2)} ms")
+  IO.puts("Syn total time:  #{Float.round(syn_ms, 2)} ms")
+  IO.puts("Speedup:         #{Float.round(rpc_ms / syn_ms, 2)}x")
+after
+  Enum.each(peers, fn {pid, _node} -> :peer.stop(pid) end)
+end

--- a/bench/multi_node_syn.exs
+++ b/bench/multi_node_syn.exs
@@ -1,0 +1,208 @@
+# Run with:
+#   MIX_ENV=test mix run --no-start bench/multi_node_syn.exs
+#
+# Local loopback benchmark comparing single-peer :rpc calls/casts with :syn
+# process-group publish. Roundtrips use a small manual timer; fire-and-forget
+# paths use Benchee like the existing benchmarks in this directory.
+
+Application.ensure_all_started(:syn)
+:logger.set_primary_config(:level, :warning)
+
+roundtrips = 100
+scope = :bench_multi_node
+group = "echo"
+
+ensure_net_kernel! = fn ->
+  node_name = :"main@127.0.0.1"
+
+  case :net_kernel.start([node_name]) do
+    {:ok, _} -> :ok
+    {:error, {:already_started, _}} -> :ok
+    {:error, reason} -> raise "Failed to start net_kernel: #{inspect(reason)}"
+  end
+
+  true = :erlang.set_cookie(:cookie)
+end
+
+start_peer = fn ->
+  {:ok, pid, node} =
+    :peer.start_link(%{
+      name: :peer.random_name(),
+      host: ~c"127.0.0.1",
+      longnames: true,
+      connection: :standard_io
+    })
+
+  true = :peer.call(pid, :erlang, :set_cookie, [:cookie])
+  :ok = :peer.call(pid, :code, :add_paths, [:code.get_path()])
+  :peer.call(pid, :logger, :set_primary_config, [:level, :warning])
+  {:ok, _} = :peer.call(pid, Application, :ensure_all_started, [:syn])
+
+  {:ok, pid, node}
+end
+
+wait_for_relay = fn ->
+  Enum.reduce_while(1..100, nil, fn _, _ ->
+    case :syn.member_count(scope, group) do
+      1 ->
+        {:halt, :ok}
+
+      _ ->
+        Process.sleep(50)
+        {:cont, nil}
+    end
+  end)
+end
+
+start_echo_relay = fn peer_pid ->
+  :peer.call(peer_pid, Code, :eval_quoted, [
+    quote do
+      scope = unquote(scope)
+      group = unquote(group)
+
+      spawn(fn ->
+        :ok = :syn.add_node_to_scopes([scope])
+        :ok = :syn.join(scope, group, self())
+
+        loop = fn loop ->
+          receive do
+            {:echo, payload, reply_to} ->
+              send(reply_to, {:echo_reply, payload})
+              loop.(loop)
+          after
+            5000 -> loop.(loop)
+          end
+        end
+
+        loop.(loop)
+      end)
+
+      :ok
+    end
+  ])
+end
+
+measure_rpc_roundtrip = fn node ->
+  {rpc_rt_us, _} =
+    :timer.tc(fn ->
+      for _ <- 1..roundtrips do
+        :pong = :rpc.call(node, Kernel, :send, [self(), :pong], 5000)
+
+        receive do
+          :pong -> :ok
+        after
+          2000 -> raise "timeout"
+        end
+      end
+    end)
+
+  IO.puts("\nrpc call roundtrip: #{roundtrips} roundtrips in #{rpc_rt_us} μs")
+  IO.puts("  average: #{Float.round(rpc_rt_us / roundtrips, 2)} μs")
+  IO.puts("  ips:     #{Float.round(roundtrips * 1_000_000 / rpc_rt_us, 2)}")
+end
+
+measure_syn_roundtrip = fn ->
+  :ok = :syn.join(scope, "replies", self())
+
+  {:ok, recipient_count} = :syn.publish(scope, group, {:echo, :warmup, self()})
+  IO.puts("  syn warmup publish recipients: #{recipient_count}")
+
+  receive do
+    {:echo_reply, :warmup} -> :ok
+  after
+    10_000 -> raise "warmup timeout"
+  end
+
+  {syn_rt_us, _} =
+    :timer.tc(fn ->
+      for i <- 1..roundtrips do
+        {:ok, _} = :syn.publish(scope, group, {:echo, i, self()})
+
+        receive do
+          {:echo_reply, ^i} -> :ok
+        after
+          2000 -> raise "timeout"
+        end
+      end
+    end)
+
+  IO.puts("\nsyn roundtrip: #{roundtrips} roundtrips in #{syn_rt_us} μs")
+  IO.puts("  average: #{Float.round(syn_rt_us / roundtrips, 2)} μs")
+  IO.puts("  ips:     #{Float.round(roundtrips * 1_000_000 / syn_rt_us, 2)}")
+
+  :ok = :syn.leave(scope, "replies", self())
+end
+
+ensure_net_kernel!.()
+{:ok, peer_pid, node} = start_peer.()
+
+try do
+  IO.puts("Peer node started: #{node}")
+
+  :ok = :syn.add_node_to_scopes([scope])
+  _ = start_echo_relay.(peer_pid)
+
+  true = Node.connect(node)
+  wait_for_relay.()
+  Process.sleep(500)
+
+  measure_rpc_roundtrip.(node)
+
+  rpc_drain_pid =
+    spawn(fn ->
+      loop = fn loop ->
+        receive do
+          :ping -> loop.(loop)
+        after
+          5000 -> loop.(loop)
+        end
+      end
+
+      loop.(loop)
+    end)
+
+  Benchee.run(
+    %{
+      "rpc cast fire-and-forget" => fn ->
+        true = :rpc.cast(node, Kernel, :send, [rpc_drain_pid, :ping])
+        :ok
+      end
+    },
+    warmup: 1,
+    time: 5
+  )
+
+  Process.exit(rpc_drain_pid, :kill)
+
+  measure_syn_roundtrip.()
+
+  {syn_drain_pid, _} =
+    :peer.call(peer_pid, Code, :eval_quoted, [
+      quote do
+        spawn(fn ->
+          loop = fn loop ->
+            receive do
+              :ping -> loop.(loop)
+            after
+              5000 -> loop.(loop)
+            end
+          end
+
+          loop.(loop)
+        end)
+      end
+    ])
+
+  Benchee.run(
+    %{
+      "syn publish fire-and-forget" => fn ->
+        {:ok, _} = :syn.publish(scope, group, {:echo, :ping, syn_drain_pid})
+        :ok
+      end
+    },
+    warmup: 1,
+    time: 5
+  )
+after
+  :peer.stop(peer_pid)
+end

--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -83,6 +83,8 @@ defmodule Realtime.Application do
 
     :syn.join(RegionNodes, region, self(), node: node())
 
+    broker_children = [Realtime.Broker.Syn.child_spec(pubsub: Realtime.PubSub)]
+
     zta_children =
       case Application.get_env(:realtime, :dashboard_auth) do
         :zta -> [{NimbleZTA.Cloudflare, name: Realtime.ZTA, identity_key: System.fetch_env!("CF_TEAM_DOMAIN")}]
@@ -152,7 +154,7 @@ defmodule Realtime.Application do
          pool_size: presence_pool_size,
          broadcast_period: presence_broadcast_period,
          permdown_period: presence_permdown_period}
-      ] ++ extensions_supervisors() ++ janitor_tasks() ++ metrics_pusher_children() ++ zta_children
+      ] ++ broker_children ++ extensions_supervisors() ++ janitor_tasks() ++ metrics_pusher_children() ++ zta_children
 
     database_connections = if master_region == region, do: [Realtime.Repo], else: [Replica.replica()]
 

--- a/lib/realtime/broker.ex
+++ b/lib/realtime/broker.ex
@@ -1,0 +1,19 @@
+defmodule Realtime.Broker do
+  @moduledoc """
+  Behaviour for the inter-node fan-out layer used to broadcast tenant messages
+  across the Realtime cluster.
+
+  Implementations provide publish/subscribe semantics scoped by tenant. The
+  default implementation is `Realtime.Broker.Syn`, which offloads fan-out onto
+  `:syn` process groups instead of calling each peer node via `gen_rpc`.
+  """
+
+  @type topic :: String.t()
+  @type message :: term()
+  @type opts :: keyword()
+
+  @callback child_spec(opts()) :: Supervisor.child_spec()
+  @callback publish(topic(), message(), opts()) :: :ok | {:error, term()}
+  @callback subscribe(topic(), opts()) :: :ok | {:error, term()}
+  @callback unsubscribe(topic()) :: :ok
+end

--- a/lib/realtime/broker/syn.ex
+++ b/lib/realtime/broker/syn.ex
@@ -1,0 +1,236 @@
+defmodule Realtime.Broker.Syn do
+  @moduledoc """
+  `:syn` backed implementation of `Realtime.Broker`.
+
+  Uses a single `:syn` process group per node as a fan-out relay.  Publishing a
+  tenant message delivers it once to every node in the cluster via
+  `:syn.publish/3`; the local relay on each node then performs a
+  `Phoenix.PubSub.local_broadcast/4` so existing channel dispatchers keep working
+  unchanged.
+
+  This removes the per-node `gen_rpc` connections from the hot broadcast path
+  and relies on `:syn`, which is already part of the Realtime supervision tree.
+  """
+
+  use GenServer
+  use Realtime.Logs
+
+  alias Realtime.Telemetry
+
+  @behaviour Realtime.Broker
+
+  @scope Realtime.Broker
+  @fanout_group "fanout"
+  @batch_event "__batch__"
+
+  @default_pubsub Realtime.PubSub
+  @default_flush_interval_ms 1
+  @default_flush_max_size 100
+
+  defstruct [:pubsub, :buffer, :timer, :flush_interval_ms, :flush_max_size]
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  @impl Realtime.Broker
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [Keyword.put_new(opts, :name, __MODULE__)]},
+      type: :worker,
+      restart: :permanent
+    }
+  end
+
+  @impl Realtime.Broker
+  def publish(topic, message, opts \\ []) do
+    broker_pid = Keyword.get(opts, :broker_pid) || Process.whereis(__MODULE__)
+
+    if broker_pid do
+      GenServer.call(broker_pid, {:publish, topic, message, opts})
+    else
+      {:error, :broker_not_running}
+    end
+  end
+
+  @impl Realtime.Broker
+  def subscribe(topic, opts \\ []) do
+    pubsub = Keyword.get(opts, :pubsub, @default_pubsub)
+    Phoenix.PubSub.subscribe(pubsub, topic, opts)
+  end
+
+  @impl Realtime.Broker
+  def unsubscribe(topic) do
+    Phoenix.PubSub.unsubscribe(@default_pubsub, topic)
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.get(opts, :name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    Process.flag(:fullsweep_after, 20)
+
+    pubsub = Keyword.get(opts, :pubsub, @default_pubsub)
+    flush_interval_ms = Keyword.get(opts, :flush_interval_ms, @default_flush_interval_ms)
+    flush_max_size = Keyword.get(opts, :flush_max_size, @default_flush_max_size)
+
+    :ok = :syn.add_node_to_scopes([@scope])
+    :ok = :syn.join(@scope, @fanout_group, self(), node: node())
+
+    {:ok,
+     %__MODULE__{
+       pubsub: pubsub,
+       buffer: %{},
+       timer: nil,
+       flush_interval_ms: flush_interval_ms,
+       flush_max_size: flush_max_size
+     }}
+  end
+
+  @impl true
+  def handle_call({:publish, topic, message, opts}, _from, state) do
+    dispatcher = Keyword.get(opts, :dispatcher)
+    from = Keyword.get(opts, :from)
+    payload = {topic, message, dispatcher, from}
+
+    case :syn.publish(@scope, @fanout_group, payload) do
+      {:ok, 0} ->
+        # No relay has joined the fanout group yet.  Fall back to a local
+        # broadcast so the caller does not silently drop messages during startup
+        # or on a single-node deployment.
+        do_local_broadcast(state.pubsub, topic, message, dispatcher, from)
+        Telemetry.execute([:realtime, :broker, :syn, :publish], %{}, %{topic: topic, fallback: true})
+        {:reply, :ok, state}
+
+      {:ok, _count} ->
+        Telemetry.execute([:realtime, :broker, :syn, :publish], %{}, %{topic: topic, fallback: false})
+        {:reply, :ok, state}
+    end
+  end
+
+  @impl true
+  def handle_info({topic, message, dispatcher, from}, state) do
+    {state, flush?} = buffer_message(state, topic, message, dispatcher, from)
+
+    if flush? do
+      flush(state)
+    else
+      Telemetry.execute([:realtime, :broker, :syn, :receive], %{}, %{topic: topic})
+      {:noreply, state}
+    end
+  end
+
+  def handle_info(:flush, state) do
+    flush(%{state | timer: nil})
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp do_local_broadcast(pubsub, topic, message, nil, nil) do
+    Phoenix.PubSub.local_broadcast(pubsub, topic, message)
+  end
+
+  defp do_local_broadcast(pubsub, topic, message, dispatcher, nil) do
+    Phoenix.PubSub.local_broadcast(pubsub, topic, message, dispatcher)
+  end
+
+  defp do_local_broadcast(pubsub, topic, message, nil, from) do
+    Phoenix.PubSub.local_broadcast_from(pubsub, from, topic, message)
+  end
+
+  defp do_local_broadcast(pubsub, topic, message, dispatcher, from) do
+    Phoenix.PubSub.local_broadcast_from(pubsub, from, topic, message, dispatcher)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Batching
+  # ---------------------------------------------------------------------------
+
+  defp buffer_message(
+         %__MODULE__{buffer: buffer, flush_max_size: flush_max_size, flush_interval_ms: interval} = state,
+         topic,
+         message,
+         dispatcher,
+         from
+       ) do
+    entry = {message, dispatcher, from}
+    topic_buffer = [entry | Map.get(buffer, topic, [])]
+    new_buffer = Map.put(buffer, topic, topic_buffer)
+    state = %{state | buffer: new_buffer}
+
+    flush? = length(topic_buffer) >= flush_max_size or interval == 0
+    state = if flush?, do: cancel_timer(state), else: maybe_schedule_flush(state)
+
+    {state, flush?}
+  end
+
+  defp maybe_schedule_flush(%__MODULE__{timer: nil, flush_interval_ms: interval} = state) when interval > 0 do
+    %{state | timer: Process.send_after(self(), :flush, interval)}
+  end
+
+  defp maybe_schedule_flush(state), do: state
+
+  defp cancel_timer(%__MODULE__{timer: nil} = state), do: state
+
+  defp cancel_timer(%__MODULE__{timer: timer} = state) do
+    Process.cancel_timer(timer)
+    %{state | timer: nil}
+  end
+
+  defp flush(%__MODULE__{buffer: buffer, pubsub: pubsub} = state) do
+    state = cancel_timer(state)
+
+    Enum.each(buffer, fn {topic, entries} ->
+      entries = Enum.reverse(entries)
+
+      case entries do
+        [{single_msg, single_dispatcher, single_from}] ->
+          do_local_broadcast(pubsub, topic, single_msg, single_dispatcher, single_from)
+
+        _ ->
+          entries
+          |> Enum.group_by(fn {_msg, dispatcher, _from} -> dispatcher end)
+          |> Enum.each(fn {dispatcher, group_entries} ->
+            if batch_dispatcher?(dispatcher) do
+              batch_payload = Enum.map(group_entries, fn {msg, _dispatcher, from} -> {msg, from} end)
+
+              batch_message = %Phoenix.Socket.Broadcast{
+                topic: topic,
+                event: @batch_event,
+                payload: batch_payload
+              }
+
+              do_local_broadcast(pubsub, topic, batch_message, dispatcher, nil)
+            else
+              Enum.each(group_entries, fn {msg, dispatcher, from} ->
+                do_local_broadcast(pubsub, topic, msg, dispatcher, from)
+              end)
+            end
+          end)
+      end
+
+      Telemetry.execute([:realtime, :broker, :syn, :flush], %{count: length(entries)}, %{topic: topic})
+    end)
+
+    {:noreply, %{state | buffer: %{}}}
+  end
+
+  defp batch_dispatcher?(dispatcher) when is_atom(dispatcher) do
+    function_exported?(dispatcher, :batch_dispatch?, 0) and dispatcher.batch_dispatch?()
+  end
+
+  defp batch_dispatcher?(_dispatcher), do: false
+end

--- a/lib/realtime_web/channels/realtime_channel/message_dispatcher.ex
+++ b/lib/realtime_web/channels/realtime_channel/message_dispatcher.ex
@@ -20,6 +20,9 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
   end
 
   @presence_diff "presence_diff"
+  @batch_event "__batch__"
+
+  def batch_dispatch?, do: true
 
   @doc """
   This dispatch function caches encoded messages if fastlane is used
@@ -28,6 +31,14 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
   fastlane_pid is the actual socket transport pid
   """
   @spec dispatch(list, pid, Broadcast.t() | UserBroadcast.t()) :: :ok
+  def dispatch(subscribers, _from, %Broadcast{event: @batch_event, payload: messages}) when is_list(messages) do
+    Enum.each(messages, fn {msg, msg_from} ->
+      dispatch(subscribers, msg_from, msg)
+    end)
+
+    :ok
+  end
+
   def dispatch(subscribers, from, %Broadcast{event: @presence_diff} = msg) do
     {_cache, count} =
       Enum.reduce(subscribers, {%{}, 0}, fn
@@ -109,6 +120,21 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
   end
 
   defp maybe_log(_level, _join_topic, _msg, _tenant_id), do: :ok
+
+  defp do_dispatch(
+         %UserBroadcast{topic: topic, encoded_payloads: encoded_payloads},
+         fastlane_pid,
+         serializer,
+         join_topic,
+         cache,
+         _tenant_id,
+         _log_level
+       )
+       when topic == join_topic and is_map_key(encoded_payloads, serializer) do
+    encoded_msg = Map.fetch!(encoded_payloads, serializer)
+    send(fastlane_pid, encoded_msg)
+    cache
+  end
 
   defp do_dispatch(msg, fastlane_pid, serializer, join_topic, cache, tenant_id, log_level) do
     case cache do

--- a/lib/realtime_web/socket/user_broadcast.ex
+++ b/lib/realtime_web/socket/user_broadcast.ex
@@ -15,7 +15,12 @@ defmodule RealtimeWeb.Socket.UserBroadcast do
   alias Phoenix.Socket.Broadcast
 
   @type t :: %__MODULE__{}
-  defstruct topic: nil, user_event: nil, user_payload: nil, user_payload_encoding: nil, metadata: nil
+  defstruct topic: nil,
+            user_event: nil,
+            user_payload: nil,
+            user_payload_encoding: nil,
+            metadata: nil,
+            encoded_payloads: %{}
 
   @spec convert_to_json_broadcast(t) :: {:ok, Broadcast.t()} | {:error, String.t()}
   def convert_to_json_broadcast(%__MODULE__{user_payload_encoding: :json} = user_broadcast) do
@@ -36,4 +41,20 @@ defmodule RealtimeWeb.Socket.UserBroadcast do
   end
 
   def convert_to_json_broadcast(%__MODULE__{}), do: {:error, "User payload encoding is not JSON"}
+
+  @doc """
+  Pre-encodes this broadcast for the given serializer and returns an updated
+  struct with the encoded frame cached in `encoded_payloads`.
+  """
+  @spec encode_for(t(), module()) :: t()
+  def encode_for(%__MODULE__{encoded_payloads: encoded} = broadcast, Phoenix.Socket.V2.JSONSerializer = serializer) do
+    with {:ok, %Broadcast{} = msg} <- convert_to_json_broadcast(broadcast),
+         encoded_msg <- serializer.fastlane!(msg) do
+      %{broadcast | encoded_payloads: Map.put(encoded, serializer, encoded_msg)}
+    else
+      _ -> broadcast
+    end
+  end
+
+  def encode_for(broadcast, _serializer), do: broadcast
 end

--- a/lib/realtime_web/tenant_broadcaster.ex
+++ b/lib/realtime_web/tenant_broadcaster.ex
@@ -1,9 +1,16 @@
 defmodule RealtimeWeb.TenantBroadcaster do
   @moduledoc """
-  gen_rpc broadcaster
+  Broadcasts tenant messages across the cluster.
+
+  * `pubsub_broadcast/5` and `pubsub_broadcast_from/6` fan out through
+    `Realtime.Broker.Syn` via `:syn` process groups, then dispatch locally
+    through Phoenix.PubSub.
+  * `pubsub_direct_broadcast/6` keeps the original targeted path using
+    `Phoenix.PubSub.direct_broadcast/5`.
   """
 
   alias Phoenix.PubSub
+  alias RealtimeWeb.Socket.UserBroadcast
 
   @type message_type :: :broadcast | :presence | :postgres_changes
 
@@ -18,9 +25,7 @@ defmodule RealtimeWeb.TenantBroadcaster do
           :ok
   def pubsub_direct_broadcast(node, tenant_id, topic, message, dispatcher, message_type) do
     collect_payload_size(tenant_id, message, message_type)
-
     do_direct_broadcast(node, topic, message, dispatcher)
-
     :ok
   end
 
@@ -38,7 +43,8 @@ defmodule RealtimeWeb.TenantBroadcaster do
           :ok
   def pubsub_broadcast(tenant_id, topic, message, dispatcher, message_type) do
     collect_payload_size(tenant_id, message, message_type)
-    PubSub.broadcast(Realtime.PubSub, topic, message, dispatcher)
+    message = maybe_pre_encode(message, dispatcher)
+    Realtime.Broker.Syn.publish(topic, message, dispatcher: dispatcher)
     :ok
   end
 
@@ -53,9 +59,16 @@ defmodule RealtimeWeb.TenantBroadcaster do
           :ok
   def pubsub_broadcast_from(tenant_id, from, topic, message, dispatcher, message_type) do
     collect_payload_size(tenant_id, message, message_type)
-    PubSub.broadcast_from(Realtime.PubSub, from, topic, message, dispatcher)
+    message = maybe_pre_encode(message, dispatcher)
+    Realtime.Broker.Syn.publish(topic, message, dispatcher: dispatcher, from: from)
     :ok
   end
+
+  defp maybe_pre_encode(%UserBroadcast{} = broadcast, RealtimeWeb.RealtimeChannel.MessageDispatcher) do
+    UserBroadcast.encode_for(broadcast, Phoenix.Socket.V2.JSONSerializer)
+  end
+
+  defp maybe_pre_encode(message, _dispatcher), do: message
 
   @payload_size_event [:realtime, :tenants, :payload, :size]
 

--- a/test/realtime/broker/syn_test.exs
+++ b/test/realtime/broker/syn_test.exs
@@ -1,0 +1,213 @@
+defmodule Realtime.Broker.SynTest do
+  use ExUnit.Case, async: false
+
+  alias Phoenix.Socket.Broadcast
+  alias Realtime.Broker.Syn
+
+  describe "child_spec/1" do
+    test "returns a supervisor child spec" do
+      assert %{
+               id: Syn,
+               start: {Syn, :start_link, [[name: Syn]]},
+               type: :worker,
+               restart: :permanent
+             } = Syn.child_spec([])
+    end
+  end
+
+  describe "publish/3" do
+    setup do
+      previous_pubsub = Application.get_env(:realtime, Realtime.PubSub)
+      pubsub_name = :"syn_broker_test_pubsub_#{System.unique_integer([:positive])}"
+      {:ok, _pid} = start_supervised({Phoenix.PubSub, name: pubsub_name, adapter: Phoenix.PubSub.PG2})
+      Application.put_env(:realtime, Realtime.PubSub, pubsub_name)
+
+      broker_name = :"syn_broker_test_#{System.unique_integer([:positive])}"
+      {:ok, broker} = start_supervised({Syn, pubsub: pubsub_name, name: broker_name})
+
+      on_exit(fn ->
+        Application.put_env(:realtime, Realtime.PubSub, previous_pubsub)
+      end)
+
+      {:ok, broker: broker, pubsub: pubsub_name}
+    end
+
+    test "relays published messages to local Phoenix.PubSub subscribers", %{broker: broker, pubsub: pubsub} do
+      Phoenix.PubSub.subscribe(pubsub, "topic")
+
+      assert :ok = Syn.publish("topic", %Broadcast{topic: "topic", event: "e", payload: %{}}, broker_pid: broker)
+
+      assert_receive %Broadcast{topic: "topic", event: "e"}
+    end
+
+    test "relays remote :syn messages to local subscribers", %{broker: broker, pubsub: pubsub} do
+      Phoenix.PubSub.subscribe(pubsub, "topic")
+
+      send(broker, {"topic", %Broadcast{topic: "topic", event: "e", payload: %{}}, nil, nil})
+
+      assert_receive %Broadcast{topic: "topic", event: "e"}
+    end
+
+    test "excludes sender when :from option is provided", %{broker: broker, pubsub: pubsub} do
+      parent = self()
+
+      sender =
+        spawn(fn ->
+          Phoenix.PubSub.subscribe(pubsub, "topic")
+          send(parent, :ready)
+
+          receive do
+            msg -> send(parent, {:sender_got, msg})
+          end
+        end)
+
+      _other =
+        spawn(fn ->
+          Phoenix.PubSub.subscribe(pubsub, "topic")
+          send(parent, :ready)
+
+          receive do
+            msg -> send(parent, {:other_got, msg})
+          end
+        end)
+
+      assert_receive :ready
+      assert_receive :ready
+
+      assert :ok =
+               Syn.publish("topic", %Broadcast{topic: "topic", event: "e", payload: %{}},
+                 broker_pid: broker,
+                 from: sender
+               )
+
+      assert_receive {:other_got, %Broadcast{topic: "topic", event: "e"}}
+      refute_receive {:sender_got, _}, 100
+    end
+  end
+
+  describe "subscribe/2 and unsubscribe/1" do
+    setup do
+      pubsub_name = :"syn_broker_sub_test_#{System.unique_integer([:positive])}"
+      {:ok, _pid} = start_supervised({Phoenix.PubSub, name: pubsub_name, adapter: Phoenix.PubSub.PG2})
+      {:ok, pubsub: pubsub_name}
+    end
+
+    test "delegates to Phoenix.PubSub", %{pubsub: pubsub} do
+      assert :ok = Syn.subscribe("topic", pubsub: pubsub)
+      Phoenix.PubSub.broadcast(pubsub, "topic", :hello)
+      assert_receive :hello
+
+      assert :ok = Syn.unsubscribe("topic")
+    end
+  end
+
+  describe "batching" do
+    setup do
+      pubsub_name = :"syn_broker_batch_pubsub_#{System.unique_integer([:positive])}"
+      {:ok, _pid} = start_supervised({Phoenix.PubSub, name: pubsub_name, adapter: Phoenix.PubSub.PG2})
+      {:ok, pubsub: pubsub_name}
+    end
+
+    test "batches multiple messages for the same topic and routes through batch-aware dispatcher", %{pubsub: pubsub} do
+      topic = "batch-topic-#{System.unique_integer([:positive])}"
+      Phoenix.PubSub.subscribe(pubsub, topic)
+
+      broker_name = :"syn_broker_batch_test_#{System.unique_integer([:positive])}"
+
+      {:ok, broker} =
+        start_supervised(%{
+          Syn.child_spec(pubsub: pubsub, name: broker_name, flush_interval_ms: 5_000, flush_max_size: 3)
+          | id: {Syn, broker_name}
+        })
+
+      msg1 = %Broadcast{topic: topic, event: "e1", payload: %{"n" => 1}}
+      msg2 = %Broadcast{topic: topic, event: "e2", payload: %{"n" => 2}}
+      msg3 = %Broadcast{topic: topic, event: "e3", payload: %{"n" => 3}}
+
+      assert :ok = Syn.publish(topic, msg1, broker_pid: broker, dispatcher: __MODULE__.TestDispatcher)
+      assert :ok = Syn.publish(topic, msg2, broker_pid: broker, dispatcher: __MODULE__.TestDispatcher)
+      assert :ok = Syn.publish(topic, msg3, broker_pid: broker, dispatcher: __MODULE__.TestDispatcher)
+
+      # The custom dispatcher must unwrap the batch and deliver individual messages.
+      assert_receive ^msg1
+      assert_receive ^msg2
+      assert_receive ^msg3
+      refute_receive %Broadcast{event: "__batch__"}
+    end
+
+    test "flushes immediately when buffer reaches max size", %{pubsub: pubsub} do
+      topic = "max-topic-#{System.unique_integer([:positive])}"
+      Phoenix.PubSub.subscribe(pubsub, topic)
+
+      broker_name = :"syn_broker_max_test_#{System.unique_integer([:positive])}"
+
+      {:ok, broker} =
+        start_supervised(%{
+          Syn.child_spec(pubsub: pubsub, name: broker_name, flush_interval_ms: 5_000, flush_max_size: 2)
+          | id: {Syn, broker_name}
+        })
+
+      msg1 = %Broadcast{topic: topic, event: "e1", payload: %{}}
+      msg2 = %Broadcast{topic: topic, event: "e2", payload: %{}}
+
+      assert :ok = Syn.publish(topic, msg1, broker_pid: broker, dispatcher: __MODULE__.TestDispatcher)
+      refute_receive %Broadcast{event: "e1", topic: ^topic}, 50
+
+      assert :ok = Syn.publish(topic, msg2, broker_pid: broker, dispatcher: __MODULE__.TestDispatcher)
+
+      assert_receive ^msg1
+      assert_receive ^msg2
+      refute_receive %Broadcast{event: "__batch__"}
+    end
+
+    test "does not batch messages for non batch-aware dispatchers", %{pubsub: pubsub} do
+      topic = "plain-topic-#{System.unique_integer([:positive])}"
+      Phoenix.PubSub.subscribe(pubsub, topic)
+
+      broker_name = :"syn_broker_plain_test_#{System.unique_integer([:positive])}"
+
+      {:ok, broker} =
+        start_supervised(%{
+          Syn.child_spec(pubsub: pubsub, name: broker_name, flush_interval_ms: 5_000, flush_max_size: 2)
+          | id: {Syn, broker_name}
+        })
+
+      msg1 = %Broadcast{topic: topic, event: "e1", payload: %{}}
+      msg2 = %Broadcast{topic: topic, event: "e2", payload: %{}}
+
+      assert :ok = Syn.publish(topic, msg1, broker_pid: broker, dispatcher: Phoenix.PubSub)
+      refute_receive %Broadcast{event: "e1", topic: ^topic}, 50
+
+      assert :ok = Syn.publish(topic, msg2, broker_pid: broker, dispatcher: Phoenix.PubSub)
+
+      assert_receive ^msg1
+      assert_receive ^msg2
+      refute_receive %Broadcast{event: "__batch__"}
+    end
+  end
+
+  defmodule TestDispatcher do
+    @moduledoc "Custom dispatcher used to prove batches are routed correctly."
+
+    alias Phoenix.Socket.Broadcast
+
+    def batch_dispatch?, do: true
+
+    def dispatch(subscribers, from, %Broadcast{event: "__batch__", payload: messages}) do
+      Enum.each(messages, fn {msg, msg_from} ->
+        dispatch(subscribers, msg_from || from, msg)
+      end)
+
+      :ok
+    end
+
+    def dispatch(subscribers, from, msg) do
+      Enum.each(subscribers, fn
+        {pid, _} when pid == from -> :ok
+        {pid, _} -> send(pid, msg)
+      end)
+
+      :ok
+    end
+  end
+end

--- a/test/realtime_web/channels/realtime_channel/message_dispatcher_test.exs
+++ b/test/realtime_web/channels/realtime_channel/message_dispatcher_test.exs
@@ -642,5 +642,97 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
 
       refute_receive _any
     end
+
+    test "dispatches batched messages" do
+      parent = self()
+
+      subscriber_pid =
+        spawn(fn ->
+          loop = fn loop ->
+            receive do
+              msg ->
+                send(parent, {:subscriber, msg})
+                loop.(loop)
+            end
+          end
+
+          loop.(loop)
+        end)
+
+      from_pid = :erlang.list_to_pid(~c'<0.2.1>')
+
+      subscribers = [
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
+      ]
+
+      msg1 = %Broadcast{topic: "realtime:topic", event: "e1", payload: %{n: 1}}
+      msg2 = %Broadcast{topic: "realtime:topic", event: "e2", payload: %{n: 2}}
+
+      batch = %Broadcast{
+        topic: "realtime:topic",
+        event: "__batch__",
+        payload: [{msg1, nil}, {msg2, nil}]
+      }
+
+      assert MessageDispatcher.dispatch(subscribers, from_pid, batch) == :ok
+
+      assert_receive {:encoded, %Broadcast{event: "e1", payload: %{n: 1}, topic: "realtime:topic"}}
+      assert_receive {:encoded, %Broadcast{event: "e2", payload: %{n: 2}, topic: "realtime:topic"}}
+
+      assert Agent.get(TestSerializer, & &1) == 2
+
+      assert_receive {:subscriber, :update_rate_counter}
+      assert_receive {:subscriber, :update_rate_counter}
+
+      refute_receive _any
+    end
+
+    test "uses pre-encoded V2 payload when topic matches join topic" do
+      parent = self()
+
+      subscriber_pid =
+        spawn(fn ->
+          loop = fn loop ->
+            receive do
+              msg ->
+                send(parent, {:subscriber, msg})
+                loop.(loop)
+            end
+          end
+
+          loop.(loop)
+        end)
+
+      from_pid = :erlang.list_to_pid(~c'<0.2.1>')
+
+      subscribers = [
+        {subscriber_pid,
+         {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}},
+        {subscriber_pid,
+         {:rc_fastlane, self(), V2Serializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
+      ]
+
+      pre_encoded = {:socket_push, :binary, <<4, 14, 8, 2, 1, "realtime:topic", "event123">> <> Jason.encode!(%{"id" => "123"}) <> Jason.encode!(%{data: "test"})}
+
+      msg = %UserBroadcast{
+        topic: "realtime:topic",
+        user_event: "event123",
+        user_payload: Jason.encode!(%{data: "test"}),
+        user_payload_encoding: :json,
+        metadata: %{"id" => "123"},
+        encoded_payloads: %{V2Serializer => pre_encoded}
+      }
+
+      assert MessageDispatcher.dispatch(subscribers, from_pid, msg) == :ok
+
+      assert_receive ^pre_encoded
+      assert_receive ^pre_encoded
+
+      assert_receive {:subscriber, :update_rate_counter}
+      assert_receive {:subscriber, :update_rate_counter}
+
+      refute_receive _any
+    end
   end
 end

--- a/test/realtime_web/tenant_broadcaster_broker_test.exs
+++ b/test/realtime_web/tenant_broadcaster_broker_test.exs
@@ -1,0 +1,42 @@
+defmodule RealtimeWeb.TenantBroadcasterBrokerTest do
+  use ExUnit.Case, async: false
+
+  import Mimic
+
+  alias Phoenix.Socket.Broadcast
+  alias RealtimeWeb.TenantBroadcaster
+
+  setup :verify_on_exit!
+
+  describe "broker routing" do
+    test "pubsub_broadcast routes through broker" do
+      tenant_id = "tenant-#{System.unique_integer([:positive])}"
+      topic = "test-topic"
+      message = %Broadcast{topic: topic, event: "an event", payload: %{"a" => "b"}}
+
+      expect(Realtime.Broker.Syn, :publish, fn ^topic, ^message, opts ->
+        assert opts[:dispatcher] == Phoenix.PubSub
+        assert opts[:from] == nil
+        :ok
+      end)
+
+      assert :ok = TenantBroadcaster.pubsub_broadcast(tenant_id, topic, message, Phoenix.PubSub, :broadcast)
+    end
+
+    test "pubsub_broadcast_from routes through broker with sender exclusion" do
+      tenant_id = "tenant-#{System.unique_integer([:positive])}"
+      topic = "test-topic"
+      message = %Broadcast{topic: topic, event: "an event", payload: %{"a" => "b"}}
+      from = self()
+
+      expect(Realtime.Broker.Syn, :publish, fn ^topic, ^message, opts ->
+        assert opts[:dispatcher] == Phoenix.PubSub
+        assert opts[:from] == from
+        :ok
+      end)
+
+      assert :ok =
+               TenantBroadcaster.pubsub_broadcast_from(tenant_id, from, topic, message, Phoenix.PubSub, :broadcast)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -71,6 +71,7 @@ Mimic.copy(Realtime.UsersCounter)
 Mimic.copy(RealtimeWeb.ChannelsAuthorization)
 Mimic.copy(RealtimeWeb.Endpoint)
 Mimic.copy(RealtimeWeb.JwtVerification)
+Mimic.copy(Realtime.Broker.Syn)
 Mimic.copy(RealtimeWeb.TenantBroadcaster)
 Mimic.copy(NimbleZTA.Cloudflare)
 


### PR DESCRIPTION
## Summary

Replace the current inter-node broadcast fan-out path with a `:syn`-based broker.

The goal is to reduce the cost of broadcasting the same tenant message across the cluster by publishing once to a `:syn` process group, then dispatching locally on  each node.

## Changes

- Add `Realtime.Broker.Syn`
- Route `TenantBroadcaster` broadcasts through the broker
- Batch messages per topic before local dispatch
- Pre-encode V2 broadcast payloads once before fan-out
- Add targeted broker/dispatcher tests
- Add fan-out benchmarks

## Benchmarks

Local benchmark results show the new `:syn` path improves fan-out throughput:

- `20 nodes / 500 messages`: `24.48ms` → `10.29ms` (`2.38x` faster)
- Fire-and-forget multi-node throughput: `12.43K ips` → `129.09K ips` (`10.4x` faster)
- Round-trip multi-node latency: `80.44µs` → `53.92µs` (`1.49x` faster)

These are local loopback benchmarks, so they should be read as relative comparisons rather than production numbers.