### PR TITLE
fix: cache not found feature flags

### DIFF
--- a/lib/realtime/feature_flags/cache.ex
+++ b/lib/realtime/feature_flags/cache.ex
@@ -3,8 +3,13 @@ defmodule Realtime.FeatureFlags.Cache do
   In-process Cachex cache for `Realtime.Api.FeatureFlag` records.
 
   Cache misses fall through to the database automatically via `Cachex.fetch/3`.
-  Nil results (flag not found) are intentionally not cached so that newly
-  created flags become visible without requiring an explicit invalidation.
+  Both hits and misses are cached: a flag that does not exist is stored as a
+  `@not_found` sentinel so that hot-path callers don't hit the database on every
+  check for a flag that isn't there. We can't cache a plain `nil`, because
+  Cachex treats `nil` as "absent" and re-runs the fallback (the DB read) for it;
+  the sentinel is a real value it can store, and `get_flag/1` maps it back to
+  `nil` at the boundary. The common create/update path already overwrites the
+  sentinel on every node via `global_update_cache/1`.
 
   Use `global_update_cache/1` after mutations to push the updated struct to all
   cluster nodes. Use `global_invalidate_cache/1` after deletes.
@@ -14,6 +19,11 @@ defmodule Realtime.FeatureFlags.Cache do
   alias Realtime.Api
   alias Realtime.Api.FeatureFlag
   alias Realtime.GenRpc
+
+  # Sentinel for "flag does not exist". Cachex uses `nil` to mean "absent" and
+  # would re-run the fallback (the DB read) for a committed `nil`, so we cache a
+  # concrete value instead and translate it back to `nil` in get_flag/1.
+  @not_found :not_found
 
   def child_spec(_) do
     tenant_cache_expiration = Application.get_env(:realtime, :tenant_cache_expiration)
@@ -29,9 +39,10 @@ defmodule Realtime.FeatureFlags.Cache do
     case Cachex.fetch(__MODULE__, cache_key(name), fn _key ->
            with %FeatureFlag{} = flag <- Api.get_feature_flag(name),
                 do: {:commit, flag},
-                else: (_ -> {:ignore, nil})
+                else: (_ -> {:commit, @not_found})
          end) do
       {:error, _} -> nil
+      {_, @not_found} -> nil
       {_, value} -> value
     end
   end

--- a/test/realtime/feature_flags_test.exs
+++ b/test/realtime/feature_flags_test.exs
@@ -5,8 +5,10 @@ defmodule Realtime.FeatureFlagsTest do
   setup :set_mimic_from_context
 
   alias Realtime.Api
+  alias Realtime.Api.FeatureFlag
   alias Realtime.FeatureFlags
   alias Realtime.FeatureFlags.Cache
+  alias Realtime.Repo
   alias Realtime.Tenants.Cache, as: TenantsCache
 
   setup do
@@ -19,6 +21,58 @@ defmodule Realtime.FeatureFlagsTest do
     test "returns nil when the cache/database lookup errors instead of leaking the error" do
       stub(Cachex, :fetch, fn _cache, _key, _fallback -> {:error, :boom} end)
       assert Cache.get_flag("any_flag") == nil
+    end
+
+    test "returns the flag when it exists" do
+      {:ok, flag} = Api.upsert_feature_flag(%{name: "present_flag", enabled: true})
+      assert %FeatureFlag{name: "present_flag", enabled: true} = Cache.get_flag("present_flag")
+      assert Cache.get_flag("present_flag").id == flag.id
+    end
+
+    test "caches a miss so the flag is not re-read from the database" do
+      # First lookup misses and caches the "not found" sentinel.
+      assert Cache.get_flag("ghost_flag") == nil
+
+      # The sentinel is what's actually stored: Cachex holds :not_found (not nil,
+      # which it would treat as absent and re-fetch). The key mirrors cache_key/1.
+      assert {:ok, :not_found} = Cachex.get(Cache, {:get_flag, "ghost_flag"})
+
+      # Insert directly, bypassing upsert_feature_flag/1's global_update_cache broadcast,
+      # so the only way to observe the new row is a fresh database read.
+      %FeatureFlag{}
+      |> FeatureFlag.changeset(%{name: "ghost_flag", enabled: true})
+      |> Repo.insert!()
+
+      # Still nil: the negative result was cached, so no fresh read happens. A plain
+      # `nil` sentinel would fail here, since Cachex re-runs the fallback for `nil`.
+      assert Cache.get_flag("ghost_flag") == nil
+    end
+  end
+
+  describe "Cache.update_cache/1" do
+    test "overwrites a cached miss (as global_update_cache/1 does on create)" do
+      # Cache the "not found" sentinel first.
+      assert Cache.get_flag("late_flag") == nil
+
+      # update_cache/1 is what global_update_cache/1 invokes on every node.
+      Cache.update_cache(%FeatureFlag{name: "late_flag", enabled: true})
+
+      assert %FeatureFlag{name: "late_flag", enabled: true} = Cache.get_flag("late_flag")
+      assert FeatureFlags.enabled?("late_flag")
+    end
+  end
+
+  describe "Cache.invalidate_cache/1" do
+    test "drops a cached flag so the next lookup reads the database again" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "drop_flag", enabled: true})
+      assert %FeatureFlag{name: "drop_flag"} = Cache.get_flag("drop_flag")
+
+      Repo.delete_all(from(f in FeatureFlag, where: f.name == "drop_flag"))
+      # Still served from cache until invalidated.
+      assert %FeatureFlag{name: "drop_flag"} = Cache.get_flag("drop_flag")
+
+      Cache.invalidate_cache("drop_flag")
+      assert Cache.get_flag("drop_flag") == nil
     end
   end
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

On a hot-path it's important to not re-query the DB
