### PR TITLE
fix: restart Connect when Connect process dies with active users

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -145,6 +145,7 @@ defmodule Realtime.Application do
          strategy: :one_for_one,
          name: Connect.DynamicSupervisor,
          partitions: connect_partition_slots},
+        Realtime.Tenants.Reconnector,
         {RealtimeWeb.RealtimeChannel.Tracker, check_interval_in_ms: no_channel_timeout_in_ms},
         RealtimeWeb.Endpoint,
         {RealtimeWeb.Presence,

--- a/lib/realtime/tenants/reconnector.ex
+++ b/lib/realtime/tenants/reconnector.ex
@@ -1,0 +1,64 @@
+defmodule Realtime.Tenants.Reconnector do
+  @moduledoc """
+  Reactively restarts a tenant's `Realtime.Tenants.Connect` process when it unregisters from
+  `:syn` while this node still has locally-connected websocket clients for that tenant.
+
+  `Connect` is started with `restart: :temporary`, so its supervisor never restarts it after
+  a crash. Without this module, a tenant whose `Connect` process dies (crash, node move,
+  database connection drop) never gets it back unless a client triggers a new join/broadcast.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Realtime.UsersCounter
+  alias Realtime.Tenants.Connect
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  def handle_syn_event([:syn, Connect, :unregistered], _measurements, %{name: tenant_id}, pid) do
+    send(pid, {:check_reconnect, tenant_id})
+  end
+
+  @impl true
+  def init(_opts) do
+    Logger.info("Starting Reconnector")
+
+    :ok =
+      :telemetry.attach(
+        [self(), :reconnector],
+        [:syn, Connect, :unregistered],
+        &__MODULE__.handle_syn_event/4,
+        self()
+      )
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  def terminate(_reason, _state) do
+    :telemetry.detach([self(), :reconnector])
+    :ok
+  end
+
+  @impl true
+  def handle_info({:check_reconnect, tenant_id}, state) do
+    if UsersCounter.tenant_users(tenant_id, node()) > 0 do
+      Task.Supervisor.start_child(Realtime.TaskSupervisor, fn -> reconnect(tenant_id) end)
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp reconnect(tenant_id) do
+    case Connect.lookup_or_start_connection(tenant_id) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Reconnector could not restart connection for #{tenant_id}: #{inspect(reason)}")
+    end
+  end
+end

--- a/lib/realtime/tenants/reconnector.ex
+++ b/lib/realtime/tenants/reconnector.ex
@@ -1,11 +1,15 @@
 defmodule Realtime.Tenants.Reconnector do
   @moduledoc """
-  Reactively restarts a tenant's `Realtime.Tenants.Connect` process when it unregisters from
-  `:syn` while this node still has locally-connected websocket clients for that tenant.
+  Periodically ensures every tenant with locally-connected websocket clients has a
+  `Realtime.Tenants.Connect` process running.
 
   `Connect` is started with `restart: :temporary`, so its supervisor never restarts it after
   a crash. Without this module, a tenant whose `Connect` process dies (crash, node move,
   database connection drop) never gets it back unless a client triggers a new join/broadcast.
+
+  Every `@check_interval_ms` this module walks the tenants with local members
+  (`Realtime.UsersCounter.local_tenant_counts/0`) and starts a task to reconnect any tenant
+  that is missing its `Connect` process.
   """
 
   use GenServer
@@ -14,43 +18,30 @@ defmodule Realtime.Tenants.Reconnector do
   alias Realtime.UsersCounter
   alias Realtime.Tenants.Connect
 
-  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+  @check_interval_ms :timer.minutes(5)
 
-  def handle_syn_event([:syn, Connect, :unregistered], _measurements, %{name: tenant_id}, pid) do
-    send(pid, {:check_reconnect, tenant_id})
-  end
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
 
   @impl true
   def init(_opts) do
     Logger.info("Starting Reconnector")
-
-    :ok =
-      :telemetry.attach(
-        [self(), :reconnector],
-        [:syn, Connect, :unregistered],
-        &__MODULE__.handle_syn_event/4,
-        self()
-      )
-
+    schedule_check()
     {:ok, %{}}
   end
 
   @impl true
-  def terminate(_reason, _state) do
-    :telemetry.detach([self(), :reconnector])
-    :ok
-  end
-
-  @impl true
-  def handle_info({:check_reconnect, tenant_id}, state) do
-    if UsersCounter.tenant_users(tenant_id, node()) > 0 do
+  def handle_info(:check, state) do
+    for {tenant_id, _count} <- UsersCounter.local_tenant_counts(), is_nil(Connect.whereis(tenant_id)) do
       Task.Supervisor.start_child(Realtime.TaskSupervisor, fn -> reconnect(tenant_id) end)
     end
 
+    schedule_check()
     {:noreply, state}
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
+
+  defp schedule_check(), do: Process.send_after(self(), :check, @check_interval_ms)
 
   defp reconnect(tenant_id) do
     case Connect.lookup_or_start_connection(tenant_id) do

--- a/test/realtime/tenants/reconnector_test.exs
+++ b/test/realtime/tenants/reconnector_test.exs
@@ -1,6 +1,5 @@
 defmodule Realtime.Tenants.ReconnectorTest do
-  # Async false since we're spawning real Connect processes and manipulating Census/:syn state
-  use Realtime.DataCase, async: false
+  use Realtime.DataCase, async: true
 
   alias Realtime.Tenants.Connect
   alias Realtime.Tenants.Reconnector
@@ -18,16 +17,10 @@ defmodule Realtime.Tenants.ReconnectorTest do
     assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, timeout
   end
 
-  describe "handle_syn_event/4" do
-    test "notifies the given pid to check for a reconnect" do
-      Reconnector.handle_syn_event([:syn, Connect, :unregistered], %{}, %{name: "a-tenant"}, self())
-
-      assert_receive {:check_reconnect, "a-tenant"}
-    end
-  end
-
-  describe "reconnect on Connect crash" do
+  describe "periodic reconnect check" do
     test "restarts Connect when this node still has connected users", %{tenant: tenant} do
+      {:ok, reconnector} = Reconnector.start_link([])
+
       assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
       pid = Connect.whereis(tenant.external_id)
 
@@ -39,12 +32,16 @@ defmodule Realtime.Tenants.ReconnectorTest do
       Process.exit(pid, :kill)
       assert_process_down(pid)
 
+      send(reconnector, :check)
+
       assert_receive %{event: "ready", payload: %{pid: new_pid}}, 5000
       assert new_pid != pid
       assert Connect.whereis(tenant.external_id) == new_pid
     end
 
     test "does not restart Connect when this node has no connected users", %{tenant: tenant} do
+      {:ok, reconnector} = Reconnector.start_link([])
+
       assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
       pid = Connect.whereis(tenant.external_id)
 
@@ -53,10 +50,10 @@ defmodule Realtime.Tenants.ReconnectorTest do
       Process.exit(pid, :kill)
       assert_process_down(pid)
 
+      send(reconnector, :check)
+
       refute_receive %{event: "ready"}, 500
       refute Connect.whereis(tenant.external_id)
-    after
-      Endpoint.unsubscribe(Connect.syn_topic(tenant.external_id))
     end
   end
 end

--- a/test/realtime/tenants/reconnector_test.exs
+++ b/test/realtime/tenants/reconnector_test.exs
@@ -1,0 +1,62 @@
+defmodule Realtime.Tenants.ReconnectorTest do
+  # Async false since we're spawning real Connect processes and manipulating Census/:syn state
+  use Realtime.DataCase, async: false
+
+  alias Realtime.Tenants.Connect
+  alias Realtime.Tenants.Reconnector
+  alias Realtime.UsersCounter
+  alias RealtimeWeb.Endpoint
+
+  setup do
+    tenant = Containers.checkout_tenant(run_migrations: true)
+
+    %{tenant: tenant}
+  end
+
+  defp assert_process_down(pid, timeout \\ 100) do
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, timeout
+  end
+
+  describe "handle_syn_event/4" do
+    test "notifies the given pid to check for a reconnect" do
+      Reconnector.handle_syn_event([:syn, Connect, :unregistered], %{}, %{name: "a-tenant"}, self())
+
+      assert_receive {:check_reconnect, "a-tenant"}
+    end
+  end
+
+  describe "reconnect on Connect crash" do
+    test "restarts Connect when this node still has connected users", %{tenant: tenant} do
+      assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
+      pid = Connect.whereis(tenant.external_id)
+
+      user_pid = spawn(fn -> Process.sleep(:infinity) end)
+      UsersCounter.add(user_pid, tenant.external_id)
+
+      Endpoint.subscribe(Connect.syn_topic(tenant.external_id))
+
+      Process.exit(pid, :kill)
+      assert_process_down(pid)
+
+      assert_receive %{event: "ready", payload: %{pid: new_pid}}, 5000
+      assert new_pid != pid
+      assert Connect.whereis(tenant.external_id) == new_pid
+    end
+
+    test "does not restart Connect when this node has no connected users", %{tenant: tenant} do
+      assert {:ok, _} = Connect.lookup_or_start_connection(tenant.external_id)
+      pid = Connect.whereis(tenant.external_id)
+
+      Endpoint.subscribe(Connect.syn_topic(tenant.external_id))
+
+      Process.exit(pid, :kill)
+      assert_process_down(pid)
+
+      refute_receive %{event: "ready"}, 500
+      refute Connect.whereis(tenant.external_id)
+    after
+      Endpoint.unsubscribe(Connect.syn_topic(tenant.external_id))
+    end
+  end
+end


### PR DESCRIPTION
Every 5 minutes every node will look for tenants with active websockets but no `Connect` running and restart it.