### PR TITLE
chore: always set mimic from context

### DIFF
--- a/forum/test/forum/muster_test.exs
+++ b/forum/test/forum/muster_test.exs
@@ -11,7 +11,7 @@ defmodule Forum.MusterTest do
 
   @fake_node :fake@nowhere
 
-  setup :set_mimic_global
+  setup :set_mimic_from_context
 
   setup ctx do
     scope = :"muster_test_#{System.unique_integer([:positive])}"

--- a/test/integration/region_aware_migrations_test.exs
+++ b/test/integration/region_aware_migrations_test.exs
@@ -2,6 +2,8 @@ defmodule Realtime.Integration.RegionAwareMigrationsTest do
   use Realtime.DataCase, async: false
   use Mimic
 
+  setup :set_mimic_from_context
+
   alias Containers
   alias Realtime.Tenants
   alias Realtime.Tenants.Migrations

--- a/test/integration/region_aware_routing_test.exs
+++ b/test/integration/region_aware_routing_test.exs
@@ -2,6 +2,8 @@ defmodule Realtime.Integration.RegionAwareRoutingTest do
   use Realtime.DataCase, async: false
   use Mimic
 
+  setup :set_mimic_from_context
+
   import Ecto.Query
 
   alias Realtime.Api

--- a/test/realtime/api_test.exs
+++ b/test/realtime/api_test.exs
@@ -3,6 +3,8 @@ defmodule Realtime.ApiTest do
 
   use Mimic
 
+  setup :set_mimic_from_context
+
   alias Realtime.Api
   alias Realtime.Api.Extensions, as: ApiExtensions
   alias Realtime.Api.FeatureFlag

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -2,6 +2,8 @@ defmodule Realtime.DatabaseTest do
   use Realtime.DataCase, async: true
   use Mimic
 
+  setup :set_mimic_from_context
+
   import ExUnit.CaptureLog
 
   alias Realtime.Database

--- a/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
+++ b/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
@@ -5,7 +5,7 @@ defmodule Realtime.Extensions.CdcRlsTest do
 
   import ExUnit.CaptureLog
 
-  setup :set_mimic_global
+  setup :set_mimic_from_context
 
   alias Extensions.PostgresCdcRls
   alias Extensions.PostgresCdcRls.ReplicationPoller

--- a/test/realtime/extensions/cdc_rls/replication_poller_test.exs
+++ b/test/realtime/extensions/cdc_rls/replication_poller_test.exs
@@ -22,7 +22,7 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
   import Poller, only: [generate_record: 1]
 
-  setup :set_mimic_global
+  setup :set_mimic_from_context
 
   @change_json ~s({"table":"test","type":"INSERT","record":{"id": 34, "details": "test"},"columns":[{"name": "id", "type": "int4"}, {"name": "details", "type": "text"}],"errors":null,"schema":"public","commit_timestamp":"2025-10-13T07:50:28.066Z"})
 

--- a/test/realtime/extensions/cdc_rls/subscription_manager_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscription_manager_test.exs
@@ -3,6 +3,8 @@ defmodule Realtime.Extensions.CdcRls.SubscriptionManagerTest do
   use Realtime.DataCase, async: false
   use Mimic
 
+  setup :set_mimic_from_context
+
   alias Extensions.PostgresCdcRls
   alias Extensions.PostgresCdcRls.SubscriptionManager
   alias Extensions.PostgresCdcRls.Subscriptions
@@ -309,8 +311,6 @@ defmodule Realtime.Extensions.CdcRls.SubscriptionManagerTest do
   end
 
   describe "message handling" do
-    setup :set_mimic_global
-
     test "re-subscribes all subscribers when publication oids change", %{pid: pid, args: args} do
       # Force state to have different oids so the new_oids branch is triggered when
       # fetch_publication_tables returns the real oids from the database
@@ -402,8 +402,6 @@ defmodule Realtime.Extensions.CdcRls.SubscriptionManagerTest do
   end
 
   describe "error handling" do
-    setup :set_mimic_global
-
     test "stops cleanly when database connection fails", %{args: args} do
       stub(Database, :connect_db, fn _settings -> {:error, :econnrefused} end)
 
@@ -558,8 +556,6 @@ defmodule Realtime.Extensions.CdcRls.SubscriptionManagerTest do
   end
 
   describe "not_alive_pids_dist/1" do
-    setup :set_mimic_global
-
     test "handles remote node RPC error gracefully" do
       remote_node = :some_remote@node
 

--- a/test/realtime/feature_flags_test.exs
+++ b/test/realtime/feature_flags_test.exs
@@ -2,6 +2,8 @@ defmodule Realtime.FeatureFlagsTest do
   use Realtime.DataCase, async: false
   use Mimic
 
+  setup :set_mimic_from_context
+
   alias Realtime.Api
   alias Realtime.FeatureFlags
   alias Realtime.FeatureFlags.Cache

--- a/test/realtime/gen_rpc_pub_sub/worker_test.exs
+++ b/test/realtime/gen_rpc_pub_sub/worker_test.exs
@@ -6,6 +6,8 @@ defmodule Realtime.GenRpcPubSub.WorkerTest do
 
   use Mimic
 
+  setup :set_mimic_from_context
+
   @topic "test_topic"
 
   setup do

--- a/test/realtime/nodes_test.exs
+++ b/test/realtime/nodes_test.exs
@@ -2,6 +2,9 @@ defmodule Realtime.NodesTest do
   # async: false due to use of Clustered and tweaking Application env
   use Realtime.DataCase, async: false
   use Mimic
+
+  setup :set_mimic_from_context
+
   alias Realtime.Nodes
   alias Realtime.Tenants
 

--- a/test/realtime/tenants/authorization_remote_test.exs
+++ b/test/realtime/tenants/authorization_remote_test.exs
@@ -3,6 +3,8 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
   use RealtimeWeb.ConnCase, async: false
   use Mimic
 
+  setup :set_mimic_from_context
+
   import ExUnit.CaptureLog
 
   alias Realtime.Database

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -2,6 +2,8 @@ defmodule Realtime.Tenants.AuthorizationTest do
   use RealtimeWeb.ConnCase, async: true
   use Mimic
 
+  setup :set_mimic_from_context
+
   import ExUnit.CaptureLog
 
   alias Realtime.Api.Message

--- a/test/realtime/tenants/batch_broadcast_test.exs
+++ b/test/realtime/tenants/batch_broadcast_test.exs
@@ -2,6 +2,8 @@ defmodule Realtime.Tenants.BatchBroadcastTest do
   use RealtimeWeb.ConnCase, async: true
   use Mimic
 
+  setup :set_mimic_from_context
+
   alias Realtime.Database
   alias Realtime.GenCounter
   alias Realtime.RateCounter

--- a/test/realtime/tenants/connect_test.exs
+++ b/test/realtime/tenants/connect_test.exs
@@ -3,7 +3,7 @@ defmodule Realtime.Tenants.ConnectTest do
   use Realtime.DataCase, async: false
   use Mimic
 
-  setup :set_mimic_global
+  setup :set_mimic_from_context
 
   import ExUnit.CaptureLog
 

--- a/test/realtime/tenants/migrations_test.exs
+++ b/test/realtime/tenants/migrations_test.exs
@@ -3,6 +3,8 @@ defmodule Realtime.Tenants.MigrationsTest do
   use Realtime.DataCase, async: false
   use Mimic
 
+  setup :set_mimic_from_context
+
   import ExUnit.CaptureLog
 
   alias Realtime.Database
@@ -16,8 +18,6 @@ defmodule Realtime.Tenants.MigrationsTest do
   end
 
   describe "run_migrations/1" do
-    setup :set_mimic_global
-
     test "migrations for a given tenant only run once" do
       tenant = Containers.checkout_tenant()
 
@@ -198,8 +198,6 @@ defmodule Realtime.Tenants.MigrationsTest do
   end
 
   describe "telemetry" do
-    setup :set_mimic_global
-
     setup do
       events = [
         [:realtime, :tenants, :migrations, :start],

--- a/test/realtime/tenants/rebalancer_test.exs
+++ b/test/realtime/tenants/rebalancer_test.exs
@@ -6,6 +6,8 @@ defmodule Realtime.Tenants.RebalancerTest do
 
   use Mimic
 
+  setup :set_mimic_from_context
+
   setup do
     tenant = Containers.checkout_tenant(run_migrations: true)
     # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues

--- a/test/realtime/tenants/replication_connection/watchdog_test.exs
+++ b/test/realtime/tenants/replication_connection/watchdog_test.exs
@@ -3,6 +3,8 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
 
   use Mimic
 
+  setup :set_mimic_from_context
+
   import ExUnit.CaptureLog
 
   alias Realtime.Database

--- a/test/realtime/tenants/single_broadcast_test.exs
+++ b/test/realtime/tenants/single_broadcast_test.exs
@@ -2,6 +2,8 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
   use RealtimeWeb.ConnCase, async: true
   use Mimic
 
+  setup :set_mimic_from_context
+
   alias Realtime.Database
   alias Realtime.GenCounter
   alias Realtime.RateCounter

--- a/test/realtime_web/channels/auth/channels_authorization_test.exs
+++ b/test/realtime_web/channels/auth/channels_authorization_test.exs
@@ -3,6 +3,8 @@ defmodule RealtimeWeb.ChannelsAuthorizationTest do
 
   use Mimic
 
+  setup :set_mimic_from_context
+
   import Generators
 
   alias RealtimeWeb.ChannelsAuthorization

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -5,6 +5,8 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
 
   use Mimic
 
+  setup :set_mimic_from_context
+
   import Generators
   import ExUnit.CaptureLog
 

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -2,6 +2,8 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
   use Realtime.DataCase, async: true
   use Mimic
 
+  setup :set_mimic_from_context
+
   import ExUnit.CaptureLog
   import Generators
 

--- a/test/realtime_web/channels/realtime_channel_replication_ready_test.exs
+++ b/test/realtime_web/channels/realtime_channel_replication_ready_test.exs
@@ -6,7 +6,7 @@ defmodule RealtimeWeb.RealtimeChannelReplicationReadyTest do
   alias Realtime.Tenants.Connect
   alias RealtimeWeb.UserSocket
 
-  setup :set_mimic_global
+  setup :set_mimic_from_context
 
   setup do
     tenant = Containers.checkout_tenant(run_migrations: true)

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -2,6 +2,8 @@ defmodule RealtimeWeb.RealtimeChannelTest do
   use RealtimeWeb.ChannelCase, async: true
   use Mimic
 
+  setup :set_mimic_from_context
+
   import ExUnit.CaptureLog
 
   alias Phoenix.Channel.Server

--- a/test/realtime_web/channels/tenant_rate_limiters_test.exs
+++ b/test/realtime_web/channels/tenant_rate_limiters_test.exs
@@ -2,6 +2,9 @@ defmodule RealtimeWeb.TenantRateLimitersTest do
   use Realtime.DataCase, async: true
 
   use Mimic
+
+  setup :set_mimic_from_context
+
   alias RealtimeWeb.TenantRateLimiters
   alias Realtime.Api.Tenant
 

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -2,6 +2,8 @@ defmodule RealtimeWeb.BroadcastControllerTest do
   use RealtimeWeb.ConnCase, async: true
   use Mimic
 
+  setup :set_mimic_from_context
+
   alias Realtime.Crypto
   alias Realtime.GenCounter
   alias Realtime.RateCounter

--- a/test/realtime_web/controllers/broadcast_single_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_single_controller_test.exs
@@ -2,6 +2,8 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
   use RealtimeWeb.ConnCase, async: true
   use Mimic
 
+  setup :set_mimic_from_context
+
   alias Realtime.Crypto
   alias Realtime.GenCounter
   alias Realtime.RateCounter

--- a/test/realtime_web/controllers/live_dasboard_test.exs
+++ b/test/realtime_web/controllers/live_dasboard_test.exs
@@ -3,6 +3,8 @@ defmodule RealtimeWeb.LiveDashboardTest do
   import Generators
   import Mimic
 
+  setup :set_mimic_from_context
+
   describe "live_dashboard with basic_auth" do
     setup do
       user = random_string()

--- a/test/realtime_web/controllers/metrics_controller_test.exs
+++ b/test/realtime_web/controllers/metrics_controller_test.exs
@@ -6,6 +6,8 @@ defmodule RealtimeWeb.MetricsControllerTest do
   import ExUnit.CaptureLog
   use Mimic
 
+  setup :set_mimic_from_context
+
   # {help_metric, value_metric, tags}
   # help_metric: base name checked against "# HELP <name>" in the response
   # value_metric: metric name passed to MetricsHelper.search (distributions use _count suffix); nil = skip value check

--- a/test/realtime_web/dashboard/tenant_info_test.exs
+++ b/test/realtime_web/dashboard/tenant_info_test.exs
@@ -8,7 +8,7 @@ defmodule RealtimeWeb.Dashboard.TenantInfoTest do
   alias Realtime.Tenants.Connect
   alias Realtime.UsersCounter
 
-  setup :set_mimic_global
+  setup :set_mimic_from_context
 
   setup do
     Application.put_env(:realtime, :dashboard_auth, :basic_auth)


### PR DESCRIPTION
Consistently set mimic's mode

if async=false it will be global, private otherwise
