### PR TITLE
feat: add support to % feature flags

### DIFF
--- a/lib/realtime/api.ex
+++ b/lib/realtime/api.ex
@@ -209,7 +209,11 @@ defmodule Realtime.Api do
     if master_region?() do
       %FeatureFlag{}
       |> FeatureFlag.changeset(attrs)
-      |> Repo.insert(on_conflict: {:replace, [:enabled, :updated_at]}, conflict_target: :name, returning: true)
+      |> Repo.insert(
+        on_conflict: {:replace, [:enabled, :rollout_percentage, :bucket_key, :updated_at]},
+        conflict_target: :name,
+        returning: true
+      )
       |> tap(fn
         {:ok, flag} -> FeatureFlags.Cache.global_update_cache(flag)
         _ -> :ok

--- a/lib/realtime/api/feature_flag.ex
+++ b/lib/realtime/api/feature_flag.ex
@@ -2,9 +2,19 @@ defmodule Realtime.Api.FeatureFlag do
   @moduledoc """
   Ecto schema for a global feature flag.
 
-  Flags have a name (unique) and a boolean enabled state. Per-tenant overrides
-  are stored separately on the `Realtime.Api.Tenant` schema as a JSONB map,
-  not as associations on this record.
+  Flags have a name (unique), a boolean enabled state, and a rollout
+  percentage (0-100, default 100) used to gradually enable the flag for a
+  subset of tenants. `enabled: false` always means off for everyone; when
+  `enabled: true`, `rollout_percentage` controls what fraction of tenants get
+  the flag when they have no explicit override. Per-tenant overrides are
+  stored separately on the `Realtime.Api.Tenant` schema as a JSONB map, not as
+  associations on this record.
+
+  `bucket_key` controls which tenants fall into the rollout percentage: it is
+  hashed together with the tenant id to pick a bucket. It defaults to the
+  flag's own `name`, so different flags get decorrelated (independent) rollout
+  cohorts by default. Set the same `bucket_key` on two flags to make them
+  intentionally share the same cohort.
   """
 
   use Ecto.Schema
@@ -17,13 +27,16 @@ defmodule Realtime.Api.FeatureFlag do
   schema "feature_flags" do
     field :name, :string
     field :enabled, :boolean, default: false
+    field :rollout_percentage, :integer, default: 100
+    field :bucket_key, :string
     timestamps()
   end
 
   def changeset(flag, attrs) do
     flag
-    |> cast(attrs, [:name, :enabled])
+    |> cast(attrs, [:name, :enabled, :rollout_percentage, :bucket_key])
     |> validate_required([:name])
+    |> validate_number(:rollout_percentage, greater_than_or_equal_to: 0, less_than_or_equal_to: 100)
     |> unique_constraint(:name)
   end
 end

--- a/lib/realtime/feature_flags.ex
+++ b/lib/realtime/feature_flags.ex
@@ -1,15 +1,29 @@
 defmodule Realtime.FeatureFlags do
   @moduledoc """
-  Manages feature flags with optional per-tenant overrides.
+  Manages feature flags with optional per-tenant overrides and percentage rollout.
 
-  Each flag has a global enabled/disabled state. Tenants can override that state
-  via a JSONB map stored on the tenant record.
+  Each flag has a global enabled/disabled state and a rollout percentage
+  (0-100, default 100) used to gradually enable it for a subset of tenants.
+  Tenants can also override the flag entirely via a JSONB map stored on the
+  tenant record.
 
-  Use `enabled?/1` to check the global flag value only.
-  Use `enabled?/2` when the flag supports per-tenant overrides. Resolution order:
-    1. Tenant-specific override (if present)
-    2. Global flag value
-    3. `false` when the flag does not exist
+  Use `enabled?/1` to check the global `enabled` value only. It ignores
+  rollout percentage, since there is no tenant to compute a rollout bucket
+  against.
+
+  Use `enabled?/2` when the flag supports per-tenant overrides and percentage
+  rollout. Resolution order:
+    1. Tenant-specific override (if present) always wins.
+    2. Otherwise, `false` when the flag is globally disabled or does not exist.
+    3. Otherwise, whether the tenant falls within `rollout_percentage`.
+
+  Rollout bucketing is deterministic per tenant (`:erlang.phash2({tenant_id, bucket_key}, 100)`),
+  so it is sticky/monotonic: a tenant included at N% remains included at any
+  percentage >= N. Raising the percentage only ever adds tenants.
+
+  `bucket_key` defaults to the flag's own `name`, so different flags get
+  independent, decorrelated cohorts. Set the same `bucket_key` on two flags to
+  make them intentionally share the same cohort.
   """
 
   alias Realtime.Api
@@ -45,11 +59,21 @@ defmodule Realtime.FeatureFlags do
       nil ->
         false
 
-      %FeatureFlag{enabled: global_enabled} ->
+      %FeatureFlag{} = flag ->
+        rollout_result = in_rollout?(flag, tenant_id)
+
         case TenantsCache.get_tenant_by_external_id(tenant_id) do
-          nil -> global_enabled
-          %{feature_flags: flags} -> Map.get(flags, flag_name, global_enabled)
+          nil -> rollout_result
+          %{feature_flags: flags} -> Map.get(flags, flag_name, rollout_result)
         end
     end
+  end
+
+  @spec in_rollout?(FeatureFlag.t(), String.t()) :: boolean()
+  defp in_rollout?(%FeatureFlag{enabled: false}, _tenant_id), do: false
+
+  defp in_rollout?(%FeatureFlag{enabled: true, rollout_percentage: rollout_percentage} = flag, tenant_id) do
+    bucket_key = flag.bucket_key || flag.name
+    :erlang.phash2({tenant_id, bucket_key}, 100) < rollout_percentage
   end
 end

--- a/lib/realtime_web/dashboard/feature_flags.ex
+++ b/lib/realtime_web/dashboard/feature_flags.ex
@@ -24,13 +24,43 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
   def handle_event("toggle", %{"id" => id}, socket) do
     flag = Enum.find(socket.assigns.flags, &(&1.id == id))
 
-    case Api.upsert_feature_flag(%{name: flag.name, enabled: !flag.enabled}) do
+    attrs = %{
+      name: flag.name,
+      enabled: !flag.enabled,
+      rollout_percentage: flag.rollout_percentage,
+      bucket_key: flag.bucket_key
+    }
+
+    case Api.upsert_feature_flag(attrs) do
       {:ok, updated} ->
         flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
         {:noreply, assign(socket, flags: flags)}
 
       {:error, _} ->
         {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event(
+        "set_rollout",
+        %{"flag_id" => id, "rollout_percentage" => rollout_percentage, "bucket_key" => bucket_key},
+        socket
+      ) do
+    flag = Enum.find(socket.assigns.flags, &(&1.id == id))
+
+    with {pct, ""} <- Integer.parse(rollout_percentage),
+         attrs = %{
+           name: flag.name,
+           enabled: flag.enabled,
+           rollout_percentage: pct,
+           bucket_key: normalize_bucket_key(bucket_key)
+         },
+         {:ok, updated} <- Api.upsert_feature_flag(attrs) do
+      flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
+      {:noreply, assign(socket, flags: flags)}
+    else
+      _ -> {:noreply, socket}
     end
   end
 
@@ -100,6 +130,13 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
     assign(socket, [managing_id: nil, tenant_search: "", found_tenant: nil, tenant_error: nil] ++ extra)
   end
 
+  defp normalize_bucket_key(bucket_key) do
+    case String.trim(bucket_key) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -120,9 +157,10 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
       <table class="table table-hover">
         <thead>
           <tr>
-            <th style="width: 60%">Name</th>
+            <th style="width: 30%">Name</th>
             <th style="width: 15%">Status</th>
-            <th style="width: 25%">Actions</th>
+            <th style="width: 35%">Rollout</th>
+            <th style="width: 20%">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -147,6 +185,32 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
                 </div>
               </td>
               <td class="align-middle">
+                <form id={"set_rollout_#{flag.id}"} phx-submit="set_rollout" class="d-flex align-items-center gap-1">
+                  <input type="hidden" name="flag_id" value={flag.id} />
+                  <input
+                    type="number"
+                    name="rollout_percentage"
+                    min="0"
+                    max="100"
+                    value={flag.rollout_percentage}
+                    class="form-control form-control-sm"
+                    style="width: 70px;"
+                  />
+                  <span class="text-muted">%</span>
+                  <input
+                    type="text"
+                    name="bucket_key"
+                    value={flag.bucket_key}
+                    placeholder={"defaults to \"#{flag.name}\""}
+                    title="Bucket key: flags sharing the same bucket key share the same rollout cohort"
+                    class="form-control form-control-sm"
+                    style="width: 120px;"
+                    autocomplete="off"
+                  />
+                  <button type="submit" class="btn btn-sm btn-outline-secondary">Save</button>
+                </form>
+              </td>
+              <td class="align-middle">
                 <div style="display: flex; gap: 0.5rem;">
                   <button phx-click="open_tenant_manager" phx-value-id={flag.id} class="btn btn-sm btn-outline-primary">
                     Tenants
@@ -164,7 +228,7 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
             </tr>
             <%= if @managing_id == flag.id do %>
               <tr>
-                <td colspan="3" style="background: #f8f9fa; padding: 1rem 1.25rem;">
+                <td colspan="4" style="background: #f8f9fa; padding: 1rem 1.25rem;">
                   <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75rem;">
                     <strong>Tenant flag: <%= flag.name %></strong>
                     <button phx-click="close_tenant_manager" class="btn btn-sm btn-secondary">Close</button>
@@ -187,7 +251,7 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
                   <% end %>
 
                   <%= if @found_tenant do %>
-                    <% flag_enabled = Map.get(@found_tenant.feature_flags, flag.name, flag.enabled) %>
+                    <% flag_enabled = Map.get(@found_tenant.feature_flags, flag.name, FeatureFlags.enabled?(flag.name, @found_tenant.external_id)) %>
                     <div style="display: flex; align-items: center; gap: 1rem; padding: 0.5rem 0.75rem; background: white; border-radius: 4px; border: 1px solid #dee2e6;">
                       <code><%= @found_tenant.external_id %></code>
                       <span class="text-muted">—</span>

--- a/lib/realtime_web/dashboard/feature_flags.ex
+++ b/lib/realtime_web/dashboard/feature_flags.ex
@@ -157,9 +157,9 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
       <table class="table table-hover">
         <thead>
           <tr>
-            <th style="width: 30%">Name</th>
-            <th style="width: 15%">Status</th>
-            <th style="width: 35%">Rollout</th>
+            <th style="width: 25%">Name</th>
+            <th style="width: 12%">Status</th>
+            <th style="width: 43%">Rollout</th>
             <th style="width: 20%">Actions</th>
           </tr>
         </thead>
@@ -185,28 +185,38 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
                 </div>
               </td>
               <td class="align-middle">
-                <form id={"set_rollout_#{flag.id}"} phx-submit="set_rollout" class="d-flex align-items-center gap-1">
+                <form id={"set_rollout_#{flag.id}"} phx-submit="set_rollout" class="d-flex align-items-end gap-3">
                   <input type="hidden" name="flag_id" value={flag.id} />
-                  <input
-                    type="number"
-                    name="rollout_percentage"
-                    min="0"
-                    max="100"
-                    value={flag.rollout_percentage}
-                    class="form-control form-control-sm"
-                    style="width: 70px;"
-                  />
-                  <span class="text-muted">%</span>
-                  <input
-                    type="text"
-                    name="bucket_key"
-                    value={flag.bucket_key}
-                    placeholder={"defaults to \"#{flag.name}\""}
-                    title="Bucket key: flags sharing the same bucket key share the same rollout cohort"
-                    class="form-control form-control-sm"
-                    style="width: 120px;"
-                    autocomplete="off"
-                  />
+                  <div>
+                    <label for={"rollout_percentage_#{flag.id}"} class="form-label text-muted small mb-1">Percentage</label>
+                    <div class="d-flex align-items-center gap-1">
+                      <input
+                        id={"rollout_percentage_#{flag.id}"}
+                        type="number"
+                        name="rollout_percentage"
+                        min="0"
+                        max="100"
+                        value={flag.rollout_percentage}
+                        class="form-control form-control-sm"
+                        style="width: 80px;"
+                      />
+                      <span class="text-muted">%</span>
+                    </div>
+                  </div>
+                  <div>
+                    <label for={"bucket_key_#{flag.id}"} class="form-label text-muted small mb-1">Bucket key</label>
+                    <input
+                      id={"bucket_key_#{flag.id}"}
+                      type="text"
+                      name="bucket_key"
+                      value={flag.bucket_key}
+                      placeholder={"defaults to \"#{flag.name}\""}
+                      title="Bucket key: flags sharing the same bucket key share the same rollout cohort"
+                      class="form-control form-control-sm"
+                      style="width: 180px;"
+                      autocomplete="off"
+                    />
+                  </div>
                   <button type="submit" class="btn btn-sm btn-outline-secondary">Save</button>
                 </form>
               </td>

--- a/lib/realtime_web/live/feature_flags_live/index.ex
+++ b/lib/realtime_web/live/feature_flags_live/index.ex
@@ -20,7 +20,14 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
   def handle_event("toggle", %{"id" => id}, socket) do
     flag = Enum.find(socket.assigns.flags, &(&1.id == id))
 
-    case Api.upsert_feature_flag(%{name: flag.name, enabled: !flag.enabled}) do
+    attrs = %{
+      name: flag.name,
+      enabled: !flag.enabled,
+      rollout_percentage: flag.rollout_percentage,
+      bucket_key: flag.bucket_key
+    }
+
+    case Api.upsert_feature_flag(attrs) do
       {:ok, updated} ->
         Endpoint.broadcast_from(self(), "feature_flags", "updated", updated)
         flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
@@ -28,6 +35,30 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
 
       {:error, _} ->
         {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event(
+        "set_rollout",
+        %{"flag_id" => id, "rollout_percentage" => rollout_percentage, "bucket_key" => bucket_key},
+        socket
+      ) do
+    flag = Enum.find(socket.assigns.flags, &(&1.id == id))
+
+    with {pct, ""} <- Integer.parse(rollout_percentage),
+         attrs = %{
+           name: flag.name,
+           enabled: flag.enabled,
+           rollout_percentage: pct,
+           bucket_key: normalize_bucket_key(bucket_key)
+         },
+         {:ok, updated} <- Api.upsert_feature_flag(attrs) do
+      Endpoint.broadcast_from(self(), "feature_flags", "updated", updated)
+      flags = Enum.map(socket.assigns.flags, fn f -> if f.id == id, do: updated, else: f end)
+      {:noreply, assign(socket, flags: flags)}
+    else
+      _ -> {:noreply, socket}
     end
   end
 
@@ -77,5 +108,12 @@ defmodule RealtimeWeb.FeatureFlagsLive.Index do
   def handle_info(%Phoenix.Socket.Broadcast{event: "deleted", payload: %{name: name}}, socket) do
     flags = Enum.reject(socket.assigns.flags, &(&1.name == name))
     {:noreply, assign(socket, flags: flags)}
+  end
+
+  defp normalize_bucket_key(bucket_key) do
+    case String.trim(bucket_key) do
+      "" -> nil
+      trimmed -> trimmed
+    end
   end
 end

--- a/lib/realtime_web/live/feature_flags_live/index.html.heex
+++ b/lib/realtime_web/live/feature_flags_live/index.html.heex
@@ -19,6 +19,7 @@
       <tr class="border-b border-gray-200">
         <th class="py-2 pr-4 font-semibold text-gray-700">Name</th>
         <th class="py-2 pr-4 font-semibold text-gray-700">Status</th>
+        <th class="py-2 pr-4 font-semibold text-gray-700">Rollout</th>
         <th class="py-2 font-semibold text-gray-700">Actions</th>
       </tr>
     </thead>
@@ -48,6 +49,31 @@
                 <%= if flag.enabled, do: "Enabled", else: "Disabled" %>
               </span>
             </div>
+          </td>
+          <td class="py-3 pr-4">
+            <form id={"set_rollout_#{flag.id}"} phx-submit="set_rollout" class="flex items-center gap-1">
+              <input type="hidden" name="flag_id" value={flag.id} />
+              <input
+                type="number"
+                name="rollout_percentage"
+                min="0"
+                max="100"
+                value={flag.rollout_percentage}
+                class="border border-gray-300 rounded px-2 py-1 text-sm w-16"
+              />
+              <span class="text-gray-500">%</span>
+              <input
+                type="text"
+                name="bucket_key"
+                value={flag.bucket_key}
+                placeholder={"defaults to \"#{flag.name}\""}
+                title="Bucket key: flags sharing the same bucket key share the same rollout cohort"
+                class="border border-gray-300 rounded px-2 py-1 text-sm w-32"
+              />
+              <button type="submit" class="bg-gray-200 hover:bg-gray-300 text-gray-700 text-xs px-2 py-1 rounded">
+                Save
+              </button>
+            </form>
           </td>
           <td class="py-3">
             <button

--- a/priv/repo/migrations/20260709151810_add_feature_flag_rollout_percentage.exs
+++ b/priv/repo/migrations/20260709151810_add_feature_flag_rollout_percentage.exs
@@ -1,0 +1,14 @@
+defmodule Realtime.Repo.Migrations.AddFeatureFlagRolloutPercentage do
+  use Ecto.Migration
+
+  def change do
+    alter table(:feature_flags) do
+      add :rollout_percentage, :integer, null: false, default: 100
+      add :bucket_key, :string
+    end
+
+    create constraint(:feature_flags, :rollout_percentage_must_be_between_0_and_100,
+             check: "rollout_percentage >= 0 AND rollout_percentage <= 100"
+           )
+  end
+end

--- a/test/realtime/api_test.exs
+++ b/test/realtime/api_test.exs
@@ -565,6 +565,48 @@ defmodule Realtime.ApiTest do
       assert {:error, changeset} = Api.upsert_feature_flag(%{enabled: false})
       assert "can't be blank" in errors_on(changeset).name
     end
+
+    test "defaults rollout_percentage to 100 when omitted" do
+      assert {:ok, %FeatureFlag{rollout_percentage: 100}} =
+               Api.upsert_feature_flag(%{name: "default_rollout_flag", enabled: true})
+    end
+
+    test "accepts a rollout_percentage within 0..100" do
+      assert {:ok, %FeatureFlag{rollout_percentage: 25}} =
+               Api.upsert_feature_flag(%{name: "partial_rollout_flag", enabled: true, rollout_percentage: 25})
+    end
+
+    test "rejects a rollout_percentage below 0" do
+      assert {:error, changeset} =
+               Api.upsert_feature_flag(%{name: "invalid_rollout_flag", enabled: true, rollout_percentage: -1})
+
+      assert "must be greater than or equal to 0" in errors_on(changeset).rollout_percentage
+    end
+
+    test "rejects a rollout_percentage above 100" do
+      assert {:error, changeset} =
+               Api.upsert_feature_flag(%{name: "invalid_rollout_flag", enabled: true, rollout_percentage: 101})
+
+      assert "must be less than or equal to 100" in errors_on(changeset).rollout_percentage
+    end
+
+    test "defaults bucket_key to nil when omitted" do
+      assert {:ok, %FeatureFlag{bucket_key: nil}} =
+               Api.upsert_feature_flag(%{name: "default_bucket_key_flag", enabled: true})
+    end
+
+    test "accepts an explicit bucket_key" do
+      assert {:ok, %FeatureFlag{bucket_key: "shared_cohort"}} =
+               Api.upsert_feature_flag(%{name: "bucket_key_flag", enabled: true, bucket_key: "shared_cohort"})
+    end
+
+    test "updating a flag without bucket_key clears any previously set bucket_key" do
+      {:ok, _} =
+        Api.upsert_feature_flag(%{name: "bucket_key_reset_flag", enabled: true, bucket_key: "shared_cohort"})
+
+      assert {:ok, %FeatureFlag{bucket_key: nil}} =
+               Api.upsert_feature_flag(%{name: "bucket_key_reset_flag", enabled: true})
+    end
   end
 
   describe "delete_feature_flag/1" do

--- a/test/realtime/feature_flags_test.exs
+++ b/test/realtime/feature_flags_test.exs
@@ -81,4 +81,105 @@ defmodule Realtime.FeatureFlagsTest do
       refute FeatureFlags.enabled?("disabled_for_tenant", tenant.external_id)
     end
   end
+
+  describe "enabled?/2 percentage rollout" do
+    # precomputed :erlang.phash2({external_id, bucket_key}, 100) buckets for these fixed ids,
+    # where bucket_key defaults to the flag's own name:
+    # {"t_6", "rollout_flag"} -> 3, {"t_7", "rollout_flag"} -> 85, {"t_11", "monotonic_flag"} -> 2
+    test "tenant within the rollout percentage is enabled, tenant outside it is not" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "rollout_flag", enabled: true, rollout_percentage: 10})
+
+      in_bucket = tenant_fixture(%{external_id: "t_6", feature_flags: %{}})
+      out_of_bucket = tenant_fixture(%{external_id: "t_7", feature_flags: %{}})
+
+      assert FeatureFlags.enabled?("rollout_flag", in_bucket.external_id)
+      refute FeatureFlags.enabled?("rollout_flag", out_of_bucket.external_id)
+    end
+
+    test "raising the rollout percentage never disables a tenant already included (monotonic)" do
+      {:ok, flag} = Api.upsert_feature_flag(%{name: "monotonic_flag", enabled: true, rollout_percentage: 10})
+      tenant = tenant_fixture(%{external_id: "t_11", feature_flags: %{}})
+
+      assert FeatureFlags.enabled?("monotonic_flag", tenant.external_id)
+
+      for percentage <- [15, 25, 50, 100] do
+        {:ok, _} = Api.upsert_feature_flag(%{name: flag.name, enabled: true, rollout_percentage: percentage})
+        assert FeatureFlags.enabled?("monotonic_flag", tenant.external_id)
+      end
+    end
+
+    test "0% rollout keeps everyone disabled regardless of bucket" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "zero_percent_flag", enabled: true, rollout_percentage: 0})
+      tenant = tenant_fixture(%{feature_flags: %{}})
+      refute FeatureFlags.enabled?("zero_percent_flag", tenant.external_id)
+    end
+
+    test "100% rollout enables everyone regardless of bucket" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "hundred_percent_flag", enabled: true, rollout_percentage: 100})
+      tenant = tenant_fixture(%{feature_flags: %{}})
+      assert FeatureFlags.enabled?("hundred_percent_flag", tenant.external_id)
+    end
+
+    test "disabled flag stays disabled even for tenants inside the rollout bucket" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "off_with_rollout", enabled: false, rollout_percentage: 100})
+      tenant = tenant_fixture(%{feature_flags: %{}})
+      refute FeatureFlags.enabled?("off_with_rollout", tenant.external_id)
+    end
+
+    test "explicit tenant override wins over the rollout percentage in both directions" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "override_flag", enabled: true, rollout_percentage: 0})
+
+      forced_on = tenant_fixture(%{feature_flags: %{"override_flag" => true}})
+      assert FeatureFlags.enabled?("override_flag", forced_on.external_id)
+
+      {:ok, _} = Api.upsert_feature_flag(%{name: "override_flag_2", enabled: true, rollout_percentage: 100})
+      forced_off = tenant_fixture(%{feature_flags: %{"override_flag_2" => false}})
+      refute FeatureFlags.enabled?("override_flag_2", forced_off.external_id)
+    end
+  end
+
+  describe "enabled?/2 bucket_key" do
+    # precomputed :erlang.phash2({external_id, bucket_key}, 100) for "t_1":
+    # {"t_1", "indep_flag_a"} -> 4, {"t_1", "indep_flag_b"} -> 59
+    test "flags default to independent (decorrelated) cohorts based on their own name" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "indep_flag_a", enabled: true, rollout_percentage: 10})
+      {:ok, _} = Api.upsert_feature_flag(%{name: "indep_flag_b", enabled: true, rollout_percentage: 10})
+      tenant = tenant_fixture(%{external_id: "t_1", feature_flags: %{}})
+
+      assert FeatureFlags.enabled?("indep_flag_a", tenant.external_id)
+      refute FeatureFlags.enabled?("indep_flag_b", tenant.external_id)
+    end
+
+    test "flags sharing an explicit bucket_key always agree on cohort membership" do
+      {:ok, _} =
+        Api.upsert_feature_flag(%{
+          name: "shared_flag_a",
+          enabled: true,
+          rollout_percentage: 50,
+          bucket_key: "shared_cohort"
+        })
+
+      {:ok, _} =
+        Api.upsert_feature_flag(%{
+          name: "shared_flag_b",
+          enabled: true,
+          rollout_percentage: 50,
+          bucket_key: "shared_cohort"
+        })
+
+      for i <- 1..10 do
+        tenant = tenant_fixture(%{external_id: "shared_cohort_tenant_#{i}", feature_flags: %{}})
+        a_enabled = FeatureFlags.enabled?("shared_flag_a", tenant.external_id)
+        b_enabled = FeatureFlags.enabled?("shared_flag_b", tenant.external_id)
+        assert a_enabled == b_enabled
+      end
+    end
+  end
+
+  describe "enabled?/1 ignores rollout percentage" do
+    test "returns true for an enabled flag even with a 0% rollout percentage" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "global_ignores_rollout", enabled: true, rollout_percentage: 0})
+      assert FeatureFlags.enabled?("global_ignores_rollout")
+    end
+  end
 end

--- a/test/realtime_web/live/feature_flags_live/index_test.exs
+++ b/test/realtime_web/live/feature_flags_live/index_test.exs
@@ -101,6 +101,68 @@ defmodule RealtimeWeb.FeatureFlagsLive.IndexTest do
     end
   end
 
+  describe "set_rollout event" do
+    test "updates the rollout percentage and persists it, keeping enabled state", %{
+      conn: conn,
+      user: user,
+      password: password
+    } do
+      flag_name = "rollout_#{random_string()}"
+      {:ok, flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: true, rollout_percentage: 100})
+
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      view
+      |> form("#set_rollout_#{flag.id}", %{"rollout_percentage" => "25"})
+      |> render_submit()
+
+      assert %FeatureFlag{enabled: true, rollout_percentage: 25} = Api.get_feature_flag(flag_name)
+    end
+
+    test "ignores a non-integer rollout percentage", %{conn: conn, user: user, password: password} do
+      flag_name = "rollout_invalid_#{random_string()}"
+      {:ok, flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: true, rollout_percentage: 100})
+
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      view
+      |> form("#set_rollout_#{flag.id}", %{"rollout_percentage" => "abc"})
+      |> render_submit()
+
+      assert %FeatureFlag{rollout_percentage: 100} = Api.get_feature_flag(flag_name)
+    end
+
+    test "sets an explicit bucket_key and persists it", %{conn: conn, user: user, password: password} do
+      flag_name = "bucket_key_#{random_string()}"
+      {:ok, flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: true, rollout_percentage: 50})
+
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      view
+      |> form("#set_rollout_#{flag.id}", %{"bucket_key" => "shared_cohort"})
+      |> render_submit()
+
+      assert %FeatureFlag{bucket_key: "shared_cohort"} = Api.get_feature_flag(flag_name)
+    end
+
+    test "blanking the bucket_key field clears it back to the default", %{
+      conn: conn,
+      user: user,
+      password: password
+    } do
+      flag_name = "bucket_key_clear_#{random_string()}"
+      {:ok, flag} = Api.upsert_feature_flag(%{name: flag_name, enabled: true, bucket_key: "shared_cohort"})
+
+      {:ok, view, _} = conn |> using_basic_auth(user, password) |> live(~p"/admin/feature-flags")
+
+      view
+      |> form("#set_rollout_#{flag.id}", %{"bucket_key" => "  "})
+      |> render_submit()
+
+      assert %FeatureFlag{bucket_key: nil} = Api.get_feature_flag(flag_name)
+    end
+  end
+
   describe "delete event" do
     test "removes the flag from the list and DB", %{conn: conn, user: user, password: password} do
       flag_name = "delete_#{random_string()}"


### PR DESCRIPTION
## What kind of change does this PR introduce?

It supports a bucket_key so that one can control if different flags map the same tenants to the same buckets. aka:

Tenant ABC belongs to 10% on feature flag X but not necessarily on flag Y

If their bucket_key is the same then they will match on the same bucket of percentages.
