### PR TITLE
fix: support jsonb expression filters

### DIFF
--- a/priv/repo/tenant_schema/schemas/realtime/functions/is_visible_through_filters.sql
+++ b/priv/repo/tenant_schema/schemas/realtime/functions/is_visible_through_filters.sql
@@ -14,8 +14,14 @@ create or replace function realtime.is_visible_through_filters (
             and sum(
                 realtime.check_equality_op(
                     op:=f.op,
-                    type_:=coalesce(col.type_oid::regtype, col.type_name::regtype),
-                    val_1:=col.value #>> '{}',
+                    type_:=case
+                        when position('->>' in f.column_name) > 0 then 'text'::regtype
+                        else coalesce(col.type_oid::regtype, col.type_name::regtype)
+                    end,
+                    val_1:=case
+                        when position('->>' in f.column_name) > 0 then col.value ->> btrim(split_part(f.column_name, '->>', 2), ' "')
+                        else col.value #>> '{}'
+                    end,
                     val_2:=f.value,
                     negate:=coalesce(f.negate, false)
                 )::int
@@ -25,7 +31,11 @@ create or replace function realtime.is_visible_through_filters (
     from
         unnest(filters) f
         left join unnest(columns) col
-            on f.column_name = col.name;
+            on split_part(f.column_name, '->>', 1) = col.name
+           and (
+             position('->>' in f.column_name) = 0
+             or coalesce(col.type_oid::regtype, col.type_name::regtype) = 'jsonb'::regtype
+           );
 $function$;
 
 alter function "realtime"."is_visible_through_filters"(realtime.wal_column[], realtime.user_defined_filter[]) owner to "supabase_realtime_admin";

--- a/priv/repo/tenant_schema/schemas/realtime/functions/subscription_check_filters.sql
+++ b/priv/repo/tenant_schema/schemas/realtime/functions/subscription_check_filters.sql
@@ -21,11 +21,27 @@ declare
             );
     filter realtime.user_defined_filter;
     col_type regtype;
+    comparison_type regtype;
+    filter_column text;
+    json_key text;
+    is_jsonb_filter boolean;
     in_val jsonb;
     selected_col text;
 begin
     for filter in select * from unnest(new.filters) loop
-        if not filter.column_name = any(col_names) then
+        is_jsonb_filter = position('->>' in filter.column_name) > 0;
+        filter_column = split_part(filter.column_name, '->>', 1);
+        json_key = btrim(split_part(filter.column_name, '->>', 2), ' "');
+
+        if is_jsonb_filter and (
+            filter_column = ''
+            or json_key = ''
+            or position('->>' in split_part(filter.column_name, '->>', 2)) > 0
+        ) then
+            raise exception 'invalid jsonb filter expression %', filter.column_name;
+        end if;
+
+        if not filter_column = any(col_names) then
             raise exception 'invalid column for filter %', filter.column_name;
         end if;
 
@@ -33,14 +49,18 @@ begin
             select atttypid::regtype
             from pg_catalog.pg_attribute
             where attrelid = new.entity
-                  and attname = filter.column_name
+                  and attname = filter_column
         );
+        if is_jsonb_filter and col_type <> 'jsonb'::regtype then
+            raise exception 'jsonb filter requires a jsonb column, got %', col_type::text;
+        end if;
+        comparison_type = case when is_jsonb_filter then 'text'::regtype else col_type end;
         if col_type is null then
             raise exception 'failed to lookup type for column %', filter.column_name;
         end if;
 
         if filter.op = 'in'::realtime.equality_op then
-            in_val = realtime.cast(filter.value, (col_type::text || '[]')::regtype);
+            in_val = realtime.cast(filter.value, (comparison_type::text || '[]')::regtype);
             if coalesce(jsonb_array_length(in_val), 0) > 100 then
                 raise exception 'too many values for `in` filter. Maximum 100';
             end if;
@@ -52,17 +72,17 @@ begin
             -- IS NULL works for any type, but IS TRUE/FALSE/UNKNOWN require a boolean
             -- operand. Reject the non-null keywords on non-boolean columns here so they
             -- don't abort apply_rls at WAL time.
-            if filter.value <> 'null' and col_type <> 'boolean'::regtype then
-                raise exception 'is % filter requires a boolean column, got %', filter.value, col_type::text;
+            if filter.value <> 'null' and comparison_type <> 'boolean'::regtype then
+                raise exception 'is % filter requires a boolean column, got %', filter.value, comparison_type::text;
             end if;
         elsif filter.op in ('like'::realtime.equality_op, 'ilike'::realtime.equality_op) then
             -- like/ilike apply the text pattern operator (~~); reject column types that
             -- have no such operator instead of failing at WAL time
             if not exists (
                 select 1 from pg_catalog.pg_operator
-                where oprname = '~~' and oprleft = col_type
+                where oprname = '~~' and oprleft = comparison_type
             ) then
-                raise exception 'operator % requires a text-compatible column type, got %', filter.op::text, col_type::text;
+                raise exception 'operator % requires a text-compatible column type, got %', filter.op::text, comparison_type::text;
             end if;
         elsif filter.op in ('match'::realtime.equality_op, 'imatch'::realtime.equality_op) then
             -- match/imatch apply the regex operators ~ / ~*; reject column types that have
@@ -71,11 +91,11 @@ begin
             if not exists (
                 select 1 from pg_catalog.pg_operator
                 where oprname = case when filter.op = 'imatch'::realtime.equality_op then '~*' else '~' end
-                  and oprleft = col_type
-                  and oprright = col_type
+                  and oprleft = comparison_type
+                  and oprright = comparison_type
                   and oprresult = 'boolean'::regtype
             ) then
-                raise exception 'operator % requires a text-compatible column type, got %', filter.op::text, col_type::text;
+                raise exception 'operator % requires a text-compatible column type, got %', filter.op::text, comparison_type::text;
             end if;
             -- validate the regex eagerly so a bad pattern is rejected here, not inside
             -- apply_rls where it would abort the WAL stream for the entity
@@ -86,7 +106,7 @@ begin
             end;
         else
             -- eq/neq/lt/lte/gt/gte: value must be coercable to the type
-            perform realtime.cast(filter.value, col_type);
+            perform realtime.cast(filter.value, comparison_type);
         end if;
     end loop;
 

--- a/test/integration/rt_channel/postgres_changes_filters_test.exs
+++ b/test/integration/rt_channel/postgres_changes_filters_test.exs
@@ -37,6 +37,74 @@ defmodule Realtime.Integration.RtChannel.PostgresChangesFiltersTest do
       assert_filter_delivers(tenant, "details=eq.hello", "hello")
     end
 
+    test "jsonb text extraction filter matches only the selected value", %{tenant: tenant} do
+      {socket, _} = get_connection(tenant, @serializer)
+      topic = "realtime:jsonb"
+
+      config = %{
+        postgres_changes: [
+          %{
+            event: "INSERT",
+            schema: "public",
+            table: "test",
+            filter: "data->>organization_id=eq.org_123"
+          }
+        ]
+      }
+
+      WebsocketClient.join(socket, topic, %{config: config})
+
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 200
+
+      assert_receive %Message{
+                       event: "system",
+                       payload: %{
+                         "channel" => "jsonb",
+                         "extension" => "postgres_changes",
+                         "message" => "Subscribed to PostgreSQL",
+                         "status" => "ok"
+                       },
+                       ref: nil,
+                       topic: ^topic
+                     },
+                     8000
+
+      {:ok, _, conn} = PostgresCdcRls.get_manager_conn(tenant.external_id)
+
+      %{rows: [[matching_id]]} =
+        Postgrex.query!(
+          conn,
+          "insert into test (details, data) values ($1, $2::jsonb) returning id",
+          ["jsonb-match", ~s|{"organization_id":"org_123"}|]
+        )
+
+      assert_receive %Message{
+                       event: "postgres_changes",
+                       payload: %{
+                         "data" => %{
+                           "record" => %{"id" => ^matching_id, "details" => "jsonb-match"},
+                           "type" => "INSERT"
+                         }
+                       },
+                       ref: nil,
+                       topic: ^topic
+                     },
+                     500
+
+      Postgrex.query!(
+        conn,
+        "insert into test (details, data) values ($1, $2::jsonb)",
+        ["jsonb-no-match", ~s|{"organization_id":"other"}|]
+      )
+
+      refute_receive %Message{
+                       event: "postgres_changes",
+                       payload: %{"data" => %{"record" => %{"details" => "jsonb-no-match"}}},
+                       topic: ^topic
+                     },
+                     500
+    end
+
     test "neq filter matches on insert, update and delete", %{tenant: tenant} do
       assert_filter_delivers(tenant, "details=neq.other", "hello")
     end

--- a/test/support/integrations.ex
+++ b/test/support/integrations.ex
@@ -75,6 +75,7 @@ defmodule Integrations do
         create table "public"."test" (
         "id" int4 not null default nextval('test_id_seq'::regclass),
         "details" text,
+        "data" jsonb,
         "binary_data" bytea,
         primary key ("id"));
         """,


### PR DESCRIPTION
## Summary

This PR adds support for filtering Postgres Changes subscriptions on a JSONB text-extraction expression such as `data->>organization_id=eq.org_123`.

Fixes #1090.

## What changed

- Validate a single `jsonb_column->>key` filter expression during subscription creation.
- Require the base column to have the `jsonb` type and validate the comparison value as text.
- Extract the requested JSONB key with PostgreSQL’s `->>` operator during row-visibility evaluation.
- Add a `data jsonb` field to the shared integration fixture.
- Add an end-to-end regression test proving that a matching JSONB value is delivered and a different value is ignored.

The implementation keeps the existing filter wire format and equality-operator machinery. It does not use dynamic SQL for the JSONB key; the base column and key are parsed and validated before the value is passed to the existing comparison function.

## Testing

- The standalone Elixir parser check for `data->>organization_id=eq.org_123` passes.
- `git diff --check` passes.
- The integration test is included but the full Mix suite was not run in this environment because the repository pins Elixir 1.19.5 / OTP 28, while the available runtime is Elixir 1.14 / OTP 25.

## Coordination note

A previous comment on issue #1090 says that `krishvsoni` wanted to work on this issue. I am opening this PR transparently so maintainers can confirm whether the work is still available. If that contributor is actively implementing the fix, I am happy to defer or adapt this branch based on maintainer guidance.

## Review focus

Please review the accepted expression syntax, behavior for missing JSONB keys and `NULL`, and interactions with `not.`, `in`, `is null`, and delete/update old-row filtering.