### PR TITLE
fix: rare DOWN Census race condition

### DIFF
--- a/forum/README.md
+++ b/forum/README.md
@@ -50,6 +50,8 @@ iex> Forum.Census.member_counts(:users)
 
 When to use Census: you want counts, totals, presence-of-anyone signals, dashboards. You don't need millisecond precision and you don't want to fan out per-event traffic.
 
+Peers find each other with a discovery handshake and monitor each other's Scope process. Counts are only recorded from a **registered** peer. This matters because the count broadcast and process monitoring can travel over independent transports (e.g. a `:gen_rpc`-backed `:message_module` for broadcasts while monitoring rides Erlang distribution), so a peer's `:sync` and its `:DOWN` are unordered: a `:sync` that arrives after the `:DOWN` was already handled would otherwise re-insert a ghost entry that nothing would ever clean up. Dropping counts from unregistered peers closes that window; to keep registration self-healing (so a dropped or reordered discovery doesn't strand a peer's counts permanently), every node re-announces itself to the cluster every `discover_interval_in_ms` (default 60 s), well above the count broadcast interval since it only heals the rare missed-registration case.
+
 ---
 
 ## `Forum.Muster`: group-routed fan-out broadcast

--- a/forum/lib/forum/census.ex
+++ b/forum/lib/forum/census.ex
@@ -4,7 +4,9 @@ defmodule Forum.Census do
 
   @type group :: Forum.group()
   @type start_option ::
-          {:partitions, pos_integer()} | {:broadcast_interval_in_ms, non_neg_integer()}
+          {:partitions, pos_integer()}
+          | {:broadcast_interval_in_ms, non_neg_integer()}
+          | {:discover_interval_in_ms, non_neg_integer()}
 
   @doc "Returns a supervisor child specification for a Forum scope"
   def child_spec([scope]) when is_atom(scope), do: child_spec([scope, []])
@@ -25,12 +27,14 @@ defmodule Forum.Census do
 
   * `:partitions` - number of partitions to use (default: number of schedulers online)
   * `:broadcast_interval_in_ms`: - interval in milliseconds to broadcast membership counts to other nodes (default: 5000 ms)
+  * `:discover_interval_in_ms`: - interval in milliseconds to re-announce ourselves to the cluster so peers we lost track of re-register us (default: 60000 ms)
   * `:message_module` - module implementing `Forum.Adapter` behaviour (default: `Forum.Adapter.ErlDist`)
   """
   @spec start_link(atom, [start_option]) :: Supervisor.on_start()
   def start_link(scope, opts \\ []) when is_atom(scope) do
     {partitions, opts} = Keyword.pop(opts, :partitions, System.schedulers_online())
     broadcast_interval_in_ms = Keyword.get(opts, :broadcast_interval_in_ms)
+    discover_interval_in_ms = Keyword.get(opts, :discover_interval_in_ms)
 
     if not (is_integer(partitions) and partitions >= 1) do
       raise ArgumentError,
@@ -41,6 +45,12 @@ defmodule Forum.Census do
          not (is_integer(broadcast_interval_in_ms) and broadcast_interval_in_ms > 0) do
       raise ArgumentError,
             "expected :broadcast_interval_in_ms to be a positive integer, got: #{inspect(broadcast_interval_in_ms)}"
+    end
+
+    if discover_interval_in_ms != nil and
+         not (is_integer(discover_interval_in_ms) and discover_interval_in_ms > 0) do
+      raise ArgumentError,
+            "expected :discover_interval_in_ms to be a positive integer, got: #{inspect(discover_interval_in_ms)}"
     end
 
     Forum.Supervisor.start_link(Forum.Census.Scope, scope, partitions, opts)

--- a/forum/lib/forum/census/scope.ex
+++ b/forum/lib/forum/census/scope.ex
@@ -7,6 +7,7 @@ defmodule Forum.Census.Scope do
   alias Forum.Census
 
   @default_broadcast_interval 5_000
+  @default_discover_interval 60_000
 
   @spec member_counts(atom) :: %{Forum.group() => non_neg_integer}
   def member_counts(scope) do
@@ -57,6 +58,7 @@ defmodule Forum.Census.Scope do
             scope: atom,
             message_module: module,
             broadcast_interval: non_neg_integer,
+            discover_interval: non_neg_integer,
             peer_counts_table: :ets.tid(),
             peers: %{pid => reference}
           }
@@ -64,6 +66,7 @@ defmodule Forum.Census.Scope do
       :scope,
       :message_module,
       :broadcast_interval,
+      :discover_interval,
       :peer_counts_table,
       peers: %{}
     ]
@@ -82,6 +85,9 @@ defmodule Forum.Census.Scope do
     broadcast_interval =
       Keyword.get(opts, :broadcast_interval_in_ms, @default_broadcast_interval)
 
+    discover_interval =
+      Keyword.get(opts, :discover_interval_in_ms, @default_discover_interval)
+
     message_module = Keyword.get(opts, :message_module, Forum.Adapter.ErlDist)
 
     Logger.info("Forum[#{node()}|#{scope}] Starting")
@@ -93,6 +99,7 @@ defmodule Forum.Census.Scope do
        scope: scope,
        message_module: message_module,
        broadcast_interval: broadcast_interval,
+       discover_interval: discover_interval,
        peer_counts_table: peer_counts_table
      }, {:continue, :discover}}
   end
@@ -102,6 +109,7 @@ defmodule Forum.Census.Scope do
   def handle_continue(:discover, state) do
     state.message_module.broadcast(state.scope, {:discover, self()})
     Process.send_after(self(), :broadcast_counts, state.broadcast_interval)
+    Process.send_after(self(), :broadcast_discover, state.discover_interval)
     {:noreply, state}
   end
 
@@ -110,6 +118,7 @@ defmodule Forum.Census.Scope do
           {:discover, pid}
           | {:sync, pid, member_counts}
           | :broadcast_counts
+          | :broadcast_discover
           | {:nodeup, node}
           | {:nodedown, node}
           | {:DOWN, reference, :process, pid, term},
@@ -146,9 +155,15 @@ defmodule Forum.Census.Scope do
     end
   end
 
-  # A remote peer has sent us its local member counts
   def handle_info({:sync, peer, member_counts}, state) do
-    :ets.insert(state.peer_counts_table, {node(peer), member_counts})
+    if Map.has_key?(state.peers, peer) do
+      :ets.insert(state.peer_counts_table, {node(peer), member_counts})
+    else
+      Logger.debug(
+        "Forum[#{node()}|#{state.scope}] Ignoring counts from unregistered peer #{inspect(peer)} on node #{node(peer)}"
+      )
+    end
+
     {:noreply, state}
   end
 
@@ -166,6 +181,16 @@ defmodule Forum.Census.Scope do
     )
 
     Process.send_after(self(), :broadcast_counts, state.broadcast_interval)
+    {:noreply, state}
+  end
+
+  # Periodically re-announce ourselves to the whole cluster so that any peer we
+  # lost track of (e.g. a discover that raced a `:DOWN`, or was dropped by the
+  # transport) re-registers us. Kept much less frequent than `:broadcast_counts`
+  # since it only needs to heal the rare case where registration was missed.
+  def handle_info(:broadcast_discover, state) do
+    state.message_module.broadcast(state.scope, {:discover, self()})
+    Process.send_after(self(), :broadcast_discover, state.discover_interval)
     {:noreply, state}
   end
 

--- a/forum/test/forum/census_test.exs
+++ b/forum/test/forum/census_test.exs
@@ -63,6 +63,26 @@ defmodule Forum.CensusTest do
                      Census.start_link(scope, broadcast_interval_in_ms: :invalid)
                    end
     end
+
+    test "raises on invalid discover_interval_in_ms", %{scope: scope} do
+      assert_raise ArgumentError,
+                   ~r/expected :discover_interval_in_ms to be a positive integer/,
+                   fn ->
+                     Census.start_link(scope, discover_interval_in_ms: 0)
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :discover_interval_in_ms to be a positive integer/,
+                   fn ->
+                     Census.start_link(scope, discover_interval_in_ms: -1)
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :discover_interval_in_ms to be a positive integer/,
+                   fn ->
+                     Census.start_link(scope, discover_interval_in_ms: :invalid)
+                   end
+    end
   end
 
   describe "join/3 and leave/3" do
@@ -341,6 +361,28 @@ defmodule Forum.CensusTest do
 
       assert partition1 == partition2
       assert partition2 == partition3
+    end
+  end
+
+  describe "sync gating" do
+    setup %{scope: scope} do
+      start_supervised!(spec(scope, partitions: 2))
+      :ok
+    end
+
+    test "ignores counts from a peer it has not registered", %{scope: scope} do
+      scope_proc = Process.whereis(Forum.Supervisor.name(scope))
+      assert is_pid(scope_proc)
+
+      # Simulate a `:sync` racing ahead of (or arriving after) registration,
+      # e.g. a late broadcast after the peer's `:DOWN` was already handled.
+      fake_peer = spawn(fn -> Process.sleep(:infinity) end)
+      send(scope_proc, {:sync, fake_peer, %{group1: 5}})
+
+      # Flush the mailbox: this call is handled after the :sync above.
+      _ = :sys.get_state(scope_proc)
+
+      assert Forum.Census.Scope.member_counts(scope) == %{}
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fix a potential race condition which would leave data from a node that is long gone.

* Ignore `:sync` from peers we don't know
* Discover from time to time to avoid any races on getting `DOWN`
