### PR TITLE
fix(tests): mirror supabase/postgres migrations

### DIFF
--- a/test/realtime/tenants/schema_test.exs
+++ b/test/realtime/tenants/schema_test.exs
@@ -14,7 +14,9 @@ defmodule Realtime.Tenants.SchemaTest do
     opts = settings |> Map.from_struct() |> Keyword.new()
 
     {:ok, conn_postgres} = opts |> Keyword.put(:username, "postgres") |> Postgrex.start_link()
-    {:ok, conn_superuser} = opts |> Keyword.put(:username, "supabase_admin") |> Postgrex.start_link()
+
+    {:ok, conn_superuser} =
+      opts |> Keyword.put(:username, "supabase_admin") |> Postgrex.start_link()
 
     %{conn_postgres: conn_postgres, conn_superuser: conn_superuser, settings: settings}
   end
@@ -24,7 +26,11 @@ defmodule Realtime.Tenants.SchemaTest do
 
     test "not a member of supabase_realtime_admin", %{conn_postgres: conn_postgres} do
       assert %Postgrex.Result{rows: [[false]]} =
-               Postgrex.query!(conn_postgres, "SELECT pg_has_role('postgres', 'supabase_realtime_admin', 'MEMBER')", [])
+               Postgrex.query!(
+                 conn_postgres,
+                 "SELECT pg_has_role('postgres', 'supabase_realtime_admin', 'MEMBER')",
+                 []
+               )
     end
 
     test "cannot assume supabase_realtime_admin", %{conn_postgres: conn_postgres} do
@@ -77,22 +83,10 @@ defmodule Realtime.Tenants.SchemaTest do
     end
 
     test "cannot create a function", %{conn_postgres: conn_postgres} do
-      assert_denied(conn_postgres, "CREATE FUNCTION realtime.evil() RETURNS void LANGUAGE sql AS 'SELECT 1'")
-    end
-
-    test "cannot create a trigger on realtime tables", %{conn_postgres: conn_postgres} do
-      Postgrex.query!(
+      assert_denied(
         conn_postgres,
-        "CREATE OR REPLACE FUNCTION public.dummy_function() RETURNS trigger AS $$ BEGIN RETURN NEW; END; $$ LANGUAGE plpgsql",
-        []
+        "CREATE FUNCTION realtime.evil() RETURNS void LANGUAGE sql AS 'SELECT 1'"
       )
-
-      for table <- ~w(messages subscription) do
-        assert_denied(
-          conn_postgres,
-          "CREATE TRIGGER #{table}_trigger BEFORE INSERT ON realtime.#{table} FOR EACH ROW EXECUTE FUNCTION public.dummy_function()"
-        )
-      end
     end
 
     test "cannot alter realtime.messages columns", %{conn_postgres: conn_postgres} do
@@ -102,7 +96,10 @@ defmodule Realtime.Tenants.SchemaTest do
     end
 
     test "cannot alter a function owner to postgres", %{conn_postgres: conn_postgres} do
-      assert_denied(conn_postgres, "ALTER FUNCTION realtime.send(jsonb, text, text, boolean) OWNER TO postgres")
+      assert_denied(
+        conn_postgres,
+        "ALTER FUNCTION realtime.send(jsonb, text, text, boolean) OWNER TO postgres"
+      )
     end
 
     test "cannot rename realtime.messages", %{conn_postgres: conn_postgres} do
@@ -113,16 +110,25 @@ defmodule Realtime.Tenants.SchemaTest do
   describe "postgres role allowances on realtime schema" do
     test "has USAGE on schema realtime", %{conn_postgres: conn_postgres} do
       assert %Postgrex.Result{rows: [[true]]} =
-               Postgrex.query!(conn_postgres, "SELECT has_schema_privilege('postgres', 'realtime', 'USAGE')", [])
+               Postgrex.query!(
+                 conn_postgres,
+                 "SELECT has_schema_privilege('postgres', 'realtime', 'USAGE')",
+                 []
+               )
     end
 
     test "can grant USAGE on schema realtime to a custom role", %{conn_postgres: conn_postgres} do
       Postgrex.query!(conn_postgres, "CREATE ROLE role_test", [])
 
-      assert {:ok, _} = Postgrex.query(conn_postgres, "GRANT USAGE ON SCHEMA realtime TO role_test", [])
+      assert {:ok, _} =
+               Postgrex.query(conn_postgres, "GRANT USAGE ON SCHEMA realtime TO role_test", [])
 
       assert %Postgrex.Result{rows: [[true]]} =
-               Postgrex.query!(conn_postgres, "SELECT has_schema_privilege('role_test', 'realtime', 'USAGE')", [])
+               Postgrex.query!(
+                 conn_postgres,
+                 "SELECT has_schema_privilege('role_test', 'realtime', 'USAGE')",
+                 []
+               )
 
       Postgrex.query!(conn_postgres, "REVOKE USAGE ON SCHEMA realtime FROM role_test", [])
       Postgrex.query!(conn_postgres, "DROP ROLE role_test", [])
@@ -138,7 +144,29 @@ defmodule Realtime.Tenants.SchemaTest do
     end
 
     test "can select from realtime.messages", %{conn_postgres: conn_postgres} do
-      assert {:ok, _} = Postgrex.query(conn_postgres, "SELECT * FROM realtime.messages LIMIT 1", [])
+      assert {:ok, _} =
+               Postgrex.query(conn_postgres, "SELECT * FROM realtime.messages LIMIT 1", [])
+    end
+
+    test "can create a trigger on realtime tables", %{conn_postgres: conn_postgres} do
+      Postgrex.query!(
+        conn_postgres,
+        "CREATE OR REPLACE FUNCTION public.dummy_function() RETURNS trigger AS $$ BEGIN RETURN NEW; END; $$ LANGUAGE plpgsql",
+        []
+      )
+
+      for table <- ~w(messages subscription) do
+        assert_allowed(
+          conn_postgres,
+          "CREATE TRIGGER #{table}_trigger BEFORE INSERT ON realtime.#{table} FOR EACH ROW EXECUTE FUNCTION public.dummy_function()"
+        )
+      end
+    end
+
+    test "can truncate realtime tables", %{conn_postgres: conn_postgres} do
+      for table <- ~w(messages subscription) do
+        assert_allowed(conn_postgres, "TRUNCATE realtime.#{table}")
+      end
     end
   end
 
@@ -152,7 +180,11 @@ defmodule Realtime.Tenants.SchemaTest do
                )
 
       assert {:ok, _} =
-               Postgrex.query(conn_postgres, "DROP POLICY messages_policy_select_test ON realtime.messages", [])
+               Postgrex.query(
+                 conn_postgres,
+                 "DROP POLICY messages_policy_select_test ON realtime.messages",
+                 []
+               )
     end
 
     test "create and drop INSERT policy", %{conn_postgres: conn_postgres} do
@@ -164,7 +196,11 @@ defmodule Realtime.Tenants.SchemaTest do
                )
 
       assert {:ok, _} =
-               Postgrex.query(conn_postgres, "DROP POLICY messages_policy_insert_test ON realtime.messages", [])
+               Postgrex.query(
+                 conn_postgres,
+                 "DROP POLICY messages_policy_insert_test ON realtime.messages",
+                 []
+               )
     end
 
     test "create and drop FOR ALL policy", %{conn_postgres: conn_postgres} do
@@ -175,7 +211,12 @@ defmodule Realtime.Tenants.SchemaTest do
                  []
                )
 
-      assert {:ok, _} = Postgrex.query(conn_postgres, "DROP POLICY messages_policy ON realtime.messages", [])
+      assert {:ok, _} =
+               Postgrex.query(
+                 conn_postgres,
+                 "DROP POLICY messages_policy ON realtime.messages",
+                 []
+               )
     end
 
     test "alter existing policy", %{conn_postgres: conn_postgres} do
@@ -192,7 +233,11 @@ defmodule Realtime.Tenants.SchemaTest do
                  []
                )
 
-      Postgrex.query!(conn_postgres, "DROP POLICY messages_policy_alter_test ON realtime.messages", [])
+      Postgrex.query!(
+        conn_postgres,
+        "DROP POLICY messages_policy_alter_test ON realtime.messages",
+        []
+      )
     end
   end
 
@@ -208,7 +253,11 @@ defmodule Realtime.Tenants.SchemaTest do
                )
 
       assert {:ok, _} =
-               Postgrex.query(conn_postgres, "DROP POLICY subscription_policy_select ON realtime.subscription", [])
+               Postgrex.query(
+                 conn_postgres,
+                 "DROP POLICY subscription_policy_select ON realtime.subscription",
+                 []
+               )
     end
 
     test "create and drop INSERT policy", %{conn_postgres: conn_postgres} do
@@ -220,7 +269,11 @@ defmodule Realtime.Tenants.SchemaTest do
                )
 
       assert {:ok, _} =
-               Postgrex.query(conn_postgres, "DROP POLICY subscription_policy_insert ON realtime.subscription", [])
+               Postgrex.query(
+                 conn_postgres,
+                 "DROP POLICY subscription_policy_insert ON realtime.subscription",
+                 []
+               )
     end
 
     test "create and drop UPDATE policy", %{conn_postgres: conn_postgres} do
@@ -232,7 +285,11 @@ defmodule Realtime.Tenants.SchemaTest do
                )
 
       assert {:ok, _} =
-               Postgrex.query(conn_postgres, "DROP POLICY subscription_policy_update ON realtime.subscription", [])
+               Postgrex.query(
+                 conn_postgres,
+                 "DROP POLICY subscription_policy_update ON realtime.subscription",
+                 []
+               )
     end
 
     test "create and drop DELETE policy", %{conn_postgres: conn_postgres} do
@@ -244,7 +301,11 @@ defmodule Realtime.Tenants.SchemaTest do
                )
 
       assert {:ok, _} =
-               Postgrex.query(conn_postgres, "DROP POLICY subscription_policy_delete ON realtime.subscription", [])
+               Postgrex.query(
+                 conn_postgres,
+                 "DROP POLICY subscription_policy_delete ON realtime.subscription",
+                 []
+               )
     end
 
     test "create and drop FOR ALL policy", %{conn_postgres: conn_postgres} do
@@ -256,7 +317,11 @@ defmodule Realtime.Tenants.SchemaTest do
                )
 
       assert {:ok, _} =
-               Postgrex.query(conn_postgres, "DROP POLICY subscription_policy_all ON realtime.subscription", [])
+               Postgrex.query(
+                 conn_postgres,
+                 "DROP POLICY subscription_policy_all ON realtime.subscription",
+                 []
+               )
     end
 
     test "alter existing policy", %{conn_postgres: conn_postgres} do
@@ -273,13 +338,21 @@ defmodule Realtime.Tenants.SchemaTest do
                  []
                )
 
-      Postgrex.query!(conn_postgres, "DROP POLICY subscription_policy_alter_test ON realtime.subscription", [])
+      Postgrex.query!(
+        conn_postgres,
+        "DROP POLICY subscription_policy_alter_test ON realtime.subscription",
+        []
+      )
     end
   end
 
   describe "realtime.schema_migrations" do
     test "postgres cannot modify rows", %{conn_postgres: conn_postgres} do
-      assert_denied(conn_postgres, "INSERT INTO realtime.schema_migrations (version, inserted_at) VALUES (0, now())")
+      assert_denied(
+        conn_postgres,
+        "INSERT INTO realtime.schema_migrations (version, inserted_at) VALUES (0, now())"
+      )
+
       assert_denied(conn_postgres, "DELETE FROM realtime.schema_migrations")
       assert_denied(conn_postgres, "UPDATE realtime.schema_migrations SET version = 0")
     end
@@ -312,12 +385,516 @@ defmodule Realtime.Tenants.SchemaTest do
                  []
                )
 
-      Postgrex.query!(conn_superuser, "DELETE FROM realtime.schema_migrations WHERE version = 1", [])
+      Postgrex.query!(
+        conn_superuser,
+        "DELETE FROM realtime.schema_migrations WHERE version = 1",
+        []
+      )
+    end
+  end
+
+  describe "database broadcast caller authorization" do
+    test "matching topic INSERT policy permits send and send_binary", %{conn_superuser: conn} do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_matching_topic ON realtime.messages FOR INSERT TO authenticated WITH CHECK (realtime.topic() = 'allowed-topic')",
+          []
+        )
+
+        as_role(conn, "authenticated", %{}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["matching_topic_json", "allowed-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "matching_topic_binary", "allowed-topic"]
+          )
+        end)
+
+        assert message_count(conn, "matching_topic") == 2
+      end)
+    end
+
+    test "wrong-topic policy denies send and send_binary", %{conn_superuser: conn} do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_wrong_topic ON realtime.messages FOR INSERT TO authenticated WITH CHECK (realtime.topic() = 'allowed-topic')",
+          []
+        )
+
+        as_role(conn, "authenticated", %{}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["wrong_topic_json", "denied-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "wrong_topic_binary", "denied-topic"]
+          )
+        end)
+
+        assert message_count(conn, "wrong_topic") == 0
+      end)
+    end
+
+    test "restrictive INSERT policy blocks broadcasts despite a permissive policy", %{
+      conn_superuser: conn
+    } do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_permissive_insert ON realtime.messages FOR INSERT TO authenticated WITH CHECK (true)",
+          []
+        )
+
+        # Restrictive policies are `AND`
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_restrictive_deny ON realtime.messages AS RESTRICTIVE FOR INSERT TO authenticated WITH CHECK (false)",
+          []
+        )
+
+        as_role(conn, "authenticated", %{}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["explicit_deny_json", "test-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "explicit_deny_binary", "test-topic"]
+          )
+        end)
+
+        assert message_count(conn, "explicit_deny") == 0
+      end)
+    end
+
+    test "authenticated caller uses authenticated INSERT policy", %{conn_superuser: conn} do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_authenticated_only ON realtime.messages FOR INSERT TO authenticated WITH CHECK (true)",
+          []
+        )
+
+        as_role(conn, "authenticated", %{}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["authenticated_caller_json", "test-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "authenticated_caller_binary", "test-topic"]
+          )
+        end)
+
+        assert message_count(conn, "authenticated_caller") == 2
+      end)
+    end
+
+    test "anon caller cannot use authenticated INSERT policy", %{conn_superuser: conn} do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_authenticated_only ON realtime.messages FOR INSERT TO authenticated WITH CHECK (true)",
+          []
+        )
+
+        as_role(conn, "anon", %{}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["anon_caller_json", "test-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "anon_caller_binary", "test-topic"]
+          )
+        end)
+
+        assert message_count(conn, "anon_caller") == 0
+      end)
+    end
+
+    test "policies evaluate the topic argument set by send and send_binary", %{
+      conn_superuser: conn
+    } do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(conn, "CREATE TABLE public.schema_test_send_topic_log (topic text)", [])
+
+        Postgrex.query!(
+          conn,
+          """
+          CREATE FUNCTION public.schema_test_capture_send_topic() RETURNS boolean
+          LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+          BEGIN
+            INSERT INTO public.schema_test_send_topic_log(topic)
+            VALUES (current_setting('realtime.topic', true));
+            RETURN true;
+          END;
+          $$
+          """,
+          []
+        )
+
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_captures_topic ON realtime.messages FOR INSERT TO authenticated WITH CHECK (public.schema_test_capture_send_topic())",
+          []
+        )
+
+        as_role(conn, "authenticated", %{}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["topic_context_json", "captured-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "topic_context_binary", "captured-topic"]
+          )
+        end)
+
+        assert %{rows: [["captured-topic"], ["captured-topic"]]} =
+                 Postgrex.query!(
+                   conn,
+                   "SELECT topic FROM public.schema_test_send_topic_log ORDER BY ctid",
+                   []
+                 )
+      end)
+    end
+
+    test "matching JWT claims permit broadcasts", %{conn_superuser: conn} do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          """
+          CREATE POLICY send_matching_claim ON realtime.messages FOR INSERT TO authenticated
+          WITH CHECK (current_setting('request.jwt.claims', true)::jsonb ->> 'sub' = 'allowed-user')
+          """,
+          []
+        )
+
+        as_role(
+          conn,
+          "authenticated",
+          %{"role" => "authenticated", "sub" => "allowed-user"},
+          fn ->
+            Postgrex.query!(
+              conn,
+              "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+              ["matching_claim_json", "test-topic"]
+            )
+
+            Postgrex.query!(
+              conn,
+              "SELECT realtime.send_binary($1, $2, $3, true)",
+              [<<1, 2>>, "matching_claim_binary", "test-topic"]
+            )
+          end
+        )
+
+        assert message_count(conn, "matching_claim") == 2
+      end)
+    end
+
+    test "non-matching JWT claims deny broadcasts", %{conn_superuser: conn} do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          """
+          CREATE POLICY send_matching_claim ON realtime.messages FOR INSERT TO authenticated
+          WITH CHECK (current_setting('request.jwt.claims', true)::jsonb ->> 'sub' = 'allowed-user')
+          """,
+          []
+        )
+
+        as_role(conn, "authenticated", %{"role" => "authenticated", "sub" => "denied-user"}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["wrong_claim_json", "test-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "wrong_claim_binary", "test-topic"]
+          )
+        end)
+
+        assert message_count(conn, "wrong_claim") == 0
+      end)
+    end
+
+    test "documented SECURITY DEFINER database trigger can broadcast", %{conn_superuser: conn} do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_database_allow ON realtime.messages FOR INSERT TO PUBLIC WITH CHECK (true)",
+          []
+        )
+
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_database_only ON realtime.messages AS RESTRICTIVE FOR INSERT TO PUBLIC WITH CHECK (false)",
+          []
+        )
+
+        as_role(conn, "postgres", %{}, fn ->
+          Postgrex.query!(conn, "CREATE TABLE public.schema_test_send_source (id int)", [])
+
+          Postgrex.query!(
+            conn,
+            "GRANT INSERT ON public.schema_test_send_source TO authenticated",
+            []
+          )
+
+          Postgrex.query!(
+            conn,
+            """
+            CREATE FUNCTION public.schema_test_send_from_trigger() RETURNS trigger
+            LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+            BEGIN
+              PERFORM realtime.send('{}'::jsonb, 'database_trigger_json', 'database-topic', true);
+              PERFORM realtime.send_binary('\\x0102'::bytea, 'database_trigger_binary', 'database-topic', true);
+              RETURN NEW;
+            END;
+            $$
+            """,
+            []
+          )
+
+          Postgrex.query!(
+            conn,
+            "CREATE TRIGGER schema_test_send_trigger AFTER INSERT ON public.schema_test_send_source FOR EACH ROW EXECUTE FUNCTION public.schema_test_send_from_trigger()",
+            []
+          )
+        end)
+
+        as_role(conn, "authenticated", %{"role" => "authenticated"}, fn ->
+          Postgrex.query!(conn, "INSERT INTO public.schema_test_send_source VALUES (1)", [])
+        end)
+
+        assert message_count(conn, "database_trigger") == 2
+      end)
+    end
+
+    test "anon caller cannot bypass restrictive broadcast policy", %{conn_superuser: conn} do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_unprivileged_allow ON realtime.messages FOR INSERT TO PUBLIC WITH CHECK (true)",
+          []
+        )
+
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_unprivileged_deny ON realtime.messages AS RESTRICTIVE FOR INSERT TO PUBLIC WITH CHECK (false)",
+          []
+        )
+
+        as_role(conn, "anon", %{"role" => "anon"}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["unprivileged_anon_json", "test-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "unprivileged_anon_binary", "test-topic"]
+          )
+        end)
+
+        assert message_count(conn, "unprivileged_anon") == 0
+      end)
+    end
+
+    test "authenticated caller cannot bypass restrictive broadcast policy", %{
+      conn_superuser: conn
+    } do
+      in_rollback(conn, fn conn ->
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_unprivileged_allow ON realtime.messages FOR INSERT TO PUBLIC WITH CHECK (true)",
+          []
+        )
+
+        Postgrex.query!(
+          conn,
+          "CREATE POLICY send_unprivileged_deny ON realtime.messages AS RESTRICTIVE FOR INSERT TO PUBLIC WITH CHECK (false)",
+          []
+        )
+
+        as_role(conn, "authenticated", %{"role" => "authenticated"}, fn ->
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send('{}'::jsonb, $1, $2, true)",
+            ["unprivileged_authenticated_json", "test-topic"]
+          )
+
+          Postgrex.query!(
+            conn,
+            "SELECT realtime.send_binary($1, $2, $3, true)",
+            [<<1, 2>>, "unprivileged_authenticated_binary", "test-topic"]
+          )
+        end)
+
+        assert message_count(conn, "unprivileged_authenticated") == 0
+      end)
+    end
+  end
+
+  describe "privileged write security contracts" do
+    @describetag :requires_supautils_policy_grants
+
+    test "functions send and send_binary preserve caller RLS", %{
+      conn_postgres: conn_postgres
+    } do
+      %Postgrex.Result{rows: rows} =
+        Postgrex.query!(
+          conn_postgres,
+          """
+          SELECT p.proname, p.prosecdef, p.proconfig
+          FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+          WHERE n.nspname = 'realtime' AND p.proname IN ('send', 'send_binary')
+          ORDER BY p.proname
+          """,
+          []
+        )
+
+      assert rows == [
+               ["send", false, nil],
+               ["send_binary", false, nil]
+             ]
+    end
+
+    test "supabase_realtime_admin cannot escalate privileges", %{conn_postgres: conn_postgres} do
+      assert %Postgrex.Result{rows: [[false, false, false]]} =
+               Postgrex.query!(
+                 conn_postgres,
+                 "SELECT rolsuper, rolcreaterole, rolcreatedb FROM pg_roles WHERE rolname = 'supabase_realtime_admin'",
+                 []
+               )
+    end
+
+    test "a trigger fired by realtime.send preserves the caller role", %{
+      conn_postgres: conn_postgres
+    } do
+      Postgrex.query!(conn_postgres, "DROP TABLE IF EXISTS public.schema_test_trigger_log", [])
+      Postgrex.query!(conn_postgres, "CREATE TABLE public.schema_test_trigger_log (who text)", [])
+
+      Postgrex.query!(
+        conn_postgres,
+        "GRANT INSERT ON public.schema_test_trigger_log TO supabase_realtime_admin",
+        []
+      )
+
+      Postgrex.query!(
+        conn_postgres,
+        """
+        CREATE OR REPLACE FUNCTION public.schema_test_capture_current_user() RETURNS trigger AS $$
+        BEGIN
+          INSERT INTO public.schema_test_trigger_log (who) VALUES (current_user);
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """,
+        []
+      )
+
+      Postgrex.query!(
+        conn_postgres,
+        "CREATE TRIGGER schema_test_capture_trigger AFTER INSERT ON realtime.messages FOR EACH ROW EXECUTE FUNCTION public.schema_test_capture_current_user()",
+        []
+      )
+
+      Postgrex.query!(
+        conn_postgres,
+        "SELECT realtime.send('{}'::jsonb, 'test_event', 'test_topic')",
+        []
+      )
+
+      assert %Postgrex.Result{rows: [["postgres"]]} =
+               Postgrex.query!(
+                 conn_postgres,
+                 "SELECT who FROM public.schema_test_trigger_log",
+                 []
+               )
+    end
+
+    test "a trigger fired by realtime.send_binary preserves the caller role", %{
+      conn_postgres: conn_postgres
+    } do
+      Postgrex.query!(conn_postgres, "DROP TABLE IF EXISTS public.schema_test_trigger_log", [])
+      Postgrex.query!(conn_postgres, "CREATE TABLE public.schema_test_trigger_log (who text)", [])
+
+      Postgrex.query!(
+        conn_postgres,
+        "GRANT INSERT ON public.schema_test_trigger_log TO supabase_realtime_admin",
+        []
+      )
+
+      Postgrex.query!(
+        conn_postgres,
+        """
+        CREATE OR REPLACE FUNCTION public.schema_test_capture_current_user() RETURNS trigger AS $$
+        BEGIN
+          INSERT INTO public.schema_test_trigger_log (who) VALUES (current_user);
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """,
+        []
+      )
+
+      Postgrex.query!(
+        conn_postgres,
+        "CREATE TRIGGER schema_test_capture_trigger AFTER INSERT ON realtime.messages FOR EACH ROW EXECUTE FUNCTION public.schema_test_capture_current_user()",
+        []
+      )
+
+      Postgrex.query!(
+        conn_postgres,
+        "SELECT realtime.send_binary('\\x00'::bytea, 'test_event', 'test_topic')",
+        []
+      )
+
+      assert %Postgrex.Result{rows: [["postgres"]]} =
+               Postgrex.query!(
+                 conn_postgres,
+                 "SELECT who FROM public.schema_test_trigger_log",
+                 []
+               )
     end
   end
 
   describe "ownership" do
-    test "all objects in the realtime schema are owned by supabase_realtime_admin", %{conn_superuser: conn_superuser} do
+    test "all objects in the realtime schema are owned by supabase_realtime_admin", %{
+      conn_superuser: conn_superuser
+    } do
       query = """
       SELECT format('table %I.%I', n.nspname, c.relname), r.rolname FROM pg_class c
       JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -343,7 +920,9 @@ defmodule Realtime.Tenants.SchemaTest do
 
       assert offenders == [],
              "realtime objects not owned by supabase_realtime_admin (add `ALTER ... OWNER TO supabase_realtime_admin` to the migration):\n" <>
-               Enum.map_join(offenders, "\n", fn [object, owner] -> "  - #{object} (owned by #{owner})" end)
+               Enum.map_join(offenders, "\n", fn [object, owner] ->
+                 "  - #{object} (owned by #{owner})"
+               end)
     end
 
     test "realtime schema is owned by supabase_admin", %{conn_superuser: conn_superuser} do
@@ -356,19 +935,35 @@ defmodule Realtime.Tenants.SchemaTest do
     end
   end
 
-  describe "supabase_admin can still manage realtime objects after the restriction" do
+  describe "supabase_admin realtime objects management" do
     @describetag :requires_supautils_policy_grants
 
     test "can alter and revert ownership of a realtime object", %{conn_superuser: conn_superuser} do
-      assert {:ok, _} = Postgrex.query(conn_superuser, "ALTER TABLE realtime.messages OWNER TO supabase_admin", [])
+      assert {:ok, _} =
+               Postgrex.query(
+                 conn_superuser,
+                 "ALTER TABLE realtime.messages OWNER TO supabase_admin",
+                 []
+               )
 
       assert {:ok, _} =
-               Postgrex.query(conn_superuser, "ALTER TABLE realtime.messages OWNER TO supabase_realtime_admin", [])
+               Postgrex.query(
+                 conn_superuser,
+                 "ALTER TABLE realtime.messages OWNER TO supabase_realtime_admin",
+                 []
+               )
     end
 
     test "can create and drop objects in realtime schema", %{conn_superuser: conn_superuser} do
-      assert {:ok, _} = Postgrex.query(conn_superuser, "CREATE TABLE realtime.future_migration_table (id int)", [])
-      assert {:ok, _} = Postgrex.query(conn_superuser, "DROP TABLE realtime.future_migration_table", [])
+      assert {:ok, _} =
+               Postgrex.query(
+                 conn_superuser,
+                 "CREATE TABLE realtime.future_migration_table (id int)",
+                 []
+               )
+
+      assert {:ok, _} =
+               Postgrex.query(conn_superuser, "DROP TABLE realtime.future_migration_table", [])
     end
   end
 
@@ -377,18 +972,31 @@ defmodule Realtime.Tenants.SchemaTest do
 
     test "is still a member of supabase_realtime_admin", %{conn_postgres: conn_postgres} do
       assert %Postgrex.Result{rows: [[true]]} =
-               Postgrex.query!(conn_postgres, "SELECT pg_has_role('postgres', 'supabase_realtime_admin', 'MEMBER')", [])
+               Postgrex.query!(
+                 conn_postgres,
+                 "SELECT pg_has_role('postgres', 'supabase_realtime_admin', 'MEMBER')",
+                 []
+               )
     end
 
     test "has CREATE on schema realtime", %{conn_postgres: conn_postgres} do
       assert %Postgrex.Result{rows: [[true]]} =
-               Postgrex.query!(conn_postgres, "SELECT has_schema_privilege('postgres', 'realtime', 'CREATE')", [])
+               Postgrex.query!(
+                 conn_postgres,
+                 "SELECT has_schema_privilege('postgres', 'realtime', 'CREATE')",
+                 []
+               )
     end
 
     test "can create and drop objects in the realtime schema", %{conn_postgres: conn_postgres} do
       assert_allowed(conn_postgres, "CREATE TABLE realtime.test (id int)")
       assert_allowed(conn_postgres, "DROP TABLE realtime.test")
-      assert_allowed(conn_postgres, "CREATE FUNCTION realtime.test() RETURNS void LANGUAGE sql AS 'SELECT 1'")
+
+      assert_allowed(
+        conn_postgres,
+        "CREATE FUNCTION realtime.test() RETURNS void LANGUAGE sql AS 'SELECT 1'"
+      )
+
       assert_allowed(conn_postgres, "DROP FUNCTION realtime.test()")
     end
 
@@ -407,13 +1015,48 @@ defmodule Realtime.Tenants.SchemaTest do
       end
     end
 
-    test "can assume supabase_realtime_admin to tamper with its objects", %{conn_postgres: conn_postgres} do
+    test "can assume supabase_realtime_admin to tamper with its objects", %{
+      conn_postgres: conn_postgres
+    } do
       Postgrex.transaction(conn_postgres, fn conn ->
         Postgrex.query!(conn, "SET ROLE supabase_realtime_admin", [])
         assert_allowed(conn, "DROP TABLE realtime.messages CASCADE")
         Postgrex.rollback(conn, :rollback)
       end)
     end
+  end
+
+  defp in_rollback(conn, fun) do
+    assert {:error, :rollback} =
+             Postgrex.transaction(conn, fn conn ->
+               fun.(conn)
+               Postgrex.rollback(conn, :rollback)
+             end)
+  end
+
+  defp as_role(conn, role, claims, fun) when role in ["anon", "authenticated", "postgres"] do
+    Postgrex.query!(conn, "SET LOCAL ROLE #{role}", [])
+
+    Postgrex.query!(
+      conn,
+      "SELECT set_config('request.jwt.claims', $1, true), set_config('request.jwt.claim.role', $2, true)",
+      [Jason.encode!(claims), role]
+    )
+
+    result = fun.()
+    Postgrex.query!(conn, "RESET ROLE", [])
+    result
+  end
+
+  defp message_count(conn, event_prefix) do
+    %{rows: [[count]]} =
+      Postgrex.query!(
+        conn,
+        "SELECT count(*) FROM realtime.messages WHERE event = ANY($1::text[])",
+        [["#{event_prefix}_json", "#{event_prefix}_binary"]]
+      )
+
+    count
   end
 
   defp assert_denied(conn, query) do

--- a/test/support/containers.ex
+++ b/test/support/containers.ex
@@ -33,7 +33,7 @@ defmodule Containers do
 
     partition = System.get_env("MIX_TEST_PARTITION", "1") |> String.to_integer()
     total_partitions = System.get_env("MIX_TEST_TOTAL_PARTITIONS", "4") |> String.to_integer()
-    all_ports = 5501..9000
+    all_ports = 6500..9000
     range_size = div(Enum.count(all_ports), total_partitions)
 
     available_ports =
@@ -230,11 +230,36 @@ defmodule Containers do
         password: settings.password
       )
 
+    # Mirrors supabase/postgres migrations
     try do
       Postgrex.query!(admin_conn, "DROP PUBLICATION IF EXISTS supabase_realtime_test", [])
       Postgrex.query!(admin_conn, "DROP SCHEMA IF EXISTS realtime CASCADE", [])
       Postgrex.query!(admin_conn, "CREATE SCHEMA realtime", [])
-      Postgrex.query!(admin_conn, "GRANT USAGE ON SCHEMA realtime TO postgres, anon, authenticated, service_role", [])
+
+      Postgrex.query!(admin_conn, "GRANT USAGE ON SCHEMA realtime TO postgres", [])
+      Postgrex.query!(admin_conn, "GRANT ALL ON ALL TABLES IN SCHEMA realtime TO postgres, dashboard_user", [])
+      Postgrex.query!(admin_conn, "GRANT ALL ON ALL SEQUENCES IN SCHEMA realtime TO postgres, dashboard_user", [])
+      Postgrex.query!(admin_conn, "GRANT ALL ON ALL ROUTINES IN SCHEMA realtime TO postgres, dashboard_user", [])
+
+      Postgrex.query!(
+        admin_conn,
+        "ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin IN SCHEMA realtime GRANT ALL ON TABLES TO postgres, dashboard_user",
+        []
+      )
+
+      Postgrex.query!(
+        admin_conn,
+        "ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin IN SCHEMA realtime GRANT ALL ON SEQUENCES TO postgres, dashboard_user",
+        []
+      )
+
+      Postgrex.query!(
+        admin_conn,
+        "ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin IN SCHEMA realtime GRANT ALL ON ROUTINES TO postgres, dashboard_user",
+        []
+      )
+
+      Postgrex.query!(admin_conn, "GRANT USAGE ON SCHEMA realtime TO anon, authenticated, service_role", [])
       Postgrex.query!(admin_conn, "GRANT ALL ON SCHEMA realtime TO supabase_realtime_admin WITH GRANT OPTION", [])
     rescue
       # Retry in case of OrioleDB OTablesMetaTranche LWLock

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -34,13 +34,17 @@ requires_no_supautils_policy_grants = if has_supautils_realtime_grants, do: :req
 
 skip_orioledb = if orioledb?, do: :skip_orioledb
 
-exclude = [
-  :failing,
-  requires_pg_140006,
-  requires_supautils_policy_grants,
-  requires_no_supautils_policy_grants,
-  skip_orioledb
-]
+exclude =
+  Enum.reject(
+    [
+      :failing,
+      requires_pg_140006,
+      requires_supautils_policy_grants,
+      requires_no_supautils_policy_grants,
+      skip_orioledb
+    ],
+    &is_nil/1
+  )
 
 ExUnit.start(exclude: exclude, max_cases: max_cases, capture_log: true)
 


### PR DESCRIPTION
Mirror supabase/postgres migrations to have a very similar PROD environment for tests, which is necessary to simulate permission checks.

Also add more tests on schema_test.ex to cover edge cases and current established patterns.
