### PR TITLE
chore: more async tests & less tenant container set-up

### DIFF
--- a/test/extensions/postgres_cdc_rls/replications_test.exs
+++ b/test/extensions/postgres_cdc_rls/replications_test.exs
@@ -1,5 +1,5 @@
 defmodule Extensions.PostgresCdcRls.ReplicationsTest do
-  use Realtime.DataCase, async: false
+  use Realtime.DataCase, async: true
 
   alias Extensions.PostgresCdcRls.Replications
   alias Extensions.PostgresCdcRls.Subscriptions

--- a/test/realtime/extensions/cdc_rls/replication_poller_test.exs
+++ b/test/realtime/extensions/cdc_rls/replication_poller_test.exs
@@ -24,10 +24,15 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
   setup :set_mimic_from_context
 
+  setup_all do
+    tenant = TestTenantDb.checkout_tenant_unboxed(run_migrations: true)
+    %{tenant: tenant}
+  end
+
   @change_json ~s({"table":"test","type":"INSERT","record":{"id": 34, "details": "test"},"columns":[{"name": "id", "type": "int4"}, {"name": "details", "type": "text"}],"errors":null,"schema":"public","commit_timestamp":"2025-10-13T07:50:28.066Z"})
 
   describe "poll" do
-    setup do
+    setup %{tenant: tenant} do
       :telemetry.attach_many(
         __MODULE__,
         [
@@ -45,7 +50,9 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
 
       on_exit(fn -> :telemetry.detach(__MODULE__) end)
 
-      tenant = TestTenantDb.checkout_tenant(run_migrations: true)
+      # The tenant is shared across the module via setup_all, so reset its rate
+      # counters per-test (checkout_tenant used to do this on every checkout).
+      RateCounterHelper.stop(tenant.external_id)
 
       {:ok, tenant} = Realtime.Api.update_tenant_by_external_id(tenant.external_id, %{"max_events_per_second" => 123})
 
@@ -941,8 +948,7 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
   end
 
   describe "get_pg_stat_activity_diff/2" do
-    setup do
-      tenant = TestTenantDb.checkout_tenant(run_migrations: true)
+    setup %{tenant: tenant} do
       {:ok, conn} = Database.connect(tenant, "realtime_rls", :stop)
       %{conn: conn}
     end
@@ -953,9 +959,7 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationPollerTest do
   end
 
   describe "error handling" do
-    setup do
-      tenant = TestTenantDb.checkout_tenant(run_migrations: true)
-
+    setup %{tenant: tenant} do
       args =
         hd(tenant.extensions).settings
         |> Map.put("id", tenant.external_id)

--- a/test/realtime/extensions/cdc_rls/replications_test.exs
+++ b/test/realtime/extensions/cdc_rls/replications_test.exs
@@ -5,8 +5,12 @@ defmodule Realtime.Extensions.PostgresCdcRls.ReplicationsTest do
   alias Extensions.PostgresCdcRls.Subscriptions
   alias Realtime.Database
 
-  setup do
-    tenant = TestTenantDb.checkout_tenant(run_migrations: true)
+  setup_all do
+    tenant = TestTenantDb.checkout_tenant_unboxed(run_migrations: true)
+    %{tenant: tenant}
+  end
+
+  setup %{tenant: tenant} do
     {:ok, conn} = Database.connect(tenant, "realtime_rls", :stop)
     %{conn: conn}
   end

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -8,7 +8,7 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   alias Extensions.PostgresCdcRls.Subscriptions
   alias Realtime.Database
 
-  setup do
+  defp setup_tenant(_) do
     tenant = TestTenantDb.checkout_tenant(run_migrations: true)
 
     {:ok, db_settings} = Database.from_tenant(tenant, "realtime_rls")
@@ -373,6 +373,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "filters: persisting to the subscription row" do
+    setup :setup_tenant
+
     test "filters are stored in the filters column", %{conn: conn} do
       {:ok, subscription_params} =
         Subscriptions.parse_subscription_params(%{
@@ -486,6 +488,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "filters: gating rows end to end (apply_rls)" do
+    setup :setup_tenant
+
     test "apply_rls honours a like filter end to end", %{conn: conn} do
       visible_id = UUID.uuid1()
       hidden_id = UUID.uuid1()
@@ -630,6 +634,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "subscribing to table changes" do
+    setup :setup_tenant
+
     test "user can subscribe to all events on all tables in a schema", %{conn: conn} do
       {:ok, subscription_params} =
         Subscriptions.parse_subscription_params(%{"event" => "*", "schema" => "public"})
@@ -937,6 +943,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "delete_all/1" do
+    setup :setup_tenant
+
     test "delete_all", %{conn: conn} do
       create_subscriptions(conn, 10)
       assert :ok = Subscriptions.delete_all(conn)
@@ -957,6 +965,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "delete/2" do
+    setup :setup_tenant
+
     test "returns error when subscription table is dropped", %{conn: conn} do
       Postgrex.query!(conn, "drop table if exists realtime.subscription cascade", [])
 
@@ -988,6 +998,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "delete_multi/2" do
+    setup :setup_tenant
+
     test "delete_multi", %{conn: conn} do
       Subscriptions.delete_all(conn)
       id1 = UUID.uuid1()
@@ -1017,6 +1029,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "delete_all_if_table_exists/1" do
+    setup :setup_tenant
+
     test "delete_all_if_table_exists", %{conn: conn} do
       Subscriptions.delete_all(conn)
       create_subscriptions(conn, 10)
@@ -1075,6 +1089,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "fetch_publication_tables/2" do
+    setup :setup_tenant
+
     test "returns {:ok, tables} for an existing publication", %{conn: conn} do
       assert {:ok, tables} = Subscriptions.fetch_publication_tables(conn, "supabase_realtime_test")
       assert tables[{"*"}] != nil
@@ -1091,6 +1107,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
   end
 
   describe "existing subscriptions without column selection continue to receive full payloads" do
+    setup :setup_tenant
+
     test "omitting select returns all columns (no behavior change for existing clients)" do
       assert {:ok, {"*", "public", "messages", [], nil}} =
                Subscriptions.parse_subscription_params(%{
@@ -1162,7 +1180,7 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
     end
   end
 
-  describe "subscribing with column selection (select param)" do
+  describe "subscribing with column selection (select param) - parse" do
     test "user can pass a list of column names to limit the payload" do
       assert {:ok, {"*", "public", "messages", [], ["id", "details"]}} =
                Subscriptions.parse_subscription_params(%{
@@ -1212,6 +1230,31 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
                  "select" => ["id", "details"]
                })
     end
+
+    test "user gets an error when using select with a schema-only (wildcard table) subscription" do
+      assert {:error, msg} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "select" => ["id"]
+               })
+
+      assert msg =~ "wildcard"
+    end
+
+    test "user gets an error when using select with an explicit wildcard table" do
+      assert {:error, msg} =
+               Subscriptions.parse_subscription_params(%{
+                 "schema" => "public",
+                 "table" => "*",
+                 "select" => ["id"]
+               })
+
+      assert msg =~ "wildcard"
+    end
+  end
+
+  describe "subscribing with column selection (select param) - create" do
+    setup :setup_tenant
 
     test "selected columns are stored in normalized (sorted) order in the database", %{
       conn: conn
@@ -1307,30 +1350,11 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
       assert %Postgrex.Result{rows: [[0]]} =
                Postgrex.query!(conn, "select count(*) from realtime.subscription", [])
     end
-
-    test "user gets an error when using select with a schema-only (wildcard table) subscription" do
-      assert {:error, msg} =
-               Subscriptions.parse_subscription_params(%{
-                 "schema" => "public",
-                 "select" => ["id"]
-               })
-
-      assert msg =~ "wildcard"
-    end
-
-    test "user gets an error when using select with an explicit wildcard table" do
-      assert {:error, msg} =
-               Subscriptions.parse_subscription_params(%{
-                 "schema" => "public",
-                 "table" => "*",
-                 "select" => ["id"]
-               })
-
-      assert msg =~ "wildcard"
-    end
   end
 
   describe "regression tests" do
+    setup :setup_tenant
+
     test "list_changes succeeds for custom roles without execution grants (issue #2001 with non-builtin role)",
          %{conn: conn, tenant: tenant} do
       {:ok, admin_settings} = Database.from_tenant(tenant, "realtime_test", :stop)

--- a/test/realtime/helpers_test.exs
+++ b/test/realtime/helpers_test.exs
@@ -1,4 +1,4 @@
 defmodule Realtime.HelpersTest do
-  use Realtime.DataCase
+  use Realtime.DataCase, async: true
   doctest Realtime.Helpers
 end

--- a/test/realtime/logs_test.exs
+++ b/test/realtime/logs_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.LogsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import ExUnit.CaptureLog
 

--- a/test/realtime/monitoring/prom_ex/plugins/phoenix_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/phoenix_test.exs
@@ -1,5 +1,5 @@
 defmodule Realtime.PromEx.Plugins.PhoenixTest do
-  use Realtime.DataCase, async: false
+  use Realtime.DataCase, async: true
   alias Realtime.PromEx.Plugins
   alias Realtime.Integration.WebsocketClient
 
@@ -17,7 +17,7 @@ defmodule Realtime.PromEx.Plugins.PhoenixTest do
   end
 
   setup do
-    %{tenant: TestTenantDb.checkout_tenant(run_migrations: true)}
+    %{tenant: TestTenantDb.checkout_tenant_unboxed(run_migrations: true)}
   end
 
   describe "pooling metrics" do

--- a/test/realtime/tenants/batch_broadcast_test.exs
+++ b/test/realtime/tenants/batch_broadcast_test.exs
@@ -16,8 +16,8 @@ defmodule Realtime.Tenants.BatchBroadcastTest do
 
   alias RealtimeWeb.TenantBroadcaster
 
-  setup do
-    tenant = TestTenantDb.checkout_tenant(run_migrations: true)
+  setup_all do
+    tenant = TestTenantDb.checkout_tenant_unboxed(run_migrations: true)
     Realtime.Tenants.Cache.update_cache(tenant)
     {:ok, tenant: tenant}
   end

--- a/test/realtime/tenants/schema_test.exs
+++ b/test/realtime/tenants/schema_test.exs
@@ -5,7 +5,7 @@ defmodule Realtime.Tenants.SchemaTest do
   # - tag `@describetag :requires_no_supautils_policy_grants` represents older images where schema restrictions can't be applied
   # - untagged tests assert behaviour on every version
 
-  use Realtime.DataCase, async: false
+  use Realtime.DataCase, async: true
   alias Realtime.Database
 
   setup do

--- a/test/realtime/tenants/single_broadcast_test.exs
+++ b/test/realtime/tenants/single_broadcast_test.exs
@@ -17,8 +17,8 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
   alias RealtimeWeb.TenantBroadcaster
   alias RealtimeWeb.Socket.UserBroadcast
 
-  setup do
-    tenant = TestTenantDb.checkout_tenant(run_migrations: true)
+  setup_all do
+    tenant = TestTenantDb.checkout_tenant_unboxed(run_migrations: true)
     Realtime.Tenants.Cache.update_cache(tenant)
     {:ok, tenant: tenant}
   end

--- a/test/realtime/tenants_test.exs
+++ b/test/realtime/tenants_test.exs
@@ -1,6 +1,5 @@
 defmodule Realtime.TenantsTest do
-  # async: false due to cache usage
-  use Realtime.DataCase, async: false
+  use Realtime.DataCase, async: true
 
   alias Realtime.Database
   alias Realtime.GenCounter

--- a/test/realtime/users_counter_test.exs
+++ b/test/realtime/users_counter_test.exs
@@ -80,7 +80,7 @@ defmodule Realtime.UsersCounterTest do
 
       my_counts = UsersCounter.local_tenant_counts()
       # Only one connection from this test process on this node
-      assert my_counts == %{tenant_id => 1}
+      assert %{^tenant_id => 1} = my_counts
     end
   end
 

--- a/test/realtime_web/channels/realtime_channel_replication_ready_test.exs
+++ b/test/realtime_web/channels/realtime_channel_replication_ready_test.exs
@@ -8,8 +8,8 @@ defmodule RealtimeWeb.RealtimeChannelReplicationReadyTest do
 
   setup :set_mimic_from_context
 
-  setup do
-    tenant = TestTenantDb.checkout_tenant(run_migrations: true)
+  setup_all do
+    tenant = TestTenantDb.checkout_tenant_unboxed(run_migrations: true)
     Realtime.Tenants.Cache.update_cache(tenant)
     {:ok, tenant: tenant}
   end

--- a/test/realtime_web/controllers/broadcast_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_controller_test.exs
@@ -14,14 +14,19 @@ defmodule RealtimeWeb.BroadcastControllerTest do
   alias RealtimeWeb.Endpoint
   alias RealtimeWeb.TenantBroadcaster
 
-  setup %{conn: conn} do
-    tenant = TestTenantDb.checkout_tenant(run_migrations: true)
-    # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues
+  setup_all do
+    tenant = TestTenantDb.checkout_tenant_unboxed(run_migrations: true)
+    %{tenant: tenant}
+  end
+
+  setup %{conn: conn, tenant: tenant} do
+    # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues.
+    # Kept per-test so the "suspended tenant" case can't leak suspend: true into later tests.
     Realtime.Tenants.Cache.update_cache(tenant)
 
     conn = generate_conn(conn, tenant)
 
-    {:ok, conn: conn, tenant: tenant}
+    {:ok, conn: conn}
   end
 
   defp subscribe(tenant_topic, topic) do

--- a/test/realtime_web/controllers/broadcast_single_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_single_controller_test.exs
@@ -14,14 +14,19 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
   alias RealtimeWeb.RealtimeChannel
   alias RealtimeWeb.Endpoint
 
-  setup %{conn: conn} do
-    tenant = TestTenantDb.checkout_tenant(run_migrations: true)
-    # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues
+  setup_all do
+    tenant = TestTenantDb.checkout_tenant_unboxed(run_migrations: true)
+    %{tenant: tenant}
+  end
+
+  setup %{conn: conn, tenant: tenant} do
+    # Warm cache to avoid Cachex and Ecto.Sandbox ownership issues.
+    # Kept per-test so the "suspended tenant" case can't leak suspend: true into later tests.
     Realtime.Tenants.Cache.update_cache(tenant)
 
     conn = generate_conn(conn, tenant)
 
-    {:ok, conn: conn, tenant: tenant}
+    {:ok, conn: conn}
   end
 
   defp subscribe(tenant_topic, topic, serializer \\ Phoenix.Socket.V1.JSONSerializer) do

--- a/test/realtime_web/controllers/openapi_controller_test.exs
+++ b/test/realtime_web/controllers/openapi_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.Controllers.OpenapiControllerTest do
-  use RealtimeWeb.ConnCase
+  use RealtimeWeb.ConnCase, async: true
 
   describe "openapi" do
     test "returns the openapi spec", %{conn: conn} do

--- a/test/realtime_web/dashboard/tenant_info_test.exs
+++ b/test/realtime_web/dashboard/tenant_info_test.exs
@@ -10,7 +10,7 @@ defmodule RealtimeWeb.Dashboard.TenantInfoTest do
 
   setup :set_mimic_from_context
 
-  setup do
+  setup_all do
     Application.put_env(:realtime, :dashboard_auth, :basic_auth)
     Application.put_env(:realtime, :dashboard_credentials, {"user", "pass"})
 
@@ -19,10 +19,14 @@ defmodule RealtimeWeb.Dashboard.TenantInfoTest do
       Application.delete_env(:realtime, :dashboard_credentials)
     end)
 
-    tenant = TestTenantDb.checkout_tenant(run_migrations: true)
-    conn = using_basic_auth(build_conn(), "user", "pass")
+    tenant = TestTenantDb.checkout_tenant_unboxed(run_migrations: true)
 
-    %{tenant: tenant, conn: conn}
+    %{tenant: tenant}
+  end
+
+  setup do
+    conn = using_basic_auth(build_conn(), "user", "pass")
+    %{conn: conn}
   end
 
   test "renders lookup form", %{conn: conn} do

--- a/test/realtime_web/live/inspector_live/conn_component_test.exs
+++ b/test/realtime_web/live/inspector_live/conn_component_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.InspectorLive.ConnComponentTest do
-  use RealtimeWeb.ConnCase
+  use RealtimeWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
   describe "connection form persistence" do

--- a/test/realtime_web/live/inspector_live/event_log_component_test.exs
+++ b/test/realtime_web/live/inspector_live/event_log_component_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.InspectorLive.EventLogComponentTest do
-  use RealtimeWeb.ConnCase
+  use RealtimeWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
   alias RealtimeWeb.InspectorLive.EventLogComponent

--- a/test/realtime_web/live/inspector_live/index_test.exs
+++ b/test/realtime_web/live/inspector_live/index_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.InspectorLive.IndexTest do
-  use RealtimeWeb.ConnCase
+  use RealtimeWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
   describe "Inspector LiveView" do

--- a/test/realtime_web/live/status_live/index_test.exs
+++ b/test/realtime_web/live/status_live/index_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.StatusLive.IndexTest do
-  use RealtimeWeb.ConnCase
+  use RealtimeWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
   alias Realtime.Latency.Payload

--- a/test/realtime_web/views/layout_view_test.exs
+++ b/test/realtime_web/views/layout_view_test.exs
@@ -1,5 +1,5 @@
 defmodule RealtimeWeb.LayoutViewTest do
-  use RealtimeWeb.ConnCase
+  use RealtimeWeb.ConnCase, async: true
 
   # When testing helpers, you may want to import Phoenix.HTML and
   # use functions such as safe_to_string() to convert the helper

--- a/test/realtime_web/views/page_view_test.exs
+++ b/test/realtime_web/views/page_view_test.exs
@@ -1,3 +1,3 @@
 defmodule RealtimeWeb.PageViewTest do
-  use RealtimeWeb.ConnCase
+  use RealtimeWeb.ConnCase, async: true
 end

--- a/test/support/test_tenant_db.ex
+++ b/test/support/test_tenant_db.ex
@@ -167,6 +167,13 @@ defmodule TestTenantDb do
       )
 
     try do
+      %{rows: slots} = Postgrex.query!(admin_conn, "SELECT slot_name, active_pid FROM pg_replication_slots", [])
+
+      Enum.each(slots, fn [slot_name, active_pid] ->
+        if active_pid, do: Postgrex.query!(admin_conn, "SELECT pg_terminate_backend($1)", [active_pid])
+        Postgrex.query!(admin_conn, "SELECT pg_drop_replication_slot($1)", [slot_name])
+      end)
+
       Postgrex.query!(admin_conn, "DROP PUBLICATION IF EXISTS supabase_realtime_test", [])
       Postgrex.query!(admin_conn, "DROP SCHEMA IF EXISTS realtime CASCADE", [])
       Postgrex.query!(admin_conn, "CREATE SCHEMA realtime", [])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Where possible use `async: true` and try to set-up test tenant dbs the minimum amount of times