### PR TITLE
fix: handle explicit override on tenant feature flags

### DIFF
--- a/lib/realtime/feature_flags.ex
+++ b/lib/realtime/feature_flags.ex
@@ -45,6 +45,23 @@ defmodule Realtime.FeatureFlags do
     end
   end
 
+  @doc """
+  Removes a tenant's explicit override for `flag_name`, so the tenant falls back
+  to the global enabled/rollout resolution. A no-op if no override is present.
+  """
+  @spec clear_tenant_flag(String.t(), String.t()) ::
+          {:ok, Realtime.Api.Tenant.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def clear_tenant_flag(flag_name, tenant_id) when is_binary(flag_name) and is_binary(tenant_id) do
+    case Api.get_tenant_by_external_id(tenant_id, use_replica?: false) do
+      nil ->
+        {:error, :not_found}
+
+      tenant ->
+        updated_flags = Map.delete(tenant.feature_flags, flag_name)
+        Api.update_tenant_by_external_id(tenant_id, %{feature_flags: updated_flags})
+    end
+  end
+
   @spec enabled?(String.t()) :: boolean()
   def enabled?(flag_name) when is_binary(flag_name) do
     case Cache.get_flag(flag_name) do

--- a/lib/realtime_web/dashboard/feature_flags.ex
+++ b/lib/realtime_web/dashboard/feature_flags.ex
@@ -126,6 +126,19 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
     end
   end
 
+  @impl true
+  def handle_event("clear_tenant_flag", %{"flag_name" => flag_name}, socket) do
+    tenant = socket.assigns.found_tenant
+
+    case FeatureFlags.clear_tenant_flag(flag_name, tenant.external_id) do
+      {:ok, updated_tenant} ->
+        {:noreply, assign(socket, found_tenant: updated_tenant)}
+
+      {:error, _} ->
+        {:noreply, assign(socket, tenant_error: "Failed to clear tenant flag")}
+    end
+  end
+
   defp reset_tenant_state(socket, extra \\ []) do
     assign(socket, [managing_id: nil, tenant_search: "", found_tenant: nil, tenant_error: nil] ++ extra)
   end
@@ -261,25 +274,52 @@ defmodule RealtimeWeb.Dashboard.FeatureFlags do
                   <% end %>
 
                   <%= if @found_tenant do %>
-                    <% flag_enabled = Map.get(@found_tenant.feature_flags, flag.name, FeatureFlags.enabled?(flag.name, @found_tenant.external_id)) %>
+                    <% override = Map.get(@found_tenant.feature_flags, flag.name) %>
+                    <% inherited = FeatureFlags.enabled?(flag.name, @found_tenant.external_id) %>
                     <div style="display: flex; align-items: center; gap: 1rem; padding: 0.5rem 0.75rem; background: white; border-radius: 4px; border: 1px solid #dee2e6;">
                       <code><%= @found_tenant.external_id %></code>
                       <span class="text-muted">—</span>
-                      <div style="display: flex; align-items: center; gap: 0.5rem;">
+                      <%= case override do %>
+                        <% true -> %>
+                          <span class="badge" style="background: #22c55e; color: white;">Override: Enabled</span>
+                        <% false -> %>
+                          <span class="badge" style="background: #6b7280; color: white;">Override: Disabled</span>
+                        <% nil -> %>
+                          <span class="badge" style="background: #e5e7eb; color: #374151;">
+                            No override · inheriting <%= if inherited, do: "Enabled", else: "Disabled" %>
+                          </span>
+                      <% end %>
+                      <div style="display: flex; gap: 0.5rem; margin-left: auto;">
                         <button
                           type="button"
                           phx-click="set_tenant_flag"
                           phx-value-flag_name={flag.name}
-                          phx-value-enabled={to_string(!flag_enabled)}
-                          role="switch"
-                          aria-checked={to_string(flag_enabled)}
-                          style={"position: relative; display: inline-flex; align-items: center; width: 44px; height: 24px; border-radius: 9999px; border: none; outline: none; cursor: pointer; padding: 0; transition: background-color 0.2s ease; background-color: #{if flag_enabled, do: "#22c55e", else: "#9ca3af"};"}
+                          phx-value-enabled="true"
+                          disabled={override == true}
+                          class={"btn btn-sm #{if override == true, do: "btn-success", else: "btn-outline-success"}"}
                         >
-                          <span style={"display: block; width: 18px; height: 18px; border-radius: 50%; background: white; box-shadow: 0 1px 3px rgba(0,0,0,0.2); transition: transform 0.2s ease; transform: translateX(#{if flag_enabled, do: "23px", else: "3px"});"} />
+                          Enable
                         </button>
-                        <span style={"font-size: 0.8125rem; font-weight: 500; color: #{if flag_enabled, do: "#16a34a", else: "#6b7280"};"}>
-                          <%= if flag_enabled, do: "Enabled", else: "Disabled" %>
-                        </span>
+                        <button
+                          type="button"
+                          phx-click="set_tenant_flag"
+                          phx-value-flag_name={flag.name}
+                          phx-value-enabled="false"
+                          disabled={override == false}
+                          class={"btn btn-sm #{if override == false, do: "btn-secondary", else: "btn-outline-secondary"}"}
+                        >
+                          Disable
+                        </button>
+                        <%= if override != nil do %>
+                          <button
+                            type="button"
+                            phx-click="clear_tenant_flag"
+                            phx-value-flag_name={flag.name}
+                            class="btn btn-sm btn-outline-danger"
+                          >
+                            Clear override
+                          </button>
+                        <% end %>
                       </div>
                     </div>
                   <% end %>

--- a/test/realtime/feature_flags_test.exs
+++ b/test/realtime/feature_flags_test.exs
@@ -232,6 +232,57 @@ defmodule Realtime.FeatureFlagsTest do
     end
   end
 
+  describe "set_tenant_flag/3" do
+    test "writes an explicit override into the tenant's feature_flags map" do
+      tenant = tenant_fixture(%{feature_flags: %{}})
+
+      assert {:ok, updated} = FeatureFlags.set_tenant_flag("some_flag", tenant.external_id, true)
+      assert updated.feature_flags == %{"some_flag" => true}
+    end
+
+    test "returns {:error, :not_found} for an unknown tenant" do
+      assert {:error, :not_found} = FeatureFlags.set_tenant_flag("some_flag", "nonexistent_tenant", true)
+    end
+  end
+
+  describe "clear_tenant_flag/2" do
+    test "removes the override so the tenant falls back to global resolution" do
+      {:ok, _} = Api.upsert_feature_flag(%{name: "clearable_flag", enabled: true, rollout_percentage: 100})
+      tenant = tenant_fixture(%{feature_flags: %{"clearable_flag" => false}})
+
+      # Override forces it off despite the global 100% rollout.
+      refute FeatureFlags.enabled?("clearable_flag", tenant.external_id)
+
+      assert {:ok, updated} = FeatureFlags.clear_tenant_flag("clearable_flag", tenant.external_id)
+      refute Map.has_key?(updated.feature_flags, "clearable_flag")
+
+      # The tenant cache is refreshed via an async multicast; clear it so enabled?/2
+      # reads the updated row instead of the pre-clear override.
+      Cachex.clear(TenantsCache)
+
+      # With the override gone, the tenant inherits the global rollout again.
+      assert FeatureFlags.enabled?("clearable_flag", tenant.external_id)
+    end
+
+    test "leaves other overrides untouched" do
+      tenant = tenant_fixture(%{feature_flags: %{"a" => true, "b" => false}})
+
+      assert {:ok, updated} = FeatureFlags.clear_tenant_flag("a", tenant.external_id)
+      assert updated.feature_flags == %{"b" => false}
+    end
+
+    test "is a no-op when there is no override" do
+      tenant = tenant_fixture(%{feature_flags: %{}})
+
+      assert {:ok, updated} = FeatureFlags.clear_tenant_flag("missing", tenant.external_id)
+      assert updated.feature_flags == %{}
+    end
+
+    test "returns {:error, :not_found} for an unknown tenant" do
+      assert {:error, :not_found} = FeatureFlags.clear_tenant_flag("some_flag", "nonexistent_tenant")
+    end
+  end
+
   describe "enabled?/1 ignores rollout percentage" do
     test "returns true for an enabled flag even with a 0% rollout percentage" do
       {:ok, _} = Api.upsert_feature_flag(%{name: "global_ignores_rollout", enabled: true, rollout_percentage: 0})

--- a/test/realtime_web/dashboard/feature_flags_test.exs
+++ b/test/realtime_web/dashboard/feature_flags_test.exs
@@ -1,0 +1,151 @@
+defmodule RealtimeWeb.Dashboard.FeatureFlagsTest do
+  use RealtimeWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Realtime.Api
+  alias Realtime.FeatureFlags.Cache
+  alias Realtime.Tenants.Cache, as: TenantsCache
+
+  @path "/admin/dashboard/feature_flags"
+
+  setup_all do
+    Application.put_env(:realtime, :dashboard_auth, :basic_auth)
+    Application.put_env(:realtime, :dashboard_credentials, {"user", "pass"})
+
+    on_exit(fn ->
+      Application.delete_env(:realtime, :dashboard_auth)
+      Application.delete_env(:realtime, :dashboard_credentials)
+    end)
+
+    :ok
+  end
+
+  setup do
+    # These caches are global (not sandboxed); clear them so a flag/tenant from a
+    # previous test can't be served stale.
+    Cachex.clear(Cache)
+    Cachex.clear(TenantsCache)
+    conn = using_basic_auth(build_conn(), "user", "pass")
+    %{conn: conn}
+  end
+
+  test "renders the page with an existing flag", %{conn: conn} do
+    flag_fixture(%{name: "render_flag"})
+
+    {:ok, _view, html} = live(conn, @path)
+
+    assert html =~ "Feature Flags"
+    assert html =~ "render_flag"
+  end
+
+  test "creates a new flag", %{conn: conn} do
+    {:ok, view, _html} = live(conn, @path)
+
+    html = view |> element("form[phx-submit='create']") |> render_submit(%{name: "brand_new_flag"})
+
+    assert html =~ "brand_new_flag"
+  end
+
+  test "toggles a flag's global enabled state", %{conn: conn} do
+    flag = flag_fixture(%{name: "toggle_flag", enabled: false})
+
+    {:ok, view, html} = live(conn, @path)
+    assert html =~ "Disabled"
+
+    html = view |> element("button[phx-click='toggle'][phx-value-id='#{flag.id}']") |> render_click()
+    assert html =~ "Enabled"
+  end
+
+  describe "tenant override manager" do
+    test "shows 'No override' with Enable/Disable and no Clear when the tenant has no override",
+         %{conn: conn} do
+      flag = flag_fixture(%{name: "no_override_flag", enabled: true})
+      tenant = tenant_fixture(%{feature_flags: %{}})
+
+      {:ok, view, _html} = live(conn, @path)
+      html = open_and_search(view, flag, tenant.external_id)
+
+      assert html =~ tenant.external_id
+      assert html =~ "No override"
+      # Both set actions are available, but there is nothing to clear yet.
+      assert html =~ "set_tenant_flag"
+      refute html =~ "clear_tenant_flag"
+    end
+
+    test "shows 'Override: Enabled' and a Clear override action for an explicitly enabled tenant",
+         %{conn: conn} do
+      flag = flag_fixture(%{name: "override_on_flag", enabled: false})
+      tenant = tenant_fixture(%{feature_flags: %{"override_on_flag" => true}})
+
+      {:ok, view, _html} = live(conn, @path)
+      html = open_and_search(view, flag, tenant.external_id)
+
+      assert html =~ "Override: Enabled"
+      assert html =~ "clear_tenant_flag"
+    end
+
+    test "shows 'Override: Disabled' for an explicitly disabled tenant", %{conn: conn} do
+      flag = flag_fixture(%{name: "override_off_flag", enabled: true})
+      tenant = tenant_fixture(%{feature_flags: %{"override_off_flag" => false}})
+
+      {:ok, view, _html} = live(conn, @path)
+      html = open_and_search(view, flag, tenant.external_id)
+
+      assert html =~ "Override: Disabled"
+      assert html =~ "clear_tenant_flag"
+    end
+
+    test "Enable button writes an explicit override", %{conn: conn} do
+      flag = flag_fixture(%{name: "enable_flag", enabled: false})
+      tenant = tenant_fixture(%{feature_flags: %{}})
+
+      {:ok, view, _html} = live(conn, @path)
+      open_and_search(view, flag, tenant.external_id)
+
+      html = view |> element("button[phx-click='set_tenant_flag'][phx-value-enabled='true']") |> render_click()
+      assert html =~ "Override: Enabled"
+
+      updated = Api.get_tenant_by_external_id(tenant.external_id, use_replica?: false)
+      assert updated.feature_flags == %{"enable_flag" => true}
+    end
+
+    test "Clear override button removes the override", %{conn: conn} do
+      flag = flag_fixture(%{name: "clear_flag", enabled: false})
+      tenant = tenant_fixture(%{feature_flags: %{"clear_flag" => true}})
+
+      {:ok, view, _html} = live(conn, @path)
+      open_and_search(view, flag, tenant.external_id)
+
+      html = view |> element("button[phx-click='clear_tenant_flag']") |> render_click()
+      assert html =~ "No override"
+
+      updated = Api.get_tenant_by_external_id(tenant.external_id, use_replica?: false)
+      assert updated.feature_flags == %{}
+    end
+
+    test "shows an error for an unknown tenant", %{conn: conn} do
+      flag = flag_fixture(%{name: "unknown_tenant_flag", enabled: false})
+
+      {:ok, view, _html} = live(conn, @path)
+      view |> element("button[phx-click='open_tenant_manager'][phx-value-id='#{flag.id}']") |> render_click()
+      html = view |> element("form[phx-submit='search_tenant']") |> render_submit(%{tenant_id: "nonexistent"})
+
+      assert html =~ "Tenant not found"
+    end
+  end
+
+  defp flag_fixture(attrs) do
+    {:ok, flag} = Api.upsert_feature_flag(Map.merge(%{name: random_string(), enabled: false}, attrs))
+    flag
+  end
+
+  defp open_and_search(view, flag, tenant_id) do
+    view |> element("button[phx-click='open_tenant_manager'][phx-value-id='#{flag.id}']") |> render_click()
+    view |> element("form[phx-submit='search_tenant']") |> render_submit(%{tenant_id: tenant_id})
+  end
+
+  defp using_basic_auth(conn, username, password) do
+    header_content = "Basic " <> Base.encode64("#{username}:#{password}")
+    put_req_header(conn, "authorization", header_content)
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

display flag overrides explicitly and allow to clear feature flags

<img width="1203" height="193" alt="Phoenix_LiveDashboard" src="https://github.com/user-attachments/assets/6f432fa3-0d08-40e4-8b10-92f846c34121" />

<img width="1194" height="196" alt="Phoenix_LiveDashboard" src="https://github.com/user-attachments/assets/59a8ea41-97cc-4a00-8097-ce8d1681f5a0" />
<img width="1230" height="186" alt="Phoenix_LiveDashboard" src="https://github.com/user-attachments/assets/6200cce5-2699-4ae7-b58a-170415a8ac8c" />

