### PR TITLE
fix: optimise read auth probe

### DIFF
--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -249,16 +249,25 @@ defmodule Realtime.Tenants.Authorization do
     Database.transaction(
       conn,
       fn transaction_conn ->
+        # Generate the probe ids client-side so we can skip RETURNING on the insert and build the
+        # extension -> id map deterministically (multi-row RETURNING order is not guaranteed).
+        messages_by_extension = Map.new(extensions, &{&1, Ecto.UUID.generate()})
+
         changesets =
-          Enum.map(extensions, fn ext ->
-            Message.changeset(%Message{}, %{topic: authorization_context.topic, extension: ext})
+          Enum.map(messages_by_extension, fn {ext, id} ->
+            # The raw insert sends params straight to Postgrex (no Ecto casting), so the uuid column
+            # needs the 16-byte binary form. The map keeps the string form for the Ecto SELECT below.
+            {:ok, dumped_id} = Ecto.UUID.dump(id)
+
+            %Message{}
+            |> Message.changeset(%{topic: authorization_context.topic, extension: ext})
+            |> Ecto.Changeset.put_change(:id, dumped_id)
           end)
 
-        with {:ok, messages} <- Repo.insert_all_entries(transaction_conn, changesets, Message),
-             messages_by_extension = Map.new(messages, &{&1.extension, &1.id}),
+        with {:ok, _} <- Repo.insert_all_entries(transaction_conn, changesets, Message, returning: false),
              _ = set_conn_config(transaction_conn, authorization_context),
              {:ok, policies} <-
-               check_read_policies(transaction_conn, authorization_context, messages_by_extension, policies) do
+               check_read_policies(transaction_conn, messages_by_extension, policies) do
           Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
           policies
         else
@@ -301,10 +310,10 @@ defmodule Realtime.Tenants.Authorization do
       else: [:broadcast]
   end
 
-  defp check_read_policies(conn, authorization_context, messages_by_extension, policies) do
+  defp check_read_policies(conn, messages_by_extension, policies) do
     ids = Map.values(messages_by_extension)
 
-    query = from(m in Message, where: m.topic == ^authorization_context.topic and m.id in ^ids)
+    query = from(m in Message, where: m.id in ^ids, select: m.id)
 
     with {:ok, res} <- Repo.all(conn, query, Message) do
       returned_ids = MapSet.new(res, & &1.id)

--- a/lib/realtime/tenants/repo.ex
+++ b/lib/realtime/tenants/repo.ex
@@ -75,10 +75,17 @@ defmodule Realtime.Tenants.Repo do
         ) ::
           {:ok, [struct()]} | {:error, any()} | Ecto.Changeset.t()
   def insert_all_entries(conn, changesets, result_struct, opts \\ []) do
-    with {:ok, {query, args}} <- insert_all_query_from_changeset(changesets) do
-      conn
-      |> run_query_with_trap(query, args, opts)
-      |> result_to_structs(result_struct)
+    {returning?, opts} = Keyword.pop(opts, :returning, true)
+
+    with {:ok, {query, args}} <- insert_all_query_from_changeset(changesets, returning: returning?) do
+      result = run_query_with_trap(conn, query, args, opts)
+
+      if returning? do
+        result_to_structs(result, result_struct)
+      else
+        with {:ok, %Postgrex.Result{}} <- result,
+             do: {:ok, Enum.map(changesets, &Ecto.Changeset.apply_changes/1)}
+      end
     end
   end
 
@@ -172,7 +179,7 @@ defmodule Realtime.Tenants.Repo do
     {:ok, {"INSERT INTO #{table} #{header} VALUES (#{arg_index})#{returning}", rows}}
   end
 
-  defp insert_all_query_from_changeset(changesets) do
+  defp insert_all_query_from_changeset(changesets, opts) do
     invalid = Enum.filter(changesets, &(!&1.valid?))
 
     if invalid != [] do
@@ -219,7 +226,8 @@ defmodule Realtime.Tenants.Repo do
 
       table = "\"#{prefix}\".\"#{source}\""
       header = "(#{Enum.map_join(header, ",", &"\"#{&1}\"")})"
-      {:ok, {"INSERT INTO #{table} #{header} VALUES #{args_index} RETURNING *", rows}}
+      returning = if Keyword.get(opts, :returning, true), do: " RETURNING *", else: ""
+      {:ok, {"INSERT INTO #{table} #{header} VALUES #{args_index}#{returning}", rows}}
     end
   end
 

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -317,7 +317,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
     @tag role: "anon", policies: []
     test "ssl recv: closed ConnectionError from Repo on read is classified as tenant_database_unavailable", context do
       conn_error = %DBConnection.ConnectionError{message: "ssl recv: closed", severity: :error, reason: :closed}
-      stub(Repo, :insert_all_entries, fn _, _, _ -> {:error, conn_error} end)
+      stub(Repo, :insert_all_entries, fn _, _, _, _ -> {:error, conn_error} end)
 
       assert {:error, :tenant_database_unavailable} =
                Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)

--- a/test/realtime/tenants/repo_test.exs
+++ b/test/realtime/tenants/repo_test.exs
@@ -145,6 +145,22 @@ defmodule Realtime.Tenants.RepoTest do
       assert Enum.all?(results, fn result -> is_map(result) end)
     end
 
+    test "with returning: false skips RETURNING and returns the applied changesets", %{db_conn: db_conn} do
+      id = Ecto.UUID.generate()
+      {:ok, dumped_id} = Ecto.UUID.dump(id)
+
+      changeset = [
+        Message.changeset(%Message{}, %{topic: random_string(), extension: :broadcast})
+        |> Ecto.Changeset.put_change(:id, dumped_id)
+      ]
+
+      assert {:ok, [%Message{} = message]} =
+               Repo.insert_all_entries(db_conn, changeset, Message, returning: false)
+
+      # No DB round-trip for the id: it is the value we supplied, not one loaded from RETURNING.
+      assert message.id == dumped_id
+    end
+
     test "returns changeset if changeset is invalid", %{db_conn: db_conn} do
       changeset = [Message.changeset(%Message{}, %{})]
       res = Repo.insert_all_entries(db_conn, changeset, Message)


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Avoid using `RETURNING` when we don't care about all the rows except `id`
* `SELECT` only `id` to identify which extension was approved
