### PR TITLE
fix: statuslive view can crash from high memory usage

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,6 +2,6 @@
   import_deps: [:ecto, :ecto_sql, :phoenix, :open_api_spex],
   subdirectories: ["priv/*/migrations"],
   plugins: [],
-  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/*seeds*.exs"],
+  inputs: ["*.{heex,ex,exs}", "{config,lib,test,scripts}/**/*.{heex,ex,exs}", "priv/*/*seeds*.exs"],
   line_length: 120
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ config/prod.secret.exs
 demo/.env
 .lexical
 .vscode
+.elixir_ls
 
 # Local
 mise.local.toml

--- a/lib/realtime/monitoring/latency.ex
+++ b/lib/realtime/monitoring/latency.ex
@@ -1,6 +1,8 @@
 defmodule Realtime.Latency do
   @moduledoc """
     Measures the latency of the cluster from each node and broadcasts it over PubSub.
+
+    The `"admin:cluster"` messages are consumed by `RealtimeWeb.StatusLive.Index`.
   """
 
   use GenServer

--- a/lib/realtime_web/live/status_live/index.ex
+++ b/lib/realtime_web/live/status_live/index.ex
@@ -8,11 +8,11 @@ defmodule RealtimeWeb.StatusLive.Index do
   alias Realtime.Nodes
   alias RealtimeWeb.Endpoint
 
-  @ping_interval 15_000
+  @ping_interval to_timeout(second: 15)
   @stale_after @ping_interval * 2
-  @warn_above_ms 1_000
+  @warn_above_ms to_timeout(second: 1)
   @problem_limit 200
-  @flush_interval 1_000
+  @flush_interval to_timeout(second: 1)
   @state_key :node_info
 
   @impl true

--- a/lib/realtime_web/live/status_live/index.ex
+++ b/lib/realtime_web/live/status_live/index.ex
@@ -12,28 +12,33 @@ defmodule RealtimeWeb.StatusLive.Index do
   @stale_after @ping_interval * 2
   @warn_above_ms 1_000
   @problem_limit 200
+  @flush_interval 1_000
+  @state_key :node_info
 
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket) do
       Endpoint.subscribe("admin:cluster")
       schedule_staleness_check()
+      schedule_flush()
     end
 
     node_ids = all_nodes()
+    pair_status = default_pair_status(node_ids)
 
     socket =
       socket
       |> assign(:active_nav, :status)
       |> assign(:node_ids, node_ids)
       |> assign(:node_regions, %{})
-      |> assign(:pair_status, default_pair_status(node_ids))
+      |> assign(:pair_status, pair_status)
       |> assign(:selected_node, nil)
       |> assign(:region_filter, "")
       |> assign(:node_sort, "node")
       |> assign(:pair_sort, "severity")
       |> assign(:drill_sort, "node")
       |> assign(:mounted_at, DateTime.utc_now())
+      |> put_state(%{pair_status: pair_status, node_regions: %{}})
 
     {:ok, socket}
   end
@@ -68,11 +73,26 @@ defmodule RealtimeWeb.StatusLive.Index do
   @impl true
   def handle_info(%Phoenix.Socket.Broadcast{payload: %Payload{} = payload}, socket) do
     {pair, entry} = pair_entry(payload)
+    state = state(socket)
+
+    state = %{
+      state
+      | pair_status: Map.put(state.pair_status, pair, entry),
+        node_regions: Map.put(state.node_regions, payload.from_node, payload.from_region)
+    }
+
+    {:noreply, put_state(socket, state)}
+  end
+
+  # scheduled flushes/draws to avoid triggering rerenders too frequently
+  def handle_info(:flush, socket) do
+    schedule_flush()
+    state = state(socket)
 
     socket =
       socket
-      |> update(:pair_status, &Map.put(&1, pair, entry))
-      |> update(:node_regions, &Map.put(&1, payload.from_node, payload.from_region))
+      |> assign(:pair_status, state.pair_status)
+      |> assign(:node_regions, state.node_regions)
 
     {:noreply, socket}
   end
@@ -80,7 +100,14 @@ defmodule RealtimeWeb.StatusLive.Index do
   def handle_info(:check_staleness, socket) do
     schedule_staleness_check()
     pair_status = apply_staleness(socket.assigns.pair_status, DateTime.utc_now(), socket.assigns.mounted_at)
-    {:noreply, assign(socket, :pair_status, pair_status)}
+    state = %{state(socket) | pair_status: pair_status}
+
+    socket =
+      socket
+      |> put_state(state)
+      |> assign(:pair_status, pair_status)
+
+    {:noreply, socket}
   end
 
   @doc false
@@ -126,6 +153,12 @@ defmodule RealtimeWeb.StatusLive.Index do
   defp payload_status(_), do: :unknown
 
   defp schedule_staleness_check, do: Process.send_after(self(), :check_staleness, @stale_after)
+  defp schedule_flush, do: Process.send_after(self(), :flush, @flush_interval)
+
+  # Private (not change-tracked) accumulator for payloads arriving between flushes,
+  # to delay rerendering until the next `flush`
+  defp state(socket), do: socket.private[@state_key]
+  defp put_state(socket, state), do: put_private(socket, @state_key, state)
 
   defp all_nodes do
     # Load-test-only escape hatch to have realistic rendering.

--- a/lib/realtime_web/live/status_live/index.ex
+++ b/lib/realtime_web/live/status_live/index.ex
@@ -1,4 +1,7 @@
 defmodule RealtimeWeb.StatusLive.Index do
+  @moduledoc """
+  Publically available status page for our clusters, showing nodes and cross region latency.
+  """
   use RealtimeWeb, :live_view
 
   alias Realtime.Latency.Payload

--- a/lib/realtime_web/live/status_live/index.ex
+++ b/lib/realtime_web/live/status_live/index.ex
@@ -128,7 +128,10 @@ defmodule RealtimeWeb.StatusLive.Index do
   defp schedule_staleness_check, do: Process.send_after(self(), :check_staleness, @stale_after)
 
   defp all_nodes do
-    [Node.self() | Node.list()] |> Enum.map(&Nodes.short_node_id_from_name/1)
+    # Load-test-only escape hatch to have realistic rendering.
+    # Practically `[]` on prod and so shouldn't have a meaningful impact.
+    extra_ids = Application.get_env(:realtime, __MODULE__, []) |> Keyword.get(:extra_node_ids, [])
+    extra_ids ++ ([Node.self() | Node.list()] |> Enum.map(&Nodes.short_node_id_from_name/1))
   end
 
   defp default_pair_status(node_ids) do

--- a/scripts/status_live_load_test.exs
+++ b/scripts/status_live_load_test.exs
@@ -48,7 +48,7 @@ defmodule RealtimeLoadTest.StatusLive do
       views: %{}
     }
 
-    state = loop(node_count, broadcasts_per_tick, ticks_until_report, total_ticks, state)
+    state = loadtest(node_count, broadcasts_per_tick, ticks_until_report, total_ticks, state)
 
     print_summary(state, node_count, rate, duration_ms)
   end
@@ -60,7 +60,7 @@ defmodule RealtimeLoadTest.StatusLive do
     Application.put_env(:realtime, RealtimeWeb.StatusLive.Index, extra_node_ids: extra_node_ids)
   end
 
-  defp loop(node_count, messages_per_tick, ticks_until_report, total_ticks, state) do
+  defp loadtest(node_count, messages_per_tick, ticks_until_report, total_ticks, state) do
     send_batch(node_count, state.sent, messages_per_tick)
     state = %{state | sent: state.sent + messages_per_tick, tick: state.tick + 1}
 
@@ -76,7 +76,7 @@ defmodule RealtimeLoadTest.StatusLive do
     else
       # this isn't quite exact (work + sleep for tick_ms) but good enough for what we do
       Process.sleep(@tick_ms)
-      loop(node_count, messages_per_tick, ticks_until_report, total_ticks, state)
+      loadtest(node_count, messages_per_tick, ticks_until_report, total_ticks, state)
     end
   end
 

--- a/scripts/status_live_load_test.exs
+++ b/scripts/status_live_load_test.exs
@@ -31,10 +31,12 @@ defmodule RealtimeLoadTest.StatusLive do
   @ping_frequency_seconds 15
 
   def run(node_count, duration_ms, poll_ms) do
+    fake_node_existence(node_count)
+
     rate = node_count * node_count / @ping_frequency_seconds
     ticks_per_second = to_timeout(second: 1) / @tick_ms
-    broadcasts_broadcasts_per_tick = round(rate / ticks_per_second)
-    ticks_until_report = div(poll_ms, @tick_ms)
+    broadcasts_per_tick = max(round(rate / ticks_per_second), 1)
+    ticks_until_report = max(div(poll_ms, @tick_ms), 1)
     total_ticks = div(duration_ms, @tick_ms)
 
     print_banner(node_count, rate, duration_ms, poll_ms)
@@ -46,9 +48,16 @@ defmodule RealtimeLoadTest.StatusLive do
       views: %{}
     }
 
-    state = loop(node_count, broadcasts_broadcasts_per_tick, ticks_until_report, total_ticks, state)
+    state = loop(node_count, broadcasts_per_tick, ticks_until_report, total_ticks, state)
 
     print_summary(state, node_count, rate, duration_ms)
+  end
+
+  # Make the status page see our synthetic node ids too, so we have meaningful rendering
+  # Works via a purpose built escape hatch.
+  defp fake_node_existence(node_count) do
+    extra_node_ids = Enum.map(0..(node_count - 1), &"loadnode-#{&1}")
+    Application.put_env(:realtime, RealtimeWeb.StatusLive.Index, extra_node_ids: extra_node_ids)
   end
 
   defp loop(node_count, messages_per_tick, ticks_until_report, total_ticks, state) do
@@ -130,7 +139,7 @@ defmodule RealtimeLoadTest.StatusLive do
 
         IO.puts(
           "[load] t=#{format_time(elapsed_ms)}  #{inspect(pid)}  sent=#{state.sent}  " <>
-            "actual=#{format_rate(state.sent, elapsed_ms)}/s mem=#{format_bytes(mem)} queue_len=#{pad(qlen)}}"
+            "actual=#{format_rate(state.sent, elapsed_ms)}/s mem=#{format_bytes(mem)} queue_len=#{pad(qlen)}"
         )
 
         view = Map.get(state.views, pid, %{samples: []})

--- a/scripts/status_live_load_test.exs
+++ b/scripts/status_live_load_test.exs
@@ -1,0 +1,203 @@
+# Local load test for RealtimeWeb.StatusLive.Index (REAL-929).
+#
+# Feeds synthetic "admin:cluster" broadcasts at a realistic, production-scale rate
+# (rate = N^2/15 msgs/sec, matching Realtime.Latency's real N-node fan-out) and watches
+# the target LiveView process's mailbox/memory via Process.info/2, so "does the mailbox
+# stay bounded" can be answered locally with real numbers instead of waiting on the
+# production crash log or a real multi-node cluster.
+#
+# Usage:
+#
+#   mise run db-start
+#   mix phx.server --no-halt scripts/status_live_load_test.exs
+#
+# then open http://localhost:4000/status in a browser tab (as soon as you see the
+# startup banner — the load window is still bounded by LOAD_DURATION_MS).
+#
+#
+# Env vars (all optional):
+#   LOAD_NODE_COUNT     simulated cluster size, rate = N*N/15 msgs/sec (default 100)
+#   LOAD_DURATION_MS    how long to sustain the load, in ms (default 60_000)
+#   LOAD_POLL_MS        how often to poll/print mailbox + memory, in ms (default 1_000)
+#
+defmodule RealtimeLoadTest.StatusLive do
+  @moduledoc false
+
+  alias Realtime.Latency.Payload
+  alias RealtimeWeb.Endpoint
+
+  @tick_ms 100
+  @regions ~w(us-east-1 us-west-1 eu-west-2 ap-southeast-1 sa-east-1 eu-central-2 ap-northeast-1 ca-central-1)
+  @ping_frequency_seconds 15
+
+  def run(node_count, duration_ms, poll_ms) do
+    rate = node_count * node_count / @ping_frequency_seconds
+    ticks_per_second = to_timeout(second: 1) / @tick_ms
+    broadcasts_broadcasts_per_tick = round(rate / ticks_per_second)
+    ticks_until_report = div(poll_ms, @tick_ms)
+    total_ticks = div(duration_ms, @tick_ms)
+
+    print_banner(node_count, rate, duration_ms, poll_ms)
+
+    state = %{
+      sent: 0,
+      tick: 0,
+      start_ms: monotonic_ms(),
+      views: %{}
+    }
+
+    state = loop(node_count, broadcasts_broadcasts_per_tick, ticks_until_report, total_ticks, state)
+
+    print_summary(state, node_count, rate, duration_ms)
+  end
+
+  defp loop(node_count, messages_per_tick, ticks_until_report, total_ticks, state) do
+    send_batch(node_count, state.sent, messages_per_tick)
+    state = %{state | sent: state.sent + messages_per_tick, tick: state.tick + 1}
+
+    state =
+      if rem(state.tick, ticks_until_report) == 0 do
+        poll_and_report(state)
+      else
+        state
+      end
+
+    if state.tick >= total_ticks do
+      state
+    else
+      # this isn't quite exact (work + sleep for tick_ms) but good enough for what we do
+      Process.sleep(@tick_ms)
+      loop(node_count, messages_per_tick, ticks_until_report, total_ticks, state)
+    end
+  end
+
+  # We're sending only a sub-set of messages per second, so we keep track of how many
+  # we've sent so we simulate the full NxN space.
+  defp send_batch(node_count, base_index, count) do
+    Enum.each(base_index..(base_index + count - 1), fn index ->
+      Endpoint.broadcast("admin:cluster", "pong", payload(node_count, index))
+    end)
+  end
+
+  defp payload(node_count, index) do
+    from_index = rem(index, node_count)
+    to_index = rem(div(index, node_count), node_count)
+
+    %Payload{
+      from_node: "loadnode-#{from_index}",
+      from_region: region(from_index),
+      node: "loadnode-#{to_index}",
+      region: region(to_index),
+      latency: 5 + :rand.uniform(20),
+      response: {:ok, {:pong, region(to_index)}},
+      timestamp: DateTime.utc_now()
+    }
+  end
+
+  defp region(idx), do: Enum.at(@regions, rem(idx, length(@regions)))
+
+  # Phoenix.LiveView.Channel tags its own process dictionary with the view module for
+  # exactly this kind of introspection, so a real, connected `/status` tab can be found.
+  defp find_status_live_pids do
+    for pid <- Process.list(),
+        {:dictionary, dict} <- [Process.info(pid, :dictionary)],
+        {:"$initial_call", {RealtimeWeb.StatusLive.Index, :mount, 3}} <- dict,
+        do: pid
+  end
+
+  defp poll_and_report(state) do
+    elapsed_ms = monotonic_ms() - state.start_ms
+
+    case find_status_live_pids() do
+      [] ->
+        IO.puts("[load] t=#{format_time(elapsed_ms)}  sent=#{state.sent}  no /status tab found yet")
+        state
+
+      pids ->
+        Enum.reduce(pids, state, &record_sample(&2, &1, elapsed_ms))
+    end
+  end
+
+  defp record_sample(state, pid, elapsed_ms) do
+    case Process.info(pid, [:message_queue_len, :memory]) do
+      nil ->
+        IO.puts("[load] t=#{format_time(elapsed_ms)}  #{inspect(pid)} is DEAD")
+        state
+
+      info ->
+        qlen = info[:message_queue_len]
+        mem = info[:memory]
+
+        IO.puts(
+          "[load] t=#{format_time(elapsed_ms)}  #{inspect(pid)}  sent=#{state.sent}  " <>
+            "actual=#{format_rate(state.sent, elapsed_ms)}/s mem=#{format_bytes(mem)} queue_len=#{pad(qlen)}}"
+        )
+
+        view = Map.get(state.views, pid, %{samples: []})
+        view = %{view | samples: [{elapsed_ms, qlen, mem} | view.samples]}
+        state = %{state | views: Map.put(state.views, pid, view)}
+
+        state
+    end
+  end
+
+  defp print_banner(node_count, rate, duration_ms, poll_ms) do
+    port = Endpoint.config(:http)[:port]
+
+    IO.puts(
+      "[load] N=#{node_count}  target_rate=#{Float.round(rate, 1)} msgs/s  " <>
+        "duration=#{duration_ms / 1000}s  poll_every=#{poll_ms}ms"
+    )
+
+    IO.puts("[load] open http://localhost:#{port}/status now to attach a tab to monitor")
+  end
+
+  defp print_summary(state, node_count, rate, duration_ms) do
+    elapsed_ms = monotonic_ms() - state.start_ms
+
+    IO.puts("[load] ================= SUMMARY =================")
+
+    IO.puts(
+      "[load] N=#{node_count}  target_rate=#{Float.round(rate, 1)} msgs/s  duration=#{duration_ms / 1000}s (ran #{format_time(elapsed_ms)})"
+    )
+
+    IO.puts("[load] messages sent: #{state.sent}  (actual throughput: #{format_rate(state.sent, elapsed_ms)} msgs/s)")
+
+    if map_size(state.views) == 0 do
+      IO.puts("[load] no /status tab was ever found — nothing to report")
+    else
+      Enum.each(state.views, fn {pid, view} -> print_view_summary(pid, view) end)
+    end
+
+    IO.puts("[load] =============================================")
+  end
+
+  defp print_view_summary(pid, view) do
+    samples = Enum.reverse(view.samples)
+    {_, first_qlen, first_mem} = List.first(samples)
+    {_, last_qlen, last_mem} = List.last(samples)
+    peak_qlen = samples |> Enum.map(&elem(&1, 1)) |> Enum.max()
+    peak_mem = samples |> Enum.map(&elem(&1, 2)) |> Enum.max()
+
+    IO.puts("[load] #{inspect(pid)}:")
+    IO.puts("[load]   queue_len: start=#{first_qlen}  peak=#{peak_qlen}  final=#{last_qlen}")
+
+    IO.puts(
+      "[load]   memory:    start=#{format_bytes(first_mem)}  peak=#{format_bytes(peak_mem)}  final=#{format_bytes(last_mem)}"
+    )
+  end
+
+  defp format_time(ms), do: "#{Float.round(ms / 1000, 1)}s"
+  defp format_rate(_sent, 0), do: "0.0"
+  defp format_rate(sent, elapsed_ms), do: Float.round(sent * 1000 / elapsed_ms, 1)
+  defp format_bytes(bytes), do: String.pad_leading("#{Float.round(bytes / 1_000_000, 1)} MB", 8)
+  defp pad(n, padding \\ 6), do: n |> Integer.to_string() |> String.pad_leading(padding)
+
+  defp monotonic_ms(), do: System.monotonic_time(:millisecond)
+end
+
+node_count = Realtime.Env.get_integer("LOAD_NODE_COUNT", 100)
+duration_ms = Realtime.Env.get_integer("LOAD_DURATION_MS", 60_000)
+poll_ms = Realtime.Env.get_integer("LOAD_POLL_MS", 1_000)
+
+RealtimeLoadTest.StatusLive.run(node_count, duration_ms, poll_ms)

--- a/test/realtime_web/live/status_live/index_test.exs
+++ b/test/realtime_web/live/status_live/index_test.exs
@@ -32,8 +32,30 @@ defmodule RealtimeWeb.StatusLive.IndexTest do
 
       Endpoint.broadcast("admin:cluster", "ping", payload)
 
+      send(view.pid, :flush)
       html = render(view)
       assert html =~ "region: us-east-1"
+    end
+
+    test "renders are throttled until the flush timer fires", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/status")
+
+      payload = %Payload{
+        from_node: @self,
+        from_region: "us-east-1",
+        node: @self,
+        region: "us-east-1",
+        latency: 42.0,
+        response: {:ok, {:pong, "us-east-1"}},
+        timestamp: DateTime.utc_now()
+      }
+
+      Endpoint.broadcast("admin:cluster", "ping", payload)
+
+      refute render(view) =~ "region: us-east-1"
+
+      send(view.pid, :flush)
+      assert render(view) =~ "region: us-east-1"
     end
   end
 


### PR DESCRIPTION
👋 

The main goal here is to stop the status page from crashing. 

The most important bit for the crash is:

```
Process: #PID<0.19739425.8> on node :"realtime@2600:1f1c:c01:4900:87b8:cc8e:10c4:1fb4"
Context: maximum heap size reached
Max Heap Size: 125000000
Total Heap Size: 149485546
Kill: true
Error Logger: true
Message Queue Len: 366999
```

I.e. the message queue is overly long.

The root cause here is that on every broadcast from `latency` we subbed to we used to do a re-render due to the change tracking via `assign`. The rendering would take too long, hence the messages would pile up and then 💥 . There's a lot of traffic since basically we get a message for every node pinging every other node once every 15 seconds. So, say 100 nodes - that's 100 * 100 / 15 = ~666 messages/s aka each render could only take ~1.5ms to keep up.

The fix applied here, stores the messages/changes triggered but renders them out only every second. That's still very fresh, but without doing all the additional work of rendering multiple times a second.

That change is implemented in df3f93e6eed502bd0402b318c020782db1754ece and is much smaller than the rest of these changes.

The remainder of the changes here are small conveniences and one big one: a script to load test this view, to verify the problem and the fix. The script sends fake messages to load test and polls the process state checking in on queue length and Memory consumption.

## Verification

### Before Fix

**node_count=100**

```
[load] t=59.2s  #PID<0.1064.0>  sent=38860  actual=656.6/s mem= 35.9 MB queue_len= 35969
[load] t=60.2s  #PID<0.1064.0>  sent=39530  actual=656.6/s mem= 36.0 MB queue_len= 36623
[load] t=61.2s  #PID<0.1064.0>  sent=40200  actual=656.6/s mem= 36.1 MB queue_len= 37276
[load] ================= SUMMARY =================
[load] N=100  target_rate=666.7 msgs/s  duration=60.0s (ran 61.2s)
[load] messages sent: 40200  (actual throughput: 656.6 msgs/s)
[load] #PID<0.1064.0>:
[load]   queue_len: start=67  peak=37276  final=37276
[load]   memory:    start=  2.6 MB  peak= 51.0 MB  final= 36.1 MB
[load] =============================================
```

_I'll spare us the higher node counts_

### After Fix

**node_count=100**

```
[load] t=60.3s  #PID<0.1130.0>  sent=38860  actual=644.1/s mem=  9.6 MB queue_len=     0
[load] t=61.4s  #PID<0.1130.0>  sent=39530  actual=643.9/s mem=  9.6 MB queue_len=     0
[load] t=62.4s  #PID<0.1130.0>  sent=40200  actual=643.8/s mem=  9.6 MB queue_len=     0
[load] ================= SUMMARY =================
[load] N=100  target_rate=666.7 msgs/s  duration=60.0s (ran 62.4s)
[load] messages sent: 40200  (actual throughput: 643.8 msgs/s)
[load] #PID<0.1130.0>:
[load]   queue_len: start=0  peak=67  final=0
[load]   memory:    start=  4.7 MB  peak= 13.2 MB  final=  9.6 MB
[load] =============================================
```

**node_count=150**

```
[load] t=60.7s  #PID<0.1064.0>  sent=87000  actual=1433.1/s mem= 22.5 MB queue_len=     0
[load] t=61.8s  #PID<0.1064.0>  sent=88500  actual=1433.2/s mem= 16.4 MB queue_len=     0
[load] t=62.8s  #PID<0.1064.0>  sent=90000  actual=1433.3/s mem= 22.5 MB queue_len=     0
[load] ================= SUMMARY =================
[load] N=150  target_rate=1.5e3 msgs/s  duration=60.0s (ran 62.8s)
[load] messages sent: 90000  (actual throughput: 1433.2 msgs/s)
[load] #PID<0.1064.0>:
[load]   queue_len: start=0  peak=450  final=0
[load]   memory:    start=  7.6 MB  peak= 24.0 MB  final= 22.5 MB
[load] =============================================
```

**node_count=200**

```
[load] t=61.9s  #PID<0.1064.0>  sent=157530  actual=2546.4/s mem= 30.7 MB queue_len=   267
[load] t=62.9s  #PID<0.1064.0>  sent=160200  actual=2546.4/s mem= 32.8 MB queue_len=   267
[load] ================= SUMMARY =================
[load] N=200  target_rate=2666.7 msgs/s  duration=60.0s (ran 62.9s)
[load] messages sent: 160200  (actual throughput: 2546.3 msgs/s)
[load] #PID<0.1064.0>:
[load]   queue_len: start=0  peak=1069  final=267
[load]   memory:    start= 11.3 MB  peak= 45.6 MB  final= 32.8 MB
[load] =============================================
```

(notably this one once went up to 800 but down to 0 again so might still stabilize)

## Note-worthy

* I put the load testing script into a new `scripts` folder - arguably it could/should be in `bench` (although not a benchmark) - happy for feedback/thoughts
* The way I got the nodes to render in the load test is slightly sus/has an effect on prod code but should be negligible and without it the view renders basically nothing --> not a realistic test