### PR TITLE
fix: fail join when Muster join is enabled and join failed

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -157,9 +157,11 @@ defmodule RealtimeWeb.RealtimeChannel do
       if presence_enabled?, do: send(self(), :sync_presence)
 
       UsersCounter.add(transport_pid, tenant_id)
-      await_muster_join(muster_join_task, socket)
 
-      {:ok, state, assign(socket, assigns)}
+      case await_muster_join(muster_join_task, socket) do
+        :ok -> {:ok, state, assign(socket, assigns)}
+        {:error, _} = error -> error
+      end
     else
       {:error, :expired_token, msg} ->
         maybe_log_warning(socket, "InvalidJWTToken", msg)
@@ -724,8 +726,6 @@ defmodule RealtimeWeb.RealtimeChannel do
       {:exit, reason} -> log_error(socket, "MusterJoinError", inspect(reason))
       nil -> log_error(socket, "MusterJoinError", "timed out after #{@muster_join_await_ms}ms")
     end
-
-    :ok
   end
 
   defp limit_max_users(tenant, transport_pid) do

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -917,7 +917,7 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       assert {:ok, _, %Socket{}} = subscribe_and_join(socket, "realtime:test", %{})
     end
 
-    test "join still succeeds when Muster.join raises", %{tenant: tenant} do
+    test "join fails when Muster.join raises", %{tenant: tenant} do
       jwt = Generators.generate_jwt_token(tenant)
       {:ok, %Socket{} = socket} = connect(UserSocket, %{"log_level" => "error"}, conn_opts(tenant, jwt))
 
@@ -927,13 +927,14 @@ defmodule RealtimeWeb.RealtimeChannelTest do
 
       log =
         capture_log(fn ->
-          assert {:ok, _, %Socket{}} = subscribe_and_join(socket, "realtime:test", %{})
+          assert {:error, %{reason: reason}} = subscribe_and_join(socket, "realtime:test", %{})
+          assert reason =~ "MusterJoinError"
         end)
 
       assert log =~ "MusterJoinError"
     end
 
-    test "join still succeeds when Muster.join exits", %{tenant: tenant} do
+    test "join fails when Muster.join exits", %{tenant: tenant} do
       jwt = Generators.generate_jwt_token(tenant)
       {:ok, %Socket{} = socket} = connect(UserSocket, %{"log_level" => "error"}, conn_opts(tenant, jwt))
 
@@ -943,13 +944,14 @@ defmodule RealtimeWeb.RealtimeChannelTest do
 
       log =
         capture_log(fn ->
-          assert {:ok, _, %Socket{}} = subscribe_and_join(socket, "realtime:test", %{})
+          assert {:error, %{reason: reason}} = subscribe_and_join(socket, "realtime:test", %{})
+          assert reason =~ "MusterJoinError"
         end)
 
       assert log =~ "MusterJoinError"
     end
 
-    test "join still succeeds when Muster.join times out", %{tenant: tenant} do
+    test "join fails when Muster.join times out", %{tenant: tenant} do
       # @muster_join_await_ms (4s) is a private constant, not overridable from
       # tests, so this pays the real timeout in wall-clock time rather than
       # shrinking it.
@@ -962,7 +964,9 @@ defmodule RealtimeWeb.RealtimeChannelTest do
 
       log =
         capture_log(fn ->
-          assert {:ok, _, %Socket{}} = subscribe_and_join(socket, "realtime:test", %{})
+          assert {:error, %{reason: reason}} = subscribe_and_join(socket, "realtime:test", %{})
+          assert reason =~ "MusterJoinError"
+          assert reason =~ "timed out"
         end)
 
       assert log =~ "MusterJoinError"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Let's block on Muster join so that we can safely use muster routing for broadcast