### PR TITLE
fix: check extension write policies lazily

### DIFF
--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -306,10 +306,9 @@ defmodule Realtime.Tenants.Authorization do
   @all_extensions [:broadcast, :presence]
 
   defp extensions_to_check(opts) do
-    Enum.filter(@all_extensions, fn
-      :broadcast -> Keyword.get(opts, :broadcast_enabled?, true)
-      :presence -> Keyword.get(opts, :presence_enabled?, true)
-    end)
+    if Keyword.get(opts, :presence_enabled?, true),
+      do: @all_extensions,
+      else: [:broadcast]
   end
 
   defp check_read_policies(conn, messages_by_extension, policies) do

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -31,6 +31,8 @@ defmodule Realtime.Tenants.Authorization do
           :sub => binary | nil
         }
 
+  @type extension :: :broadcast | :presence
+
   @doc """
   Builds a new authorization struct which will be used to retain the information required to check Policies.
 
@@ -114,7 +116,7 @@ defmodule Realtime.Tenants.Authorization do
 
   Automatically uses RPC if the database connection is not in the same node
   """
-  @spec get_write_authorizations(Policies.t(), pid(), t(), keyword()) ::
+  @spec get_write_authorizations(Policies.t(), pid(), t(), extension()) ::
           {:ok, Policies.t()}
           | {:error, :rls_policy_error, Postgrex.Error.t()}
           | {:error, :query_canceled, Postgrex.Error.t()}
@@ -122,14 +124,13 @@ defmodule Realtime.Tenants.Authorization do
           | {:error, :increase_connection_pool}
           | {:error, :tenant_database_unavailable}
           | {:error, any()}
-  def get_write_authorizations(policies, db_conn, authorization_context, opts \\ [])
-
-  def get_write_authorizations(policies, db_conn, authorization_context, opts) when node() == node(db_conn) do
+  def get_write_authorizations(policies, db_conn, authorization_context, extension)
+      when extension in [:broadcast, :presence] and node() == node(db_conn) do
     rate_counter = rate_counter(authorization_context.tenant_id)
 
     if rate_counter.limit.triggered == false do
       db_conn
-      |> get_write_policies_for_connection(authorization_context, policies, opts)
+      |> get_write_policies_for_connection(authorization_context, policies, extension)
       |> handle_policies_result(rate_counter)
     else
       {:error, :increase_connection_pool}
@@ -137,7 +138,8 @@ defmodule Realtime.Tenants.Authorization do
   end
 
   # Remote call
-  def get_write_authorizations(policies, db_conn, authorization_context, opts) do
+  def get_write_authorizations(policies, db_conn, authorization_context, extension)
+      when extension in [:broadcast, :presence] do
     rate_counter = rate_counter(authorization_context.tenant_id)
 
     if rate_counter.limit.triggered == false do
@@ -145,7 +147,7 @@ defmodule Realtime.Tenants.Authorization do
              node(db_conn),
              __MODULE__,
              :get_write_authorizations,
-             [policies, db_conn, authorization_context, opts],
+             [policies, db_conn, authorization_context, extension],
              tenant_id: authorization_context.tenant_id,
              key: authorization_context.tenant_id
            ) do
@@ -164,8 +166,8 @@ defmodule Realtime.Tenants.Authorization do
     end
   end
 
-  def get_write_authorizations(db_conn, authorization_context),
-    do: get_write_authorizations(%Policies{}, db_conn, authorization_context)
+  def get_write_authorizations(db_conn, authorization_context, extension),
+    do: get_write_authorizations(%Policies{}, db_conn, authorization_context, extension)
 
   defp handle_policies_result(result, rate_counter) do
     case result do
@@ -279,18 +281,17 @@ defmodule Realtime.Tenants.Authorization do
     )
   end
 
-  defp get_write_policies_for_connection(conn, authorization_context, policies, caller_opts) do
+  defp get_write_policies_for_connection(conn, authorization_context, policies, extension) do
     tenant_id = authorization_context.tenant_id
     opts = [telemetry: [:realtime, :tenants, :write_authorization_check], tenant_id: tenant_id]
     metadata = [project: tenant_id, external_id: tenant_id]
-    extensions = extensions_to_check(caller_opts)
 
     Database.transaction(
       conn,
       fn transaction_conn ->
         set_conn_config(transaction_conn, authorization_context)
 
-        with {:ok, policies} <- check_write_policies(transaction_conn, authorization_context, extensions, policies) do
+        with {:ok, policies} <- check_write_policy(transaction_conn, authorization_context, extension, policies) do
           Postgrex.query!(transaction_conn, "ROLLBACK AND CHAIN", [])
           policies
         else
@@ -329,21 +330,19 @@ defmodule Realtime.Tenants.Authorization do
     end
   end
 
-  defp check_write_policies(conn, authorization_context, extensions, policies) do
-    Enum.reduce_while(extensions, {:ok, policies}, fn extension, {:ok, acc} ->
-      changeset = Message.changeset(%Message{}, %{topic: authorization_context.topic, extension: extension})
+  defp check_write_policy(conn, authorization_context, extension, policies) do
+    changeset = Message.changeset(%Message{}, %{topic: authorization_context.topic, extension: extension})
 
-      case Repo.insert(conn, changeset, Message, mode: :savepoint, returning: false) do
-        {:ok, _} ->
-          {:cont, {:ok, Policies.update_policies(acc, extension, :write, true)}}
+    case Repo.insert(conn, changeset, Message, mode: :savepoint, returning: false) do
+      {:ok, _} ->
+        {:ok, Policies.update_policies(policies, extension, :write, true)}
 
-        {:error, %Postgrex.Error{postgres: %{code: :insufficient_privilege}}} ->
-          {:cont, {:ok, Policies.update_policies(acc, extension, :write, false)}}
+      {:error, %Postgrex.Error{postgres: %{code: :insufficient_privilege}}} ->
+        {:ok, Policies.update_policies(policies, extension, :write, false)}
 
-        {:error, reason} ->
-          {:halt, {:error, reason}}
-      end
-    end)
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   defp rate_counter(tenant_id) do

--- a/lib/realtime/tenants/authorization.ex
+++ b/lib/realtime/tenants/authorization.ex
@@ -305,9 +305,10 @@ defmodule Realtime.Tenants.Authorization do
   @all_extensions [:broadcast, :presence]
 
   defp extensions_to_check(opts) do
-    if Keyword.get(opts, :presence_enabled?, true),
-      do: @all_extensions,
-      else: [:broadcast]
+    Enum.filter(@all_extensions, fn
+      :broadcast -> Keyword.get(opts, :broadcast_enabled?, true)
+      :presence -> Keyword.get(opts, :presence_enabled?, true)
+    end)
   end
 
   defp check_read_policies(conn, messages_by_extension, policies) do
@@ -329,22 +330,18 @@ defmodule Realtime.Tenants.Authorization do
   end
 
   defp check_write_policies(conn, authorization_context, extensions, policies) do
-    Enum.reduce_while(@all_extensions, {:ok, policies}, fn extension, {:ok, acc} ->
-      if extension in extensions do
-        changeset = Message.changeset(%Message{}, %{topic: authorization_context.topic, extension: extension})
+    Enum.reduce_while(extensions, {:ok, policies}, fn extension, {:ok, acc} ->
+      changeset = Message.changeset(%Message{}, %{topic: authorization_context.topic, extension: extension})
 
-        case Repo.insert(conn, changeset, Message, mode: :savepoint, returning: false) do
-          {:ok, _} ->
-            {:cont, {:ok, Policies.update_policies(acc, extension, :write, true)}}
+      case Repo.insert(conn, changeset, Message, mode: :savepoint, returning: false) do
+        {:ok, _} ->
+          {:cont, {:ok, Policies.update_policies(acc, extension, :write, true)}}
 
-          {:error, %Postgrex.Error{postgres: %{code: :insufficient_privilege}}} ->
-            {:cont, {:ok, Policies.update_policies(acc, extension, :write, false)}}
+        {:error, %Postgrex.Error{postgres: %{code: :insufficient_privilege}}} ->
+          {:cont, {:ok, Policies.update_policies(acc, extension, :write, false)}}
 
-          {:error, reason} ->
-            {:halt, {:error, reason}}
-        end
-      else
-        {:cont, {:ok, Policies.update_policies(acc, extension, :write, false)}}
+        {:error, reason} ->
+          {:halt, {:error, reason}}
       end
     end)
   end

--- a/lib/realtime/tenants/batch_broadcast.ex
+++ b/lib/realtime/tenants/batch_broadcast.ex
@@ -159,7 +159,7 @@ defmodule Realtime.Tenants.BatchBroadcast do
         |> Map.put(:topic, topic)
         |> Authorization.build_authorization_params()
 
-      case Authorization.get_write_authorizations(db_conn, auth_params) do
+      case Authorization.get_write_authorizations(db_conn, auth_params, :broadcast) do
         {:ok, policies} -> policies
         {:error, :not_found} -> nil
         error -> error

--- a/lib/realtime/tenants/single_broadcast.ex
+++ b/lib/realtime/tenants/single_broadcast.ex
@@ -204,7 +204,7 @@ defmodule Realtime.Tenants.SingleBroadcast do
   defp permissions_for_message(tenant, auth_params, topic) do
     with {:ok, db_conn} <- Connect.lookup_or_start_connection(tenant.external_id) do
       auth_params = %{auth_params | topic: topic}
-      Authorization.get_write_authorizations(db_conn, auth_params)
+      Authorization.get_write_authorizations(db_conn, auth_params, :broadcast)
     end
   end
 

--- a/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
@@ -172,7 +172,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
          db_conn,
          authorization_context
        ) do
-    Authorization.get_write_authorizations(policies, db_conn, authorization_context, presence_enabled?: false)
+    Authorization.get_write_authorizations(policies, db_conn, authorization_context, :broadcast)
   end
 
   defp run_authorization_check(socket, _db_conn, _authorization_context) do

--- a/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/broadcast_handler.ex
@@ -172,7 +172,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandler do
          db_conn,
          authorization_context
        ) do
-    Authorization.get_write_authorizations(policies, db_conn, authorization_context)
+    Authorization.get_write_authorizations(policies, db_conn, authorization_context, presence_enabled?: false)
   end
 
   defp run_authorization_check(socket, _db_conn, _authorization_context) do

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -91,7 +91,12 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
     # presence_diff for this socket, then authorize presence.write.
     with {:ok, policies} <- maybe_authorize_presence_read(policies, db_conn, authorization_context),
          {:ok, policies} <-
-           Authorization.get_write_authorizations(policies, db_conn, authorization_context, presence_enabled?: true) do
+           Authorization.get_write_authorizations(
+             policies,
+             db_conn,
+             authorization_context,
+             broadcast_enabled?: false
+           ) do
       socket = assign(socket, :policies, policies)
       handle_presence_event("track", payload, db_conn, socket)
     else

--- a/lib/realtime_web/channels/realtime_channel/presence_handler.ex
+++ b/lib/realtime_web/channels/realtime_channel/presence_handler.ex
@@ -95,7 +95,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandler do
              policies,
              db_conn,
              authorization_context,
-             broadcast_enabled?: false
+             :presence
            ) do
       socket = assign(socket, :policies, policies)
       handle_presence_event("track", payload, db_conn, socket)

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -217,7 +217,8 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
         Authorization.get_write_authorizations(
           %Policies{},
           context.db_conn,
-          context.authorization_context
+          context.authorization_context,
+          :broadcast
         )
 
       # Wait enough time for the poll rate to be triggered at least once

--- a/test/realtime/tenants/authorization_remote_test.exs
+++ b/test/realtime/tenants/authorization_remote_test.exs
@@ -44,7 +44,16 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
         Authorization.get_write_authorizations(
           policies,
           context.db_conn,
-          context.authorization_context
+          context.authorization_context,
+          :broadcast
+        )
+
+      {:ok, policies} =
+        Authorization.get_write_authorizations(
+          policies,
+          context.db_conn,
+          context.authorization_context,
+          :presence
         )
 
       assert %Policies{
@@ -72,7 +81,16 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
         Authorization.get_write_authorizations(
           policies,
           context.db_conn,
-          context.authorization_context
+          context.authorization_context,
+          :broadcast
+        )
+
+      {:ok, policies} =
+        Authorization.get_write_authorizations(
+          policies,
+          context.db_conn,
+          context.authorization_context,
+          :presence
         )
 
       assert %Policies{
@@ -90,7 +108,7 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
         Authorization.get_read_authorizations(%Policies{}, db_conn, context.authorization_context)
 
       {:error, :increase_connection_pool} =
-        Authorization.get_write_authorizations(%Policies{}, db_conn, context.authorization_context)
+        Authorization.get_write_authorizations(%Policies{}, db_conn, context.authorization_context, :broadcast)
     end
 
     @tag role: "anon", policies: []
@@ -125,7 +143,7 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
         capture_log(fn ->
           for _ <- 1..6 do
             {:error, :increase_connection_pool} =
-              Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context)
+              Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context, :broadcast)
           end
 
           rate_counter = Realtime.Tenants.authorization_errors_per_second_rate(context.tenant)
@@ -133,7 +151,7 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
 
           for _ <- 1..10 do
             {:error, :increase_connection_pool} =
-              Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context)
+              Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context, :broadcast)
           end
         end)
 
@@ -177,7 +195,8 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
                        Authorization.get_write_authorizations(
                          %Policies{},
                          context.db_conn,
-                         context.authorization_context
+                         context.authorization_context,
+                         :broadcast
                        )
             end)
 
@@ -208,7 +227,8 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
                Authorization.get_write_authorizations(
                  %Policies{},
                  context.db_conn,
-                 context.authorization_context
+                 context.authorization_context,
+                 :presence
                )
 
       assert {:error, :rls_policy_error, %Postgrex.Error{}} =
@@ -222,14 +242,16 @@ defmodule Realtime.Tenants.AuthorizationRemoteTest do
                Authorization.get_write_authorizations(
                  %Policies{},
                  context.db_conn,
-                 context.authorization_context
+                 context.authorization_context,
+                 :presence
                )
 
       assert {:error, :rls_policy_error, %Postgrex.Error{}} =
                Authorization.get_write_authorizations(
                  %Policies{},
                  context.db_conn,
-                 context.authorization_context
+                 context.authorization_context,
+                 :presence
                )
     end
   end

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -73,10 +73,23 @@ defmodule Realtime.Tenants.AuthorizationTest do
           presence_enabled?: false
         )
 
-      # presence.read is left unevaluated (nil) since presence was not checked; write is false.
+      # Presence is left unevaluated since it was not checked.
       assert %Policies{
                broadcast: %BroadcastPolicies{read: true, write: true},
-               presence: %PresencePolicies{read: nil, write: false}
+               presence: %PresencePolicies{read: nil, write: nil}
+             } == policies
+    end
+
+    @tag role: "authenticated", policies: [:authenticated_write_presence]
+    test "skips broadcast RLS check when broadcast is disabled", context do
+      {:ok, policies} =
+        Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context,
+          broadcast_enabled?: false
+        )
+
+      assert %Policies{
+               broadcast: %BroadcastPolicies{read: nil, write: nil},
+               presence: %PresencePolicies{read: nil, write: true}
              } == policies
     end
 

--- a/test/realtime/tenants/authorization_test.exs
+++ b/test/realtime/tenants/authorization_test.exs
@@ -27,7 +27,10 @@ defmodule Realtime.Tenants.AuthorizationTest do
         Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
 
       {:ok, policies} =
-        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context)
+        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context, :broadcast)
+
+      {:ok, policies} =
+        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context, :presence)
 
       assert %Policies{
                broadcast: %BroadcastPolicies{read: true, write: true},
@@ -62,16 +65,14 @@ defmodule Realtime.Tenants.AuthorizationTest do
 
     @tag role: "authenticated",
          policies: [:authenticated_read_broadcast, :authenticated_write_broadcast]
-    test "skips presence RLS check when presence is disabled", context do
+    test "checks only the requested broadcast write policy", context do
       {:ok, policies} =
         Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context,
           presence_enabled?: false
         )
 
       {:ok, policies} =
-        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context,
-          presence_enabled?: false
-        )
+        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context, :broadcast)
 
       # Presence is left unevaluated since it was not checked.
       assert %Policies{
@@ -81,11 +82,9 @@ defmodule Realtime.Tenants.AuthorizationTest do
     end
 
     @tag role: "authenticated", policies: [:authenticated_write_presence]
-    test "skips broadcast RLS check when broadcast is disabled", context do
+    test "checks only the requested presence write policy", context do
       {:ok, policies} =
-        Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context,
-          broadcast_enabled?: false
-        )
+        Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context, :presence)
 
       assert %Policies{
                broadcast: %BroadcastPolicies{read: nil, write: nil},
@@ -103,7 +102,10 @@ defmodule Realtime.Tenants.AuthorizationTest do
         Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
 
       {:ok, policies} =
-        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context)
+        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context, :broadcast)
+
+      {:ok, policies} =
+        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context, :presence)
 
       assert %Policies{
                broadcast: %BroadcastPolicies{read: false, write: false},
@@ -119,7 +121,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
         Authorization.get_read_authorizations(%Policies{}, pid, context.authorization_context)
 
       {:error, :increase_connection_pool} =
-        Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context)
+        Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context, :broadcast)
     end
 
     @tag role: "anon", policies: []
@@ -157,7 +159,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
         capture_log(fn ->
           for _ <- 1..6 do
             {:error, :increase_connection_pool} =
-              Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context)
+              Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context, :broadcast)
           end
 
           rate_counter = Realtime.Tenants.authorization_errors_per_second_rate(context.tenant)
@@ -166,7 +168,7 @@ defmodule Realtime.Tenants.AuthorizationTest do
 
           for _ <- 1..10 do
             {:error, :increase_connection_pool} =
-              Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context)
+              Authorization.get_write_authorizations(%Policies{}, pid, context.authorization_context, :broadcast)
           end
         end)
 
@@ -208,7 +210,8 @@ defmodule Realtime.Tenants.AuthorizationTest do
                        Authorization.get_write_authorizations(
                          %Policies{},
                          context.db_conn,
-                         context.authorization_context
+                         context.authorization_context,
+                         :broadcast
                        )
             end)
 
@@ -233,16 +236,31 @@ defmodule Realtime.Tenants.AuthorizationTest do
                Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
 
       assert {:error, :rls_policy_error, %Postgrex.Error{}} =
-               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context,
+                 :presence
+               )
 
       assert {:error, :rls_policy_error, %Postgrex.Error{}} =
                Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
 
       assert {:error, :rls_policy_error, %Postgrex.Error{}} =
-               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context,
+                 :presence
+               )
 
       assert {:error, :rls_policy_error, %Postgrex.Error{}} =
-               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context,
+                 :presence
+               )
     end
   end
 
@@ -254,7 +272,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
          ]
     test "authenticated user has expected policies", context do
       {:ok, _} = Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
-      {:ok, _} = Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+
+      {:ok, policies} =
+        Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context, :broadcast)
+
+      {:ok, _} =
+        Authorization.get_write_authorizations(policies, context.db_conn, context.authorization_context, :presence)
 
       {:ok, db_conn} = Database.connect(context.tenant, "realtime_test")
       assert {:ok, []} = Repo.all(db_conn, Message, Message)
@@ -273,7 +296,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
                Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
 
       assert {:error, :rls_policy_error, %Postgrex.Error{}} =
-               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context,
+                 :broadcast
+               )
     end
 
     @tag role: "anon", policies: []
@@ -290,7 +318,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
                Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
 
       assert {:error, :query_canceled, %Postgrex.Error{}} =
-               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context,
+                 :broadcast
+               )
     end
 
     @tag role: "anon", policies: []
@@ -311,7 +344,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
                Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
 
       assert {:error, :missing_partition} =
-               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context,
+                 :broadcast
+               )
     end
 
     @tag role: "anon", policies: []
@@ -324,7 +362,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
                Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
 
       assert {:error, :tenant_database_unavailable} =
-               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context,
+                 :broadcast
+               )
     end
 
     @tag role: "anon", policies: []
@@ -342,7 +385,12 @@ defmodule Realtime.Tenants.AuthorizationTest do
       stub(Repo, :insert, fn _, _, _, _ -> {:error, conn_error} end)
 
       assert {:error, :tenant_database_unavailable} =
-               Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+               Authorization.get_write_authorizations(
+                 %Policies{},
+                 context.db_conn,
+                 context.authorization_context,
+                 :broadcast
+               )
     end
 
     @tag role: "anon", policies: []
@@ -381,7 +429,14 @@ defmodule Realtime.Tenants.AuthorizationTest do
       )
 
       {:ok, _} = Authorization.get_read_authorizations(%Policies{}, context.db_conn, context.authorization_context)
-      {:ok, _} = Authorization.get_write_authorizations(%Policies{}, context.db_conn, context.authorization_context)
+
+      {:ok, _} =
+        Authorization.get_write_authorizations(
+          %Policies{},
+          context.db_conn,
+          context.authorization_context,
+          :broadcast
+        )
 
       external_id = context.authorization_context.tenant_id
 

--- a/test/realtime/tenants/batch_broadcast_test.exs
+++ b/test/realtime/tenants/batch_broadcast_test.exs
@@ -146,7 +146,9 @@ defmodule Realtime.Tenants.BatchBroadcastTest do
 
       Authorization
       |> expect(:build_authorization_params, fn params -> params end)
-      |> expect(:get_write_authorizations, fn _, _ -> {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}} end)
+      |> expect(:get_write_authorizations, fn _, _, :broadcast ->
+        {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
+      end)
 
       expect(TenantBroadcaster, :pubsub_broadcast, 1, fn _, _, _, _, _ -> :ok end)
 
@@ -169,7 +171,7 @@ defmodule Realtime.Tenants.BatchBroadcastTest do
 
       Authorization
       |> expect(:build_authorization_params, 1, fn params -> params end)
-      |> expect(:get_write_authorizations, 1, fn _, _ ->
+      |> expect(:get_write_authorizations, 1, fn _, _, :broadcast ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: false}}}
       end)
 
@@ -211,8 +213,8 @@ defmodule Realtime.Tenants.BatchBroadcastTest do
       Authorization
       |> expect(:build_authorization_params, 2, fn params -> params end)
       |> expect(:get_write_authorizations, 2, fn
-        _, %{topic: ^topic} -> %Policies{broadcast: %BroadcastPolicies{write: true}}
-        _, _ -> %Policies{broadcast: %BroadcastPolicies{write: false}}
+        _, %{topic: ^topic}, :broadcast -> %Policies{broadcast: %BroadcastPolicies{write: true}}
+        _, _, :broadcast -> %Policies{broadcast: %BroadcastPolicies{write: false}}
       end)
 
       # Only one topic will actually be broadcasted
@@ -251,7 +253,7 @@ defmodule Realtime.Tenants.BatchBroadcastTest do
 
       Authorization
       |> expect(:build_authorization_params, 2, fn params -> params end)
-      |> expect(:get_write_authorizations, 2, fn _, _ ->
+      |> expect(:get_write_authorizations, 2, fn _, _, :broadcast ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
       end)
 
@@ -324,7 +326,7 @@ defmodule Realtime.Tenants.BatchBroadcastTest do
 
       Authorization
       |> expect(:build_authorization_params, fn params -> params end)
-      |> expect(:get_write_authorizations, fn _, _ ->
+      |> expect(:get_write_authorizations, fn _, _, :broadcast ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
       end)
 

--- a/test/realtime/tenants/single_broadcast_test.exs
+++ b/test/realtime/tenants/single_broadcast_test.exs
@@ -145,7 +145,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
 
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
 
-      expect(Authorization, :get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
       end)
 
@@ -171,7 +171,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
           sub: sub
         })
 
-      expect(Authorization, :get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: false}}}
       end)
 
@@ -204,7 +204,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
 
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
 
-      expect(Authorization, :get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
       end)
 
@@ -236,7 +236,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
           sub: sub
         })
 
-      expect(Authorization, :get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: false}}}
       end)
 
@@ -427,7 +427,7 @@ defmodule Realtime.Tenants.SingleBroadcastTest do
       expect(GenCounter, :add, fn ^broadcast_events_key -> :ok end)
       expect(Connect, :lookup_or_start_connection, fn _ -> {:ok, db_conn} end)
 
-      expect(Authorization, :get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast ->
         {:ok, %Policies{broadcast: %BroadcastPolicies{write: true}}}
       end)
 

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -16,6 +16,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
   alias Realtime.Tenants.Authorization
   alias Realtime.Tenants.Authorization.Policies
   alias Realtime.Tenants.Authorization.Policies.BroadcastPolicies
+  alias Realtime.Tenants.Authorization.Policies.PresencePolicies
   alias Realtime.Tenants.Connect
   alias RealtimeWeb.Endpoint
   alias RealtimeWeb.RealtimeChannel.BroadcastHandler
@@ -182,17 +183,24 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
          %{topic: topic, tenant: tenant, db_conn: db_conn, serializer: serializer} do
       socket = socket_fixture(tenant, topic)
 
-      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context ->
-        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context])
+      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
+        assert opts == [presence_enabled?: false]
+        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
       end)
 
-      reject(&Authorization.get_write_authorizations/3)
+      reject(&Authorization.get_write_authorizations/4)
 
-      for _ <- 1..100, reduce: socket do
-        socket ->
-          {:reply, :ok, socket} = BroadcastHandler.handle(@payload, db_conn, socket)
-          socket
-      end
+      socket =
+        for _ <- 1..100, reduce: socket do
+          socket ->
+            {:reply, :ok, socket} = BroadcastHandler.handle(@payload, db_conn, socket)
+            socket
+        end
+
+      assert %Policies{
+               broadcast: %BroadcastPolicies{write: true},
+               presence: %PresencePolicies{write: nil}
+             } = socket.assigns.policies
 
       for _ <- 1..100 do
         topic = "realtime:#{topic}"
@@ -204,8 +212,9 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
     test "validation only runs once on nil and blocking policies", %{topic: topic, tenant: tenant, db_conn: db_conn} do
       socket = socket_fixture(tenant, topic)
 
-      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context ->
-        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context])
+      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
+        assert opts == [presence_enabled?: false]
+        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
       end)
 
       for _ <- 1..100, reduce: socket do
@@ -361,7 +370,7 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
          %{topic: topic, tenant: tenant, db_conn: db_conn} do
       socket = socket_fixture(tenant, topic)
 
-      stub(Authorization, :get_write_authorizations, fn _, _, _ -> {:error, :increase_connection_pool} end)
+      stub(Authorization, :get_write_authorizations, fn _, _, _, _ -> {:error, :increase_connection_pool} end)
 
       log =
         capture_log(fn ->

--- a/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/broadcast_handler_test.exs
@@ -183,9 +183,9 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
          %{topic: topic, tenant: tenant, db_conn: db_conn, serializer: serializer} do
       socket = socket_fixture(tenant, topic)
 
-      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
-        assert opts == [presence_enabled?: false]
-        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
+      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, extension ->
+        assert extension == :broadcast
+        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, extension])
       end)
 
       reject(&Authorization.get_write_authorizations/4)
@@ -212,9 +212,9 @@ defmodule RealtimeWeb.RealtimeChannel.BroadcastHandlerTest do
     test "validation only runs once on nil and blocking policies", %{topic: topic, tenant: tenant, db_conn: db_conn} do
       socket = socket_fixture(tenant, topic)
 
-      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
-        assert opts == [presence_enabled?: false]
-        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
+      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, extension ->
+        assert extension == :broadcast
+        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, extension])
       end)
 
       for _ <- 1..100, reduce: socket do

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -257,6 +257,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "only checks write policies once on private channels", %{tenant: tenant, topic: topic, db_conn: db_conn} do
       expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
+        assert opts == [broadcast_enabled?: false]
         call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
       end)
 
@@ -280,6 +281,28 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
           assert_receive %Broadcast{topic: ^topic, event: "presence_diff"}
           socket
       end
+    end
+
+    @tag policies: [:authenticated_read_presence, :authenticated_write_presence]
+    test "leaves broadcast write policy unevaluated when tracking presence", %{
+      tenant: tenant,
+      topic: topic,
+      db_conn: db_conn
+    } do
+      key = random_string()
+      socket = socket_fixture(tenant, topic, key)
+
+      assert {:ok, socket} =
+               PresenceHandler.handle(
+                 %{"event" => "track", "payload" => %{"metadata" => random_string()}},
+                 db_conn,
+                 socket
+               )
+
+      assert %Policies{
+               broadcast: %BroadcastPolicies{write: nil},
+               presence: %PresencePolicies{write: true}
+             } = socket.assigns.policies
     end
 
     test "increase_connection_pool from write authorization returns error and does not log UnableToSetPolicies",

--- a/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
+++ b/test/realtime_web/channels/realtime_channel/presence_handler_test.exs
@@ -256,12 +256,10 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :authenticated_write_broadcast_and_presence]
     test "only checks write policies once on private channels", %{tenant: tenant, topic: topic, db_conn: db_conn} do
-      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
-        assert opts == [broadcast_enabled?: false]
-        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
+      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, extension ->
+        assert extension == :presence
+        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, extension])
       end)
-
-      reject(&Authorization.get_write_authorizations/3)
 
       key = random_string()
       # Use high client rate limit to test tenant-level rate limiting
@@ -327,8 +325,9 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
 
     @tag policies: [:authenticated_read_broadcast_and_presence, :broken_write_presence]
     test "handle failing rls policy", %{tenant: tenant, topic: topic, db_conn: db_conn} do
-      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, opts ->
-        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, opts])
+      expect(Authorization, :get_write_authorizations, 1, fn conn, db_conn, auth_context, extension ->
+        assert extension == :presence
+        call_original(Authorization, :get_write_authorizations, [conn, db_conn, auth_context, extension])
       end)
 
       key = random_string()
@@ -351,7 +350,7 @@ defmodule RealtimeWeb.RealtimeChannel.PresenceHandlerTest do
     end
 
     test "does not check write policies once on public channels", %{tenant: tenant, topic: topic} do
-      reject(&Authorization.get_write_authorizations/3)
+      reject(&Authorization.get_write_authorizations/4)
 
       key = random_string()
       policies = %Policies{broadcast: %BroadcastPolicies{read: false}}

--- a/test/realtime_web/controllers/broadcast_single_controller_test.exs
+++ b/test/realtime_web/controllers/broadcast_single_controller_test.exs
@@ -510,7 +510,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       request_events_key = Tenants.requests_per_second_key(tenant)
       expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
-      expect(Authorization, :get_write_authorizations, fn _, _ ->
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast ->
         {:error, :query_canceled,
          %Postgrex.Error{postgres: %{code: :query_canceled, message: "canceling statement due to user request"}}}
       end)
@@ -528,7 +528,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       request_events_key = Tenants.requests_per_second_key(tenant)
       expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
-      expect(Authorization, :get_write_authorizations, fn _, _ -> {:error, :missing_partition} end)
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast -> {:error, :missing_partition} end)
 
       conn =
         conn
@@ -543,7 +543,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       request_events_key = Tenants.requests_per_second_key(tenant)
       expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
-      expect(Authorization, :get_write_authorizations, fn _, _ -> {:error, :increase_connection_pool} end)
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast -> {:error, :increase_connection_pool} end)
 
       conn =
         conn
@@ -558,7 +558,9 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       request_events_key = Tenants.requests_per_second_key(tenant)
       expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
-      expect(Authorization, :get_write_authorizations, fn _, _ -> {:error, :tenant_database_unavailable} end)
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast ->
+        {:error, :tenant_database_unavailable}
+      end)
 
       conn =
         conn
@@ -573,7 +575,7 @@ defmodule RealtimeWeb.BroadcastSingleControllerTest do
       request_events_key = Tenants.requests_per_second_key(tenant)
       expect(GenCounter, :add, fn ^request_events_key -> :ok end)
 
-      expect(Authorization, :get_write_authorizations, fn _, _ -> {:error, "boom"} end)
+      expect(Authorization, :get_write_authorizations, fn _, _, :broadcast -> {:error, "boom"} end)
 
       conn =
         conn


### PR DESCRIPTION
## Summary

- require every write-authorization probe to select exactly `:broadcast` or `:presence`
- keep the unselected extension policy unevaluated so each feature authorizes itself on first use
- pass the explicit extension from channel presence/broadcast handlers and the SingleBroadcast and BatchBroadcast paths
- add regression coverage for presence-only tracking and lazy broadcast authorization

Closes #1953

## Verification

- `mix compile --force --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo` (no issues)
- `mix deps.unlock --check-unused`
- `mix sobelow --config .sobelow-conf`
- GitHub Actions database matrix requested; currently awaiting maintainer workflow approval
- `mix hex.audit` reports the locked `cowlib 2.19.0` advisory; this branch does not change `mix.lock`
