### PR TITLE
fix: improve naming on controller for postgres changes pool configuration

### DIFF
--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -132,6 +132,7 @@ defmodule RealtimeWeb.TenantController do
   )
 
   def update(conn, %{"tenant_id" => external_id, "tenant" => tenant_params}) do
+    tenant_params = translate_postgres_changes_pool(tenant_params)
     tenant = Api.get_tenant_by_external_id(external_id, use_replica?: false)
 
     case tenant do
@@ -296,6 +297,17 @@ defmodule RealtimeWeb.TenantController do
       {:error, :tenant_not_found} -> {:error, :not_found}
     end
   end
+
+  # `postgres_changes_pool` it's the naming used in middleware
+  defp translate_postgres_changes_pool(%{"extensions" => extensions} = params) when is_list(extensions),
+    do: %{params | "extensions" => Enum.map(extensions, &translate_extension_pool/1)}
+
+  defp translate_postgres_changes_pool(params), do: params
+
+  defp translate_extension_pool(%{"settings" => %{"postgres_changes_pool" => pool} = settings} = extension),
+    do: %{extension | "settings" => Map.put(settings, "subcriber_pool_size", pool)}
+
+  defp translate_extension_pool(extension), do: extension
 
   defp set_observability_attributes(conn, _opts) do
     tenant_id = conn.path_params["tenant_id"]

--- a/lib/realtime_web/controllers/tenant_controller.ex
+++ b/lib/realtime_web/controllers/tenant_controller.ex
@@ -298,14 +298,16 @@ defmodule RealtimeWeb.TenantController do
     end
   end
 
-  # `postgres_changes_pool` it's the naming used in middleware
+  # `postgres_changes_pool` is the public facing name for this setting to make it more explicit on intent
   defp translate_postgres_changes_pool(%{"extensions" => extensions} = params) when is_list(extensions),
     do: %{params | "extensions" => Enum.map(extensions, &translate_extension_pool/1)}
 
   defp translate_postgres_changes_pool(params), do: params
 
-  defp translate_extension_pool(%{"settings" => %{"postgres_changes_pool" => pool} = settings} = extension),
-    do: %{extension | "settings" => Map.put(settings, "subcriber_pool_size", pool)}
+  defp translate_extension_pool(%{"settings" => %{"postgres_changes_pool" => pool} = settings} = extension) do
+    settings = settings |> Map.delete("postgres_changes_pool") |> Map.put("subcriber_pool_size", pool)
+    %{extension | "settings" => settings}
+  end
 
   defp translate_extension_pool(extension), do: extension
 

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -251,6 +251,20 @@ defmodule RealtimeWeb.TenantControllerTest do
       assert updated_tenant.presence_enabled == true
     end
 
+    test "postgres_changes_pool is stored as subcriber_pool_size and overrides it", %{tenant: tenant, conn: conn} do
+      external_id = tenant.external_id
+      port = tenant_db_port(tenant)
+      attrs = default_tenant_attrs(port) |> put_extension_setting("subcriber_pool_size", 3)
+
+      conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
+      assert [%{"settings" => %{"subcriber_pool_size" => 3}}] = json_response(conn, 200)["data"]["extensions"]
+
+      attrs = put_extension_setting(attrs, "postgres_changes_pool", 10)
+
+      conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
+      assert [%{"settings" => %{"subcriber_pool_size" => 10}}] = json_response(conn, 200)["data"]["extensions"]
+    end
+
     test "renders errors when data is invalid", %{conn: conn} do
       conn = put(conn, ~p"/api/tenants/#{random_string()}", tenant: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
@@ -682,6 +696,10 @@ defmodule RealtimeWeb.TenantControllerTest do
       "postgres_cdc_default" => "postgres_cdc_rls",
       "jwt_secret" => "new secret"
     }
+  end
+
+  defp put_extension_setting(%{"extensions" => [extension]} = attrs, key, value) do
+    %{attrs | "extensions" => [update_in(extension, ["settings"], &Map.put(&1, key, value))]}
   end
 
   defp wait_on_postgres_cdc_rls(external_id, attempt \\ 10)

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -262,7 +262,9 @@ defmodule RealtimeWeb.TenantControllerTest do
       attrs = put_extension_setting(attrs, "postgres_changes_pool", 10)
 
       conn = put(conn, ~p"/api/tenants/#{external_id}", tenant: attrs)
-      assert [%{"settings" => %{"subcriber_pool_size" => 10}}] = json_response(conn, 200)["data"]["extensions"]
+      assert [%{"settings" => settings}] = json_response(conn, 200)["data"]["extensions"]
+      assert settings["subcriber_pool_size"] == 10
+      refute Map.has_key?(settings, "postgres_changes_pool")
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
## What kind of change does this PR introduce?

improve naming on controller for postgres changes pool configuration