### PR TITLE
fix: log kid on bad signer error

### DIFF
--- a/lib/realtime_web/channels/auth/jwt_verification.ex
+++ b/lib/realtime_web/channels/auth/jwt_verification.ex
@@ -94,7 +94,7 @@ defmodule RealtimeWeb.JwtVerification do
     jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "RSA" and jwk["kid"] == kid end)
 
     case jwk do
-      nil -> {:error, :error_generating_signer}
+      nil -> {:error, {:error_generating_signer, kid}}
       _ -> {:ok, Joken.Signer.create(alg, jwk)}
     end
   end
@@ -104,7 +104,7 @@ defmodule RealtimeWeb.JwtVerification do
     jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "EC" and jwk["kid"] == kid end)
 
     case jwk do
-      nil -> {:error, :error_generating_signer}
+      nil -> {:error, {:error_generating_signer, kid}}
       _ -> {:ok, Joken.Signer.create(alg, jwk)}
     end
   end
@@ -114,7 +114,7 @@ defmodule RealtimeWeb.JwtVerification do
     jwk = Enum.find(keys, fn jwk -> jwk["kty"] == "OKP" and jwk["kid"] == kid end)
 
     case jwk do
-      nil -> {:error, :error_generating_signer}
+      nil -> {:error, {:error_generating_signer, kid}}
       _ -> {:ok, Joken.Signer.create(alg, jwk)}
     end
   end
@@ -131,7 +131,7 @@ defmodule RealtimeWeb.JwtVerification do
     if jwk do
       case Base.url_decode64(jwk["k"], padding: false) do
         {:ok, secret} -> {:ok, Joken.Signer.create(alg, secret)}
-        _ -> {:error, :error_generating_signer}
+        _ -> {:error, {:error_generating_signer, kid}}
       end
     else
       # If there's no JWK, and HS* is being used, instead of erroring, try

--- a/lib/realtime_web/channels/auth/jwt_verification.ex
+++ b/lib/realtime_web/channels/auth/jwt_verification.ex
@@ -42,7 +42,10 @@ defmodule RealtimeWeb.JwtVerification do
   @doc """
   Verify JWT token and validate claims
   """
-  @spec verify(binary(), binary(), binary() | nil) :: {:ok, map()} | {:error, any()}
+  @spec verify(binary(), binary(), binary() | nil) ::
+          {:ok, map()}
+          | {:error, Joken.error_reason()}
+          | {:error, {:error_generating_signer, binary()}}
   def verify(token, jwt_secret, jwt_jwks) when is_binary(token) do
     with {:ok, _claims} <- check_claims_format(token),
          {:ok, header} <- check_header_format(token),

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -428,6 +428,13 @@ defmodule RealtimeWeb.RealtimeChannel do
       {:error, :expired_token, msg} ->
         shutdown_response(socket, msg)
 
+      {:error, {:error_generating_signer, kid}} ->
+        msg =
+          "Failed to generate JWT signer for key ID (kid) #{inspect(kid)}, check your JWT secret or JWKS configuration"
+
+        log_error(socket, "JwtSignerError", msg)
+        shutdown_response(socket, :error_generating_signer)
+
       {:error, error} ->
         shutdown_response(socket, Realtime.Logs.to_log(error))
     end
@@ -604,6 +611,13 @@ defmodule RealtimeWeb.RealtimeChannel do
 
       {:error, :rpc_error, reason} ->
         shutdown_response(socket, "RPC call error: " <> inspect(reason))
+
+      {:error, {:error_generating_signer, kid}} ->
+        msg =
+          "Failed to generate JWT signer for key ID (kid) #{inspect(kid)}, check your JWT secret or JWKS configuration"
+
+        log_error(socket, "JwtSignerError", msg)
+        shutdown_response(socket, msg)
 
       {:error, error} ->
         shutdown_response(socket, inspect(error))

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -265,6 +265,13 @@ defmodule RealtimeWeb.RealtimeChannel do
       {:error, :invalid_replay_channel} ->
         log_error(socket, "UnableToReplayMessages", "Replay is not allowed for public channels")
 
+      {:error, {:error_generating_signer, kid}} ->
+        log_error(
+          socket,
+          "JwtSignerError",
+          "Failed to generate JWT signer for key ID (kid) #{inspect(kid)}, check your JWT secret or JWKS configuration"
+        )
+
       {:error, :error_generating_signer} ->
         log_error(
           socket,

--- a/lib/realtime_web/plugs/auth_tenant.ex
+++ b/lib/realtime_web/plugs/auth_tenant.ex
@@ -10,6 +10,8 @@ defmodule RealtimeWeb.AuthTenant do
 
   alias RealtimeWeb.ChannelsAuthorization
 
+  require Logger
+
   def init(opts), do: opts
 
   def call(%{assigns: %{tenant: tenant}} = conn, _opts) do
@@ -25,7 +27,15 @@ defmodule RealtimeWeb.AuthTenant do
       |> assign(:role, claims["role"])
       |> assign(:sub, claims["sub"])
     else
-      _error -> unauthorized(conn)
+      {:error, {:error_generating_signer, kid}} ->
+        Logger.error(
+          "JwtSignerError: Failed to generate JWT signer for key ID (kid) #{inspect(kid)}, check your JWT secret or JWKS configuration"
+        )
+
+        unauthorized(conn)
+
+      _error ->
+        unauthorized(conn)
     end
   end
 

--- a/test/realtime_web/channels/auth/jwt_verification_test.exs
+++ b/test/realtime_web/channels/auth/jwt_verification_test.exs
@@ -445,7 +445,7 @@ defmodule RealtimeWeb.JwtVerificationTest do
       jwt_secret = "secret"
       jwks = %{"keys" => [%{"kty" => "RSA", "kid" => "some_other_kid"}]}
 
-      assert {:error, :error_generating_signer} = JwtVerification.verify(token, jwt_secret, jwks)
+      assert {:error, {:error_generating_signer, "key-id-1"}} = JwtVerification.verify(token, jwt_secret, jwks)
     end
 
     test "returns error when no matching JWK is found for EC algorithm" do
@@ -456,7 +456,7 @@ defmodule RealtimeWeb.JwtVerificationTest do
       jwt_secret = "secret"
       jwks = %{"keys" => [%{"kty" => "EC", "kid" => "some_other_kid"}]}
 
-      assert {:error, :error_generating_signer} = JwtVerification.verify(token, jwt_secret, jwks)
+      assert {:error, {:error_generating_signer, "key-id-1"}} = JwtVerification.verify(token, jwt_secret, jwks)
     end
 
     test "returns error when no matching JWK is found for OKP algorithm" do
@@ -467,7 +467,17 @@ defmodule RealtimeWeb.JwtVerificationTest do
       jwt_secret = "secret"
       jwks = %{"keys" => [%{"kty" => "OKP", "kid" => "some_other_kid"}]}
 
-      assert {:error, :error_generating_signer} = JwtVerification.verify(token, jwt_secret, jwks)
+      assert {:error, {:error_generating_signer, "key-id-1"}} = JwtVerification.verify(token, jwt_secret, jwks)
+    end
+
+    test "returns error without kid when the header has no kid" do
+      header = Base.url_encode64(Jason.encode!(%{"alg" => "RS256", "typ" => "JWT"}), padding: false)
+      claims = Base.url_encode64(Jason.encode!(%{"exp" => 9_999_999_999}), padding: false)
+      token = "#{header}.#{claims}.signature"
+
+      jwks = %{"keys" => [%{"kty" => "RSA", "kid" => "some_kid"}]}
+
+      assert {:error, :error_generating_signer} = JwtVerification.verify(token, "secret", jwks)
     end
 
     test "using Ed25519 JWK" do

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -874,6 +874,28 @@ defmodule RealtimeWeb.RealtimeChannelTest do
   end
 
   describe "access_token" do
+    # RS256 token with header kid "key-id-1"
+    @rsa_token "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImtleS1pZC0xIn0.eyJpYXQiOjE3MTIwNDc1NjUsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwic3ViIjoidXNlci1pZCIsImV4cCI6MTcxMjA1MTE2NX0.zUeoZrWK1efAc4q9y978_9qkhdXktdjf5H8O9Rw0SHcPaXW8OBcuNR2huRrgORvqFx6_sHn6nCJaWkZGzO-f8wskMD7Z4INq2JUypr6nASie3Qu2lLyeY3WTInaXNAKH-oqlfTLRskbz8zkIxOj2bBJiN9ceQLkJU-c92ndiuiG5D1jyQrGsvRdFem_cemp0yOoEaC0XWdjeV6C_UD-34GIyv3o8H4HZg1GcCiyNnAfDmLAcTOQPmqkwsRDQb-pm5O3HwpQt9WHOB6i1vzf-nmIGyCRA7STPdALK16-aiAyT4SJRxM5WN3iK8yitH7g4JETb9WocBbwIM_zfNnUI5w"
+
+    test "shuts down with JwtSignerError when refresh token kid has no matching JWK", %{tenant: tenant} do
+      jwks = %{"keys" => [%{"kty" => "RSA", "kid" => "some_other_kid"}]}
+      {:ok, tenant} = Realtime.Api.update_tenant_by_external_id(tenant.external_id, %{jwt_jwks: jwks})
+      Realtime.Tenants.Cache.update_cache(tenant)
+
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{"log_level" => "warning"}, conn_opts(tenant, jwt))
+      socket = subscribe_and_join!(socket, "realtime:test", %{})
+
+      log =
+        capture_log(fn ->
+          push(socket, "access_token", %{"access_token" => @rsa_token})
+          assert_process_down(socket.channel_pid)
+        end)
+
+      assert log =~ "JwtSignerError"
+      assert log =~ "key-id-1"
+    end
+
     @tag policies: [:authenticated_all_topic_read]
     test "new valid access_token", %{tenant: tenant} do
       jwt = Generators.generate_jwt_token(tenant)

--- a/test/realtime_web/plugs/auth_tenant_test.exs
+++ b/test/realtime_web/plugs/auth_tenant_test.exs
@@ -2,6 +2,7 @@ defmodule RealtimeWeb.AuthTenantTest do
   use RealtimeWeb.ConnCase, async: true
 
   import Plug.Conn
+  import ExUnit.CaptureLog
 
   alias RealtimeWeb.AuthTenant
 
@@ -98,6 +99,31 @@ defmodule RealtimeWeb.AuthTenantTest do
       assert conn.assigns.role == "test"
       assert %{"exp" => exp, "iat" => iat, "role" => "test"} = conn.assigns.claims
       assert is_integer(exp) and is_integer(iat)
+    end
+  end
+
+  describe "with JWKS that does not match the token kid" do
+    # RS256 token with header kid "key-id-1"
+    @rsa_token "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImtleS1pZC0xIn0.eyJpYXQiOjE3MTIwNDc1NjUsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwic3ViIjoidXNlci1pZCIsImV4cCI6MTcxMjA1MTE2NX0.zUeoZrWK1efAc4q9y978_9qkhdXktdjf5H8O9Rw0SHcPaXW8OBcuNR2huRrgORvqFx6_sHn6nCJaWkZGzO-f8wskMD7Z4INq2JUypr6nASie3Qu2lLyeY3WTInaXNAKH-oqlfTLRskbz8zkIxOj2bBJiN9ceQLkJU-c92ndiuiG5D1jyQrGsvRdFem_cemp0yOoEaC0XWdjeV6C_UD-34GIyv3o8H4HZg1GcCiyNnAfDmLAcTOQPmqkwsRDQb-pm5O3HwpQt9WHOB6i1vzf-nmIGyCRA7STPdALK16-aiAyT4SJRxM5WN3iK8yitH7g4JETb9WocBbwIM_zfNnUI5w"
+
+    setup %{conn: conn} do
+      jwks = %{"keys" => [%{"kty" => "RSA", "kid" => "some_other_kid"}]}
+      tenant = tenant_fixture(%{jwt_jwks: jwks})
+      %{conn: assign(conn, :tenant, tenant)}
+    end
+
+    test "logs JwtSignerError with the kid and returns 401", %{conn: conn} do
+      conn = put_req_header(conn, "authorization", "Bearer " <> @rsa_token)
+
+      log =
+        capture_log(fn ->
+          conn = AuthTenant.call(conn, %{})
+          assert conn.status == 401
+          assert conn.halted
+        end)
+
+      assert log =~ "JwtSignerError"
+      assert log =~ "key-id-1"
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

To improve the capacity for a user to debug the issues they have with badly created tokens we will log in the error message the kid used for a given token
