### PR TITLE
chore: Setup with devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential autoconf libncurses-dev libssl-dev \
       ca-certificates curl git inotify-tools locales openssh-client \
-      postgresql-client procps sudo \
+      postgresql-client procps sudo zsh \
     && rm -rf /var/lib/apt/lists/*
 
 # Elixir warns and can misbehave when the VM's native name encoding is not utf8, which is
@@ -26,7 +26,7 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=1000
 RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m -s /bin/bash $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m -s /bin/zsh $USERNAME \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
@@ -52,7 +52,15 @@ RUN curl -fsSL https://mise.run | sh \
 # start and hides this; `devcontainer exec`, plain `docker run` and CI get no such fixup.
 RUN printf 'PATH=/mise/shims:$PATH\n' > /etc/profile.d/00-mise-shims.sh
 
+# zsh does not need the profile.d fixup above: /etc/zsh/zprofile ships empty on Debian and
+# /etc/zsh/zshenv only overwrites PATH when it is unset or the bare "/bin:/usr/bin" default, so
+# the shims dir survives both login and interactive zsh unmolested (verified in an isolated
+# container). Only the git/command completion below is zsh-specific.
 USER $USERNAME
+
+# The zsh package ships completion functions (e.g. _git) but nothing wires them up by default,
+# so a bare new shell has no tab-completion until compinit runs once.
+RUN printf 'autoload -Uz compinit\ncompinit\n' > /home/$USERNAME/.zshrc
 
 # Production containers carry no wx/ODBC/Java either, so skip them and save build time.
 ENV KERL_CONFIGURE_OPTIONS="--without-javac --without-wx --without-odbc --without-observer --without-debugger --without-et"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,84 @@
+# Dev container for supabase/realtime, aiming for parity with the production image - bump both together.
+#
+# Plain Debian rather than an elixir/OTP image, so mise.toml and mise.lock stay the single
+# source of tool versions and the workflow is identical inside and outside the container.
+FROM debian:trixie-20260713-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# We need to build erlang/OTP from source as no Debian target is published.
+# inotify-tools backs Phoenix live reload
+# sudo is for post-create's chown
+# procps supplies the `ps` the VS Code server probes with
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential autoconf libncurses-dev libssl-dev \
+      ca-certificates curl git inotify-tools locales openssh-client \
+      postgresql-client procps sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Elixir warns and can misbehave when the VM's native name encoding is not utf8, which is
+# what a non-UTF-8 locale leaves it as.
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
+
+# Non-root: the workspace is bind-mounted, so files must not end up root-owned.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m -s /bin/bash $USERNAME \
+    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# mise lives outside $HOME so a home-directory volume cannot shadow the installs. Shims -
+# not `mise activate` - are what put tools on PATH: `devcontainer exec` probes with a
+# login-interactive shell, so .bashrc loads and activate prepends the raw tool bin dirs
+# ahead of /mise/shims, while its hook-env never fires because no prompt is drawn. That
+# yields activate's PATH without activate's [env], and mix boots without
+# METRICS_JWT_SECRET. Shims also need the config trusted - see devcontainer.json.
+# Installs and shims are shared; the cache stays per-user. Root uses these shims too, so a
+# feature running `npm install -g` would otherwise bake a root-owned cache into the image and
+# `mise install` as vscode dies from then on with "failed to update lockfiles: Permission denied".
+ENV MISE_DATA_DIR=/mise \
+    MISE_CONFIG_DIR=/mise \
+    MISE_INSTALL_PATH=/usr/local/bin/mise \
+    PATH=/mise/shims:$PATH
+RUN curl -fsSL https://mise.run | sh \
+    && mkdir -p /mise \
+    && chown -R $USER_UID:$USER_GID /mise
+
+# ENV does not survive *login* shells: Debian's /etc/profile assigns PATH outright rather
+# than defaulting it, so `bash -l` drops the shims. VS Code patches /etc/profile at container
+# start and hides this; `devcontainer exec`, plain `docker run` and CI get no such fixup.
+RUN printf 'PATH=/mise/shims:$PATH\n' > /etc/profile.d/00-mise-shims.sh
+
+USER $USERNAME
+
+# Production containers carry no wx/ODBC/Java either, so skip them and save build time.
+ENV KERL_CONFIGURE_OPTIONS="--without-javac --without-wx --without-odbc --without-observer --without-debugger --without-et"
+
+# Only these two files, so the expensive `mise install` below stays cached against the
+# toolchain definition rather than every source edit. Do not add MISE_LOCKFILE=false: a build
+# cannot write back to its context, so there is no lockfile here worth protecting, and an
+# unlocked resolve bakes a different node patch than mise.lock pins - mise.toml says only
+# "24" - which every container start then re-downloads.
+COPY --chown=$USER_UID:$USER_GID mise.toml mise.lock /tmp/toolchain/
+RUN cd /tmp/toolchain \
+    # Only this copy - the workspace mise.toml does not exist at build time.
+    && mise trust \
+    && mise install \
+    && mise exec -- mix local.hex --force \
+    && mise exec -- mix local.rebar --force \
+    # Also record them as *global* versions: shims resolve from the mise.toml in scope, so
+    # anything running outside the workspace - devcontainer features doing `npm install -g`
+    # at build time - otherwise dies with "No version is set for shim". Read back from the
+    # locked resolve so they cannot drift from mise.lock.
+    && for tool in erlang elixir node supabase; do \
+         mise use -g "${tool}@$(mise current ${tool})"; \
+       done \
+    # Only test/e2e/.tool-versions asks for bun, and .dockerignore keeps /test/ out of the
+    # build context, so `mise run e2e` fails on a missing tool without this. It pins nothing
+    # ("bun latest"); if upstream moves past this build, mise fetches the newer one on use.
+    && mise use -g bun@latest \
+    # The kerl source tree alone is ~790MB, none of it needed at runtime.
+    && rm -rf /tmp/toolchain "$HOME/.cache/mise"

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,7 +50,18 @@
       "extensions": [
         "JakeBecker.elixir-ls",
         "phoenixframework.phoenix"
-      ]
+      ],
+      // The vscode user's login shell is zsh (Dockerfile), but VS Code's terminal profile
+      // picker doesn't follow /etc/passwd, so it needs its own explicit zsh profile too.
+      // The IDE may flag "zsh" here as invalid while editing on the host - that's the
+      // *local* editor validating against shells on your machine, not the container's;
+      // it resolves once VS Code actually connects into the devcontainer.
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "zsh": { "path": "/usr/bin/zsh" }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      }
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+{
+  "name": "supabase/realtime",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+
+  // mix test starts its own Postgres containers with `docker run -p <port>:5432` and then
+  // connects at 127.0.0.1:<port> (test/support/test_tenant_db/backend/docker.ex). Those
+  // published ports live on the daemon's network namespace; on a bridge they are not there.
+  "runArgs": ["--network=host"],
+
+  // The workspace must sit at its host path: bind-mount sources are resolved by the host
+  // daemon, yet compose.dbs.yml and docker.ex both hand it paths from inside here. A mismatch
+  // mounts empty dirs instead, so the Postgres init scripts never run and you get a confusing
+  // supabase_admin/_realtime failure rather than a mount error.
+  "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+  "workspaceFolder": "${localWorkspaceFolder}",
+  "remoteUser": "vscode",
+
+  "features": {
+    // moby-cli is not published for trixie; false installs upstream docker-ce-cli instead.
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": { "moby": false }
+  },
+
+  // Nothing PATH-related belongs in here: ${containerEnv:PATH} is only substituted in
+  // remoteEnv, so in containerEnv it self-references and the container loses even /usr/bin.
+  // The Dockerfile's ENV already covers every process.
+  "containerEnv": {
+    // The workspace's `mise trust`, declarative and covering nested configs
+    // (test/e2e/.tool-versions). Untrusted, every shim aborts and takes [env] down with it,
+    // so mix would boot without METRICS_JWT_SECRET. Set here rather than in post-create so
+    // tool resolution never waits on a hook - the language server may start first.
+    "MISE_TRUSTED_CONFIG_PATHS": "${localWorkspaceFolder}"
+  },
+
+  // Write-heavy, many-small-file dirs: several times slower over a macOS bind mount even
+  // under VirtioFS. All are gitignored, so keeping them out of the host tree loses nothing.
+  "mounts": [
+    "source=realtime-build-${devcontainerId},target=${containerWorkspaceFolder}/_build,type=volume",
+    "source=realtime-deps-${devcontainerId},target=${containerWorkspaceFolder}/deps,type=volume",
+    "source=realtime-node-modules-${devcontainerId},target=${containerWorkspaceFolder}/assets/node_modules,type=volume",
+    "source=realtime-plts-${devcontainerId},target=${containerWorkspaceFolder}/priv/plts,type=volume"
+  ],
+
+  "postCreateCommand": ".devcontainer/post-create.sh",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "JakeBecker.elixir-ls",
+        "phoenixframework.phoenix"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The image has nothing behind these four paths, so their named volumes mount root-owned.
+sudo chown -R vscode:vscode _build deps assets/node_modules priv/plts
+
+# Fills the empty deps volume so ElixirLS is useful straight away. `mix setup` is left to the
+# user because it needs the databases running.
+mix deps.get
+
+cat <<'EOF'
+
+  Ready. Next steps:
+
+    mise run db-start   # Postgres on 127.0.0.1:5432 (repo) and :5433 (tenant)
+    mix setup           # needs both of the above running
+    mise run dev        # http://localhost:4000/status, also from host
+
+  Tests need the databases up too: mise run db-start && mix test
+
+EOF

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -6,6 +6,7 @@
   - [Client libraries](#client-libraries)
 - [Server](#server)
   - [Server Setup](#server-setup)
+  - [Devcontainer](#devcontainer)
   - [Tenants](#tenants)
   - [WebSocket](#websocket)
     - [WebSocket URL](#websocket-url)
@@ -76,6 +77,18 @@ To see all available tasks:
 ```bash
 mise task ls
 ```
+
+### Devcontainer
+
+If you use VS Code (or another [Dev Containers](https://containers.dev)-compatible editor), `.devcontainer/` gives you a ready-to-use environment without installing mise, Elixir, or Erlang on your host.
+
+The image installs the exact toolchain as discussed above and all commands should work similarly.
+
+To use it, open the repo in VS Code and run **Dev Containers: Reopen in Container**.
+Once the container has built and `postCreateCommand` finishes, follow the same steps as above: `mise run db-start`, `mix setup`, `mise run dev`.
+
+> **Note**
+> It uses `--network=host`, which requires a container runtime that supports it. This works natively on Linux and on OrbStack; on Docker Desktop for Mac you need to enable the host networking beta feature first.
 
 ### Tenants
 

--- a/mise.lock
+++ b/mise.lock
@@ -36,7 +36,19 @@ url = "https://builds.hex.pm/builds/elixir/v1.19.5-otp-28.zip"
 version = "28.5.0.4"
 backend = "core:erlang"
 
+[tools.erlang."platforms.linux-arm64"]
+checksum = "sha256:efb045f96ee56d274f6c1fe3a9612b45caa01d2f82e35fe4e0ac9b0c501f6e53"
+url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_src_28.5.0.4.tar.gz"
+url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491552679"
+install = "source"
+
 [tools.erlang."platforms.linux-arm64-musl"]
+checksum = "sha256:efb045f96ee56d274f6c1fe3a9612b45caa01d2f82e35fe4e0ac9b0c501f6e53"
+url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_src_28.5.0.4.tar.gz"
+url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491552679"
+install = "source"
+
+[tools.erlang."platforms.linux-x64"]
 checksum = "sha256:efb045f96ee56d274f6c1fe3a9612b45caa01d2f82e35fe4e0ac9b0c501f6e53"
 url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_src_28.5.0.4.tar.gz"
 url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491552679"


### PR DESCRIPTION
**why**
* allow AI agents to run in an isolated environment
* I can pretend I'm using Linux
* even easier setup for contributors
* close to a production environment

**how**
I decided to use the same (OS) base image as our production deploy for parity there.

However, I decided to leave erlang, elixir and friends in management with `mise` so that this workflow is as similar as possible to the normal local development flow.

As another result of that, I mostly wanted to make it work with the code base as is without adjusting it too much/not at all if possible.

As I know docker/devcontainers but am in no form or shape an expert this was AI assisted. It makes sense to me, but feel free to challenge the setup :)

**example**
```
vscode@orbstack:/Users/tobi/supabase/realtime$ mise run db-start
[db-start] $ docker compose -f compose.dbs.yml up -d --wait
[+] up 2/2
 ✔ Container realtime-tenant_db-1 Healthy                                                                0.5s
 ✔ Container realtime-db-1        Healthy                                                                0.5s
vscode@orbstack:/Users/tobi/supabase/realtime$ mix setup
Resolving Hex dependencies...
Resolution completed in 0.29s
...
vscode@orbstack:/Users/tobi/supabase/realtime$ mix test

11:44:50.781 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address

11:44:50.858 [info] Migrations already up
[test_helper.exs] Time to start tests: 1711 ms
Running ExUnit with seed: 826323, max_cases: 4
Excluding tags: [:failing, :requires_no_supautils_policy_grants]

...
Finished in 543.4 seconds (156.3s async, 387.0s sync)
23 doctests, 1964 tests, 0 failures, 1 skipped (6 excluded)
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
[os_mon] memory supervisor port (memsup): Erlang has closed
```

slow down vs. local install seems to be negligible/about the same:

```
Finished in 544.2 seconds (178.9s async, 365.2s sync)
23 doctests, 1972 tests, 1 failure, 1 skipped (6 excluded)
```