### PR TITLE
perf: cache "all nodes" call

### DIFF
--- a/bench/region_set_cache.exs
+++ b/bench/region_set_cache.exs
@@ -1,0 +1,84 @@
+# Benchmarks the region-SET read on the GenRpcPubSub broadcast hot path — the one
+# call `Realtime.GenRpcPubSub.RegionRings.all_node_regions/0` replaces:
+#
+#   * CURRENT: `:syn.group_names(scope)` — a full `:ets.select/2` scan of the
+#     RegionNodes by-name table (one row per node) plus an `ordsets:from_list` usort
+#     down to the distinct region names. O(nodes) per broadcast.
+#   * CACHED : a single `:ets.lookup/2` of the pre-computed region list that
+#     RegionRings maintains in its table (reserved `:__all_regions__` row, refreshed
+#     on syn membership changes). O(1), independent of fleet size.
+#
+# This isolates ONLY the region-list read. It is NOT the full cross-region
+# resolution — after this read the muster path (`cross_region_route`) does pure-ETS
+# `RegionRings.expected_router/2` per region, so `group_names` is that path's
+# dominant syn cost and this is where the cache pays off. For the full flood-path
+# resolution (which also does `node_from_region/2` per region) see
+# `bench/nodes_topology.exs`.
+#
+# Self-contained: boots only :syn (no DB / full app). Run with:
+#   mix run --no-start bench/region_set_cache.exs
+#
+# Each scenario gets its own syn scope + cached row and is fed to Benchee as an
+# input, so the two reads are measured across a matrix of cluster topologies.
+
+{:ok, _} = Application.ensure_all_started(:syn)
+
+scenarios =
+  for regions_count <- [5, 7], nodes_per_region <- [4, 8, 12, 20, 30] do
+    {regions_count, nodes_per_region}
+  end
+
+# Build one syn scope + cached ETS row per topology, then expose both as a Benchee
+# input so each job reads from the matching scenario.
+inputs =
+  Map.new(scenarios, fn {regions_count, nodes_per_region} ->
+    total_nodes = regions_count * nodes_per_region
+    scope = :"RegionNodes_#{regions_count}x#{nodes_per_region}"
+    :ok = :syn.add_node_to_scopes([scope])
+
+    regions = for i <- 1..regions_count, do: "region-#{i}"
+
+    # One long-lived process per (region, node), joined with `[node: node]` metadata,
+    # matching how Realtime.Application registers nodes into RegionNodes.
+    for region <- regions, n <- 1..nodes_per_region do
+      node = :"node_#{region}_#{n}"
+
+      {:ok, _pid} =
+        Task.start_link(fn ->
+          :syn.join(scope, region, self(), node: node)
+          Process.sleep(:infinity)
+        end)
+    end
+
+    # Give syn a moment to register everyone before snapshotting the cache row.
+    Process.sleep(50)
+
+    table = :ets.new(:"bench_region_set_#{scope}", [:set, :public, read_concurrency: true])
+    region_set = :syn.group_names(scope)
+    :ets.insert(table, {:__all_regions__, region_set})
+
+    # Sanity: both strategies return the same region set for this scenario.
+    true = Enum.sort(region_set) == Enum.sort(:syn.group_names(scope))
+
+    label =
+      "#{regions_count} regions x #{String.pad_leading(Integer.to_string(nodes_per_region), 2)} nodes " <>
+        "= #{String.pad_leading(Integer.to_string(total_nodes), 3)} nodes"
+
+    {label, %{scope: scope, table: table}}
+  end)
+
+IO.puts("Sanity check passed: both strategies resolve the same region set\n")
+
+Benchee.run(
+  %{
+    "current (:syn.group_names full scan + usort)" => fn %{scope: scope} ->
+      :syn.group_names(scope)
+    end,
+    "cached (single :ets.lookup)" => fn %{table: table} ->
+      :ets.lookup(table, :__all_regions__) |> hd() |> elem(1)
+    end
+  },
+  inputs: inputs,
+  time: 3,
+  memory_time: 1
+)

--- a/bench/region_set_cache.exs
+++ b/bench/region_set_cache.exs
@@ -1,26 +1,3 @@
-# Benchmarks the region-SET read on the GenRpcPubSub broadcast hot path — the one
-# call `Realtime.GenRpcPubSub.RegionRings.all_node_regions/0` replaces:
-#
-#   * CURRENT: `:syn.group_names(scope)` — a full `:ets.select/2` scan of the
-#     RegionNodes by-name table (one row per node) plus an `ordsets:from_list` usort
-#     down to the distinct region names. O(nodes) per broadcast.
-#   * CACHED : a single `:ets.lookup/2` of the pre-computed region list that
-#     RegionRings maintains in its table (reserved `:__all_regions__` row, refreshed
-#     on syn membership changes). O(1), independent of fleet size.
-#
-# This isolates ONLY the region-list read. It is NOT the full cross-region
-# resolution — after this read the muster path (`cross_region_route`) does pure-ETS
-# `RegionRings.expected_router/2` per region, so `group_names` is that path's
-# dominant syn cost and this is where the cache pays off. For the full flood-path
-# resolution (which also does `node_from_region/2` per region) see
-# `bench/nodes_topology.exs`.
-#
-# Self-contained: boots only :syn (no DB / full app). Run with:
-#   mix run --no-start bench/region_set_cache.exs
-#
-# Each scenario gets its own syn scope + cached row and is fed to Benchee as an
-# input, so the two reads are measured across a matrix of cluster topologies.
-
 {:ok, _} = Application.ensure_all_started(:syn)
 
 scenarios =

--- a/lib/realtime/gen_rpc/pub_sub.ex
+++ b/lib/realtime/gen_rpc/pub_sub.ex
@@ -130,7 +130,7 @@ defmodule Realtime.GenRpcPubSub do
   end
 
   defp nodes_from_other_regions(my_region, key) do
-    Enum.flat_map(Nodes.all_node_regions(), fn
+    Enum.flat_map(RegionRings.all_node_regions(), fn
       ^my_region ->
         []
 
@@ -149,7 +149,7 @@ defmodule Realtime.GenRpcPubSub do
   # representative-per-region flood (`:ftr`), so cross-region delivery is never worse
   # than before Muster routing.
   defp cross_region_route(worker, my_region, tenant_id, topic, message, dispatcher) do
-    Enum.each(Nodes.all_node_regions(), fn
+    Enum.each(RegionRings.all_node_regions(), fn
       ^my_region ->
         :ok
 

--- a/lib/realtime/gen_rpc/pub_sub/region_rings.ex
+++ b/lib/realtime/gen_rpc/pub_sub/region_rings.ex
@@ -43,6 +43,9 @@ defmodule Realtime.GenRpcPubSub.RegionRings do
   @table :realtime_region_router_rings
   @default_reconcile_interval_ms :timer.minutes(5)
 
+  # Reserved row in @table caching the full cluster region set
+  @all_regions_key :__all_regions__
+
   defmodule State do
     @moduledoc false
 
@@ -55,6 +58,9 @@ defmodule Realtime.GenRpcPubSub.RegionRings do
             # region => the node set last applied to its ring, so an unchanged
             # reconcile can skip the non-idempotent `set_nodes`
             members: %{optional(String.t()) => MapSet.t(node())},
+            # last full region set written to the cache row, so an unchanged
+            # reconcile can skip rewriting it (nil until the first reconcile)
+            all_regions: [String.t()] | nil,
             # ETS table holding {region, ring_name, view_hash} for lock-free reads
             table: atom(),
             # reconcile backstop interval, in ms
@@ -62,7 +68,7 @@ defmodule Realtime.GenRpcPubSub.RegionRings do
           }
 
     @enforce_keys [:table, :interval]
-    defstruct rings: %{}, members: %{}, table: nil, interval: nil
+    defstruct rings: %{}, members: %{}, all_regions: nil, table: nil, interval: nil
   end
 
   ## Client
@@ -95,6 +101,30 @@ defmodule Realtime.GenRpcPubSub.RegionRings do
   rescue
     # Table doesn't exist yet (registry not started); :ets.lookup raises here.
     ArgumentError -> :error
+  end
+
+  @doc """
+  Returns the cached full cluster region set — the same value
+  `Realtime.Nodes.all_node_regions/0` would return (sorted, de-duplicated) —
+  maintained by `reconcile/1`.
+
+  This is the broadcast hot path's read: a single lock-free ETS lookup instead of
+  the full-table `:syn.group_names/1` scan on every message. Falls back to a live
+  syn read when the cache row or table is not present yet (registry still
+  starting, or between a crash and the rebuilding reconcile), so it is never less
+  fresh than reading syn directly.
+
+  `table` selects the backing ETS table.
+  """
+  @spec all_node_regions(atom()) :: [String.t()]
+  def all_node_regions(table \\ @table) do
+    case :ets.lookup(table, @all_regions_key) do
+      [{@all_regions_key, regions}] -> regions
+      [] -> Nodes.all_node_regions()
+    end
+  rescue
+    # Table doesn't exist yet (registry not started); :ets.lookup raises here.
+    ArgumentError -> Nodes.all_node_regions()
   end
 
   defp ring_name(table, region), do: :"#{table}_ring_#{region}"
@@ -173,7 +203,13 @@ defmodule Realtime.GenRpcPubSub.RegionRings do
   @spec reconcile(State.t()) :: State.t()
   defp reconcile(%State{} = state) do
     own_region = Application.get_env(:realtime, :region)
-    wanted = Nodes.all_node_regions() |> Enum.reject(&(&1 == own_region))
+    all_regions = Nodes.all_node_regions()
+
+    if all_regions != state.all_regions do
+      :ets.insert(state.table, {@all_regions_key, all_regions})
+    end
+
+    wanted = Enum.reject(all_regions, &(&1 == own_region))
 
     # Add/update rings for every other region. Rings for regions that go away
     # (a deployment draining a region) are left in place: they're rare, harmless
@@ -198,7 +234,7 @@ defmodule Realtime.GenRpcPubSub.RegionRings do
         {Map.put(rings, region, entry), Map.put(members, region, desired)}
       end)
 
-    %State{state | rings: rings, members: members}
+    %State{state | rings: rings, members: members, all_regions: all_regions}
   end
 
   defp ensure_ring(table, region, rings) do

--- a/test/realtime/gen_rpc_pub_sub/region_rings_test.exs
+++ b/test/realtime/gen_rpc_pub_sub/region_rings_test.exs
@@ -52,6 +52,57 @@ defmodule Realtime.GenRpcPubSub.RegionRingsTest do
     end
   end
 
+  describe "all_node_regions/1" do
+    test "falls back to a live syn read before the table exists" do
+      # No RegionRings started: the table is absent, so :ets.lookup raises and the
+      # rescue must fall back to a single Nodes.all_node_regions/0 read.
+      expect(Nodes, :all_node_regions, fn -> [@region, "us-east-1"] end)
+
+      assert RegionRings.all_node_regions(:rr_absent_table) == [@region, "us-east-1"]
+    end
+
+    test "falls back to a live syn read before any reconcile has populated the cache row" do
+      %{table: table} = start_region_rings!()
+
+      # Table exists (created in init) but the cache row hasn't been written yet, so
+      # the empty-lookup branch must fall back to a single Nodes.all_node_regions/0 read.
+      expect(Nodes, :all_node_regions, fn -> [@region, "us-east-1"] end)
+
+      assert RegionRings.all_node_regions(table) == [@region, "us-east-1"]
+    end
+
+    test "reads are served from the cache after a reconcile, never re-reading syn" do
+      %{pid: pid, table: table} = start_region_rings!()
+
+      # Exactly one syn read, performed by the reconcile itself. If any later
+      # all_node_regions/1 fell through to syn, Mimic would see a second call and fail.
+      expect(Nodes, :all_node_regions, 1, fn -> [@region, "us-east-1"] end)
+      expect(Nodes, :region_nodes, 1, fn _ -> members() end)
+
+      reconcile(pid)
+
+      assert RegionRings.all_node_regions(table) == [@region, "us-east-1"]
+      # Read again: served from ETS, not from syn (guaranteed by the expect-once above).
+      assert RegionRings.all_node_regions(table) == [@region, "us-east-1"]
+    end
+
+    test "a reconcile refreshes the cached region set when membership changes" do
+      %{pid: pid, table: table} = start_region_rings!()
+
+      # One region_nodes read per reconcile (only @region is wanted; "us-east-1" is
+      # own_region and is rejected).
+      expect(Nodes, :region_nodes, 2, fn _ -> members() end)
+
+      expect(Nodes, :all_node_regions, fn -> [@region] end)
+      reconcile(pid)
+      assert RegionRings.all_node_regions(table) == [@region]
+
+      expect(Nodes, :all_node_regions, fn -> [@region, "us-east-1"] end)
+      reconcile(pid)
+      assert RegionRings.all_node_regions(table) == [@region, "us-east-1"]
+    end
+  end
+
   describe "ring process exit" do
     test "rebuilds a ring that exits and recovers expected_router" do
       members = members()

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -1294,15 +1294,16 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       assert_process_down(channel_pid)
 
       assert_receive %Socket.Message{
-        topic: "realtime:test",
-        event: "system",
-        payload: %{
-          message: "Token has expired 0 seconds ago",
-          status: "error",
-          extension: "system",
-          channel: "test"
-        }
-      }
+                       topic: "realtime:test",
+                       event: "system",
+                       payload: %{
+                         message: "Token has expired" <> _,
+                         status: "error",
+                         extension: "system",
+                         channel: "test"
+                       }
+                     },
+                     1000
     end
 
     test "shuts down cleanly with JwtSignerError when the signer can no longer be generated", %{tenant: tenant} do


### PR DESCRIPTION
## What kind of change does this PR introduce?

The :syn call scans an ETS table and then does "unique sort" using ordsets every time  that :syn.group_names is called

This happens on every GenRpcPubSub broadcast which is quite a hot path.

As expected doing an ETS lookup is a lot faster (benchmark added to `bench` directory):

```
5 & 7 regions with different number of nodes per region
┌────────────────┬────────────────┬──────────────┬─────────┐
│     Input      │ Current (scan) │ Cached (ETS) │ Speedup │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 5×4 = 20 nodes │        1.23 μs │     0.106 μs │   11.6× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 5×8 = 40       │        2.26 μs │     0.087 μs │     26× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 5×12 = 60      │        3.20 μs │     0.089 μs │     36× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 5×20 = 100     │        5.20 μs │     0.091 μs │     57× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 5×30 = 150     │        8.08 μs │     0.090 μs │     89× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 7×4 = 28       │        1.61 μs │     0.076 μs │     21× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 7×8 = 56       │        2.94 μs │     0.074 μs │     40× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 7×12 = 84      │        4.45 μs │     0.078 μs │     57× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 7×20 = 140     │        6.97 μs │     0.079 μs │     88× │
├────────────────┼────────────────┼──────────────┼─────────┤
│ 7×30 = 210     │       10.88 μs │     0.074 μs │    146× │
└────────────────┴────────────────┴──────────────┴─────────┘
```