### PR TITLE
feat: collect fanout broadcast metric

### DIFF
--- a/lib/realtime/gen_rpc/pub_sub.ex
+++ b/lib/realtime/gen_rpc/pub_sub.ex
@@ -102,16 +102,20 @@ defmodule Realtime.GenRpcPubSub.Worker do
   @impl true
   # Forward to local
   def handle_info({:ftl, topic, message, dispatcher}, {pubsub, worker}) do
+    maybe_measure_broadcast_fanout(message)
     Phoenix.PubSub.local_broadcast(pubsub, topic, message, dispatcher)
     {:noreply, {pubsub, worker}}
   end
 
   # Forward to the rest of the region
   def handle_info({:ftr, topic, message, dispatcher}, {pubsub, worker}) do
+    maybe_measure_broadcast_fanout(message)
+
     # Forward to local first
     Phoenix.PubSub.local_broadcast(pubsub, topic, message, dispatcher)
 
-    # Then broadcast to the rest of my region
+    # Then broadcast to the rest of my region, keeping the message intact so the
+    # downstream :ftl handlers can attribute the fan-out too.
     my_region = Application.get_env(:realtime, :region)
     other_nodes = for node <- Realtime.Nodes.region_nodes(my_region), node != node(), do: node
 
@@ -124,4 +128,17 @@ defmodule Realtime.GenRpcPubSub.Worker do
 
   @impl true
   def handle_info(_, pubsub), do: {:noreply, pubsub}
+
+  @fanout_event [:realtime, :broadcast, :fanout, :node_delivery]
+
+  # A broadcast forwarded to this node: record whether the node holds any connection for the
+  # tenant, so aggregating hit=false tells us how many cross-cluster sends could be avoided.
+  # Only broadcast messages are tagged (see RealtimeWeb.TenantBroadcaster); everything else is a no-op.
+  defp maybe_measure_broadcast_fanout({:tb, tenant_id, _message}) do
+    count = Forum.Census.local_member_count(:users, tenant_id)
+
+    :telemetry.execute(@fanout_event, %{local_tenant_users: count}, %{tenant: tenant_id, hit: count > 0})
+  end
+
+  defp maybe_measure_broadcast_fanout(_message), do: :ok
 end

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -21,8 +21,24 @@ defmodule Realtime.PromEx.Plugins.Tenant do
       channel_events(),
       payload_size_metrics(),
       replication_metrics(),
-      subscription_metrics()
+      subscription_metrics(),
+      broadcast_fanout_metrics()
     ]
+  end
+
+  defp broadcast_fanout_metrics do
+    Event.build(
+      :realtime_tenant_broadcast_fanout_metrics,
+      [
+        counter(
+          [:realtime, :broadcast, :fanout, :node_delivery, :total],
+          event_name: [:realtime, :broadcast, :fanout, :node_delivery],
+          description:
+            "Cross-cluster broadcast deliveries to this node for the tenant, split by whether the node held a connection for the tenant. hit=false means the send could have been avoided.",
+          tags: [:tenant, :hit]
+        )
+      ]
+    )
   end
 
   defmodule PayloadSize.Buckets do

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant_global.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant_global.ex
@@ -46,8 +46,24 @@ defmodule Realtime.PromEx.Plugins.TenantGlobal do
   def event_metrics(_opts) do
     [
       channel_global_events(),
-      payload_global_size_metrics()
+      payload_global_size_metrics(),
+      broadcast_fanout_global_metrics()
     ]
+  end
+
+  defp broadcast_fanout_global_metrics do
+    Event.build(
+      :realtime_global_broadcast_fanout_metrics,
+      [
+        counter(
+          [:realtime, :broadcast, :global, :fanout, :node_delivery, :total],
+          event_name: [:realtime, :broadcast, :fanout, :node_delivery],
+          description:
+            "Cross-cluster broadcast deliveries to this node across all tenants, split by whether the node held a connection for the tenant. hit=false means the send could have been avoided.",
+          tags: [:hit]
+        )
+      ]
+    )
   end
 
   def execute_global_connection_metrics do

--- a/lib/realtime_web/channels/realtime_channel/message_dispatcher.ex
+++ b/lib/realtime_web/channels/realtime_channel/message_dispatcher.ex
@@ -27,7 +27,19 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcher do
 
   fastlane_pid is the actual socket transport pid
   """
-  @spec dispatch(list, pid, Broadcast.t() | UserBroadcast.t()) :: :ok
+  @spec dispatch(
+          list,
+          pid,
+          Broadcast.t()
+          | UserBroadcast.t()
+          | {:tb, String.t(), Broadcast.t() | UserBroadcast.t()}
+        ) :: :ok
+  # Broadcast messages are tagged with their tenant_id by RealtimeWeb.TenantBroadcaster so the
+  # receiving node can attribute the fan-out before delivery. Strip the tag here so every
+  # downstream clause (and the client) only ever sees the underlying struct.
+  def dispatch(subscribers, from, {:tb, _tenant_id, msg}),
+    do: dispatch(subscribers, from, msg)
+
   def dispatch(subscribers, from, %Broadcast{event: @presence_diff} = msg) do
     {_cache, count} =
       Enum.reduce(subscribers, {%{}, 0}, fn

--- a/lib/realtime_web/tenant_broadcaster.ex
+++ b/lib/realtime_web/tenant_broadcaster.ex
@@ -4,6 +4,7 @@ defmodule RealtimeWeb.TenantBroadcaster do
   """
 
   alias Phoenix.PubSub
+  alias RealtimeWeb.RealtimeChannel.MessageDispatcher
 
   @type message_type :: :broadcast | :presence | :postgres_changes
 
@@ -38,7 +39,7 @@ defmodule RealtimeWeb.TenantBroadcaster do
           :ok
   def pubsub_broadcast(tenant_id, topic, message, dispatcher, message_type) do
     collect_payload_size(tenant_id, message, message_type)
-    PubSub.broadcast(Realtime.PubSub, topic, message, dispatcher)
+    PubSub.broadcast(Realtime.PubSub, topic, tag_tenant(tenant_id, message, dispatcher, message_type), dispatcher)
     :ok
   end
 
@@ -53,9 +54,24 @@ defmodule RealtimeWeb.TenantBroadcaster do
           :ok
   def pubsub_broadcast_from(tenant_id, from, topic, message, dispatcher, message_type) do
     collect_payload_size(tenant_id, message, message_type)
-    PubSub.broadcast_from(Realtime.PubSub, from, topic, message, dispatcher)
+
+    PubSub.broadcast_from(
+      Realtime.PubSub,
+      from,
+      topic,
+      tag_tenant(tenant_id, message, dispatcher, message_type),
+      dispatcher
+    )
+
     :ok
   end
+
+  # Tag broadcast messages with their tenant_id so the receiving node can attribute the fan-out
+  # (see the telemetry in Realtime.GenRpcPubSub.Worker). Only tag when MessageDispatcher is the
+  # dispatcher, since it is the component that unwraps the tag before delivery
+  # Presence/postgres_changes stay untagged.
+  defp tag_tenant(tenant_id, message, MessageDispatcher, :broadcast), do: {:tb, tenant_id, message}
+  defp tag_tenant(_tenant_id, message, _dispatcher, _message_type), do: message
 
   @payload_size_event [:realtime, :tenants, :payload, :size]
 

--- a/test/realtime/gen_rpc_pub_sub/worker_test.exs
+++ b/test/realtime/gen_rpc_pub_sub/worker_test.exs
@@ -70,4 +70,62 @@ defmodule Realtime.GenRpcPubSub.WorkerTest do
       refute_receive _any
     end
   end
+
+  describe "broadcast fan-out telemetry" do
+    @fanout_event [:realtime, :broadcast, :fanout, :node_delivery]
+
+    setup do
+      %{ref: :telemetry_test.attach_event_handlers(self(), [@fanout_event])}
+    end
+
+    test "forward to local emits hit=true when the node holds a connection for the tenant",
+         %{worker: worker, ref: ref} do
+      tenant_id = "worker-hit-#{System.unique_integer([:positive])}"
+      :ok = Realtime.UsersCounter.add(self(), tenant_id)
+
+      message = {:tb, tenant_id, %Phoenix.Socket.Broadcast{topic: @topic, event: "e", payload: %{}}}
+      send(worker, Worker.forward_to_local(@topic, message, Phoenix.PubSub))
+
+      assert_receive {@fanout_event, ^ref, %{local_tenant_users: count}, %{tenant: ^tenant_id, hit: true}}
+      assert count >= 1
+      refute_receive _any
+    end
+
+    test "forward to local emits hit=false when the node holds no connection for the tenant",
+         %{worker: worker, ref: ref} do
+      tenant_id = "worker-miss-#{System.unique_integer([:positive])}"
+
+      message = {:tb, tenant_id, %Phoenix.Socket.Broadcast{topic: @topic, event: "e", payload: %{}}}
+      send(worker, Worker.forward_to_local(@topic, message, Phoenix.PubSub))
+
+      assert_receive {@fanout_event, ^ref, %{local_tenant_users: 0}, %{tenant: ^tenant_id, hit: false}}
+      refute_receive _any
+    end
+
+    test "does not emit for untagged messages", %{worker: worker, ref: ref} do
+      send(worker, Worker.forward_to_local(@topic, "untagged message", Phoenix.PubSub))
+
+      refute_receive _any
+    end
+
+    test "forward to region also measures fan-out on the receiving node", %{worker: worker, ref: ref} do
+      GenRpc
+      |> stub()
+      |> allow(self(), worker)
+
+      Nodes
+      |> stub()
+      |> allow(self(), worker)
+
+      expect(Nodes, :region_nodes, fn "us-east-1" -> [node()] end)
+
+      tenant_id = "worker-region-#{System.unique_integer([:positive])}"
+
+      message = {:tb, tenant_id, %Phoenix.Socket.Broadcast{topic: @topic, event: "e", payload: %{}}}
+      send(worker, Worker.forward_to_region(@topic, message, Phoenix.PubSub))
+
+      assert_receive {@fanout_event, ^ref, %{local_tenant_users: 0}, %{tenant: ^tenant_id, hit: false}}
+      refute_receive _any
+    end
+  end
 end

--- a/test/realtime/gen_rpc_pub_sub_test.exs
+++ b/test/realtime/gen_rpc_pub_sub_test.exs
@@ -38,6 +38,26 @@ defmodule Realtime.GenRpcPubSubTest do
                     loop.(loop)
                   end)
                 end
+
+                # Register a long-lived local member for the tenant so this node reports hit=true.
+                def add_user(tenant_id) do
+                  pid = spawn(fn -> Process.sleep(:infinity) end)
+                  :ok = Realtime.UsersCounter.add(pid, tenant_id)
+                end
+
+                # Relay the fan-out telemetry emitted on this (receiving) node back to the test process.
+                def attach_fanout(dest) do
+                  :telemetry.attach(
+                    {__MODULE__, dest},
+                    [:realtime, :broadcast, :fanout, :node_delivery],
+                    &__MODULE__.relay_fanout/4,
+                    dest
+                  )
+                end
+
+                def relay_fanout(_event, measurements, metadata, dest) do
+                  send(dest, {:fanout, node(), measurements, metadata})
+                end
               end
             end)
 
@@ -54,7 +74,7 @@ defmodule Realtime.GenRpcPubSubTest do
       :ok
     end
 
-    test "all messages are received" do
+    test "broadcasts fan out across regions and each receiving node emits fan-out telemetry" do
       # start 1 node in us-east-1 to test my region broadcasting
       # start 2 nodes in ap-southeast-2 to test other region broadcasting
 
@@ -105,6 +125,10 @@ defmodule Realtime.GenRpcPubSubTest do
       assert_receive {:ready, "ap-southeast-2"}
       assert_receive {:ready, "ap-southeast-2"}
 
+      # Relay the fan-out telemetry emitted on every receiving node back to this process.
+      for node <- Node.list(), do: :ok = :erpc.call(node, Subscriber, :attach_fanout, [self()])
+
+      # Untagged broadcast: delivered to every node, but a no-op for fan-out telemetry.
       message = %Phoenix.Socket.Broadcast{topic: @topic, event: "an event", payload: ["a", %{"b" => "c"}, 1, 23]}
       Phoenix.PubSub.broadcast(Realtime.PubSub, @topic, message)
 
@@ -114,6 +138,45 @@ defmodule Realtime.GenRpcPubSubTest do
       assert_receive {:relay, :"us_node@127.0.0.1", ^message}, 5000
       assert_receive {:relay, :"ap2_nodeX@127.0.0.1", ^message}, 1000
       assert_receive {:relay, :"ap2_nodeY@127.0.0.1", ^message}, 1000
+
+      # Untagged messages do not emit fan-out telemetry
+      refute_receive {:fanout, _, _, _}
+      refute_receive _any
+
+      # Tagged broadcast: fans out via :ftl (us_node, same region) and :ftr (ap nodes, other region),
+      # and each receiving node emits the fan-out telemetry. Register a connection on us_node so it
+      # reports hit=true while the ap nodes report hit=false.
+      tenant_id = "fanout-#{System.unique_integer([:positive])}"
+      :ok = :erpc.call(:"us_node@127.0.0.1", Subscriber, :add_user, [tenant_id])
+
+      tagged_message = %Phoenix.Socket.Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
+
+      Phoenix.PubSub.broadcast(
+        Realtime.PubSub,
+        @topic,
+        {:tb, tenant_id, tagged_message},
+        RealtimeWeb.RealtimeChannel.MessageDispatcher
+      )
+
+      # The tag is stripped before delivery: subscribers only ever see the underlying struct
+      assert_receive ^tagged_message
+      assert_receive {:relay, :"us_node@127.0.0.1", ^tagged_message}, 5000
+      assert_receive {:relay, :"ap2_nodeX@127.0.0.1", ^tagged_message}, 1000
+      assert_receive {:relay, :"ap2_nodeY@127.0.0.1", ^tagged_message}, 1000
+
+      # us_node holds a connection for the tenant (:ftl path) -> hit=true
+      assert_receive {:fanout, :"us_node@127.0.0.1", %{local_tenant_users: us_count}, %{tenant: ^tenant_id, hit: true}},
+                     5000
+
+      assert us_count >= 1
+
+      # ap nodes hold no connection for the tenant (:ftr path + its re-forwarded :ftl) -> hit=false
+      assert_receive {:fanout, :"ap2_nodeX@127.0.0.1", %{local_tenant_users: 0}, %{tenant: ^tenant_id, hit: false}},
+                     1000
+
+      assert_receive {:fanout, :"ap2_nodeY@127.0.0.1", %{local_tenant_users: 0}, %{tenant: ^tenant_id, hit: false}},
+                     1000
+
       refute_receive _any
     end
   end

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -301,6 +301,32 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
       assert metric_value("realtime_payload_size_bucket", le: "250.0") > 0
     end
 
+    test "broadcast fan-out counter increments tagged by tenant and hit", %{tenant: %{external_id: external_id}} do
+      metric = "realtime_broadcast_fanout_node_delivery_total"
+      metric_value = metric_value(metric, tenant: external_id, hit: true) || 0
+
+      :telemetry.execute([:realtime, :broadcast, :fanout, :node_delivery], %{local_tenant_users: 2}, %{
+        tenant: external_id,
+        hit: true
+      })
+
+      Process.sleep(100)
+      assert metric_value(metric, tenant: external_id, hit: true) == metric_value + 1
+    end
+
+    test "global broadcast fan-out counter increments tagged by hit only", %{tenant: %{external_id: external_id}} do
+      metric = "realtime_broadcast_global_fanout_node_delivery_total"
+      metric_value = metric_value(metric, hit: false) || 0
+
+      :telemetry.execute([:realtime, :broadcast, :fanout, :node_delivery], %{local_tenant_users: 0}, %{
+        tenant: external_id,
+        hit: false
+      })
+
+      Process.sleep(100)
+      assert metric_value(metric, hit: false) == metric_value + 1
+    end
+
     test "channel input bytes", context do
       external_id = context.tenant.external_id
 

--- a/test/realtime_web/channels/realtime_channel/message_dispatcher_test.exs
+++ b/test/realtime_web/channels/realtime_channel/message_dispatcher_test.exs
@@ -109,6 +109,64 @@ defmodule RealtimeWeb.RealtimeChannel.MessageDispatcherTest do
       refute_receive _any
     end
 
+    test "strips the {:tb, tenant_id, msg} tenant tag before dispatching to fastlane subscribers" do
+      parent = self()
+
+      subscriber_pid =
+        spawn(fn ->
+          loop = fn loop ->
+            receive do
+              msg ->
+                send(parent, {:subscriber, msg})
+                loop.(loop)
+            end
+          end
+
+          loop.(loop)
+        end)
+
+      from_pid = :erlang.list_to_pid(~c'<0.2.1>')
+
+      subscribers = [
+        {subscriber_pid,
+         {:rc_fastlane, self(), TestSerializer, "realtime:topic", :info, "tenant123", MapSet.new(), true}}
+      ]
+
+      msg = %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
+
+      # TenantBroadcaster tags broadcasts with their tenant_id; dispatch/3 must unwrap so the
+      # downstream fastlane path (and the client) only ever sees the underlying struct.
+      assert MessageDispatcher.dispatch(subscribers, from_pid, {:tb, "tenant123", msg}) == :ok
+
+      assert_receive {:encoded, %Broadcast{event: "event", payload: %{data: "test"}, topic: "realtime:topic"}}
+      assert Agent.get(TestSerializer, & &1) == 1
+
+      assert_receive {:subscriber, :update_rate_counter}
+
+      # The {:tb, ...} wrapper never reaches subscribers
+      refute_receive {:tb, _, _}
+      refute_receive _any
+    end
+
+    test "strips the {:tb, tenant_id, msg} tenant tag before dispatching to non fastlane subscribers" do
+      from_pid = :erlang.list_to_pid(~c'<0.2.1>')
+
+      subscribers = [
+        {self(), :not_fastlane},
+        {self(), :not_fastlane}
+      ]
+
+      msg = %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
+
+      assert MessageDispatcher.dispatch(subscribers, from_pid, {:tb, "tenant123", msg}) == :ok
+
+      assert_receive %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
+      assert_receive %Broadcast{topic: "some:other:topic", event: "event", payload: %{data: "test"}}
+
+      refute_receive {:tb, _, _}
+      assert Agent.get(TestSerializer, & &1) == 0
+    end
+
     test "dispatches 'presence_diff' messages to fastlane subscribers" do
       parent = self()
 

--- a/test/realtime_web/tenant_broadcaster_test.exs
+++ b/test/realtime_web/tenant_broadcaster_test.exs
@@ -5,6 +5,7 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
   alias Phoenix.Socket.Broadcast
 
   alias RealtimeWeb.Endpoint
+  alias RealtimeWeb.RealtimeChannel.MessageDispatcher
   alias RealtimeWeb.TenantBroadcaster
 
   @topic "test-topic" <> to_string(__MODULE__)
@@ -22,6 +23,22 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
                         send(subscriber, {:relay, node(), msg})
                     end
                   end)
+                end
+
+                # Relay the fan-out telemetry emitted on this (receiving) node back to the test process.
+                def attach_fanout(dest) do
+                  :telemetry.attach(
+                    {__MODULE__, dest},
+                    [:realtime, :broadcast, :fanout, :node_delivery],
+                    &__MODULE__.relay_fanout/4,
+                    dest
+                  )
+                end
+
+                def detach_fanout(dest), do: :telemetry.detach({__MODULE__, dest})
+
+                def relay_fanout(_event, measurements, metadata, dest) do
+                  send(dest, {:fanout, measurements, metadata})
                 end
               end
             end)
@@ -227,6 +244,40 @@ defmodule RealtimeWeb.TenantBroadcasterTest do
 
       assert_receive {:telemetry, [:realtime, :tenants, :payload, :size], %{size: 15},
                       %{tenant: ^tenant_id, message_type: :presence}}
+    end
+  end
+
+  describe "broadcast fan-out tagging" do
+    setup %{node: node} do
+      :ok = :erpc.call(node, Subscriber, :attach_fanout, [self()])
+      on_exit(fn -> :erpc.call(node, Subscriber, :detach_fanout, [self()]) end)
+      :ok
+    end
+
+    test "tags :broadcast messages dispatched via MessageDispatcher so the receiving node measures fan-out",
+         %{tenant_id: tenant_id} do
+      message = %Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
+
+      TenantBroadcaster.pubsub_broadcast(tenant_id, @topic, message, MessageDispatcher, :broadcast)
+
+      # The receiving node holds no connection for this tenant -> hit=false
+      assert_receive {:fanout, %{local_tenant_users: 0}, %{tenant: ^tenant_id, hit: false}}
+    end
+
+    test "does not tag :broadcast messages dispatched by another dispatcher", %{tenant_id: tenant_id} do
+      message = %Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
+
+      TenantBroadcaster.pubsub_broadcast(tenant_id, @topic, message, Phoenix.PubSub, :broadcast)
+
+      refute_receive {:fanout, _, _}
+    end
+
+    test "does not tag non-broadcast message types", %{tenant_id: tenant_id} do
+      message = %Broadcast{topic: @topic, event: "an event", payload: %{"a" => "b"}}
+
+      TenantBroadcaster.pubsub_broadcast(tenant_id, @topic, message, MessageDispatcher, :presence)
+
+      refute_receive {:fanout, _, _}
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Collect how often we have "hits" when broadcasting. Notice that we are not tracking if the `topic` is populated just if there are potential targets/websockets.