### PR TITLE
feat: pg changes able to wait on subscription

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,7 @@ config :realtime,
   replication_watchdog_interval: :timer.minutes(5),
   replication_watchdog_timeout: :timer.minutes(1),
   replication_ready_timeout: :timer.minutes(1),
+  # Blocks the transport process, so keep it under the client heartbeat interval (30s)
   postgres_changes_wait_max_timeout: :timer.seconds(20)
 
 # Configures the endpoint

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,8 @@ config :realtime,
   version: Mix.Project.config()[:version],
   replication_watchdog_interval: :timer.minutes(5),
   replication_watchdog_timeout: :timer.minutes(1),
-  replication_ready_timeout: :timer.minutes(1)
+  replication_ready_timeout: :timer.minutes(1),
+  postgres_changes_wait_max_timeout: :timer.seconds(20)
 
 # Configures the endpoint
 config :realtime, RealtimeWeb.Endpoint,

--- a/lib/realtime_web/channels/payloads/config.ex
+++ b/lib/realtime_web/channels/payloads/config.ex
@@ -8,12 +8,14 @@ defmodule RealtimeWeb.Channels.Payloads.Config do
   alias RealtimeWeb.Channels.Payloads.Broadcast
   alias RealtimeWeb.Channels.Payloads.Presence
   alias RealtimeWeb.Channels.Payloads.PostgresChange
+  alias RealtimeWeb.Channels.Payloads.PostgresChangesOptions
   alias RealtimeWeb.Channels.Payloads.FlexibleBoolean
 
   embedded_schema do
     embeds_one :broadcast, Broadcast
     embeds_one :presence, Presence
     embeds_many :postgres_changes, PostgresChange
+    embeds_one :postgres_changes_options, PostgresChangesOptions
     field :private, FlexibleBoolean, default: false
   end
 
@@ -32,5 +34,6 @@ defmodule RealtimeWeb.Channels.Payloads.Config do
     |> cast_embed(:broadcast, invalid_message: "unable to parse, expected a map")
     |> cast_embed(:presence, invalid_message: "unable to parse, expected a map")
     |> cast_embed(:postgres_changes, invalid_message: "unable to parse, expected an array of maps")
+    |> cast_embed(:postgres_changes_options, invalid_message: "unable to parse, expected a map")
   end
 end

--- a/lib/realtime_web/channels/payloads/join.ex
+++ b/lib/realtime_web/channels/payloads/join.ex
@@ -6,6 +6,7 @@ defmodule RealtimeWeb.Channels.Payloads.Join do
   import Ecto.Changeset
   alias RealtimeWeb.Channels.Payloads.Config
   alias RealtimeWeb.Channels.Payloads.Broadcast
+  alias RealtimeWeb.Channels.Payloads.PostgresChangesOptions
   alias RealtimeWeb.Channels.Payloads.Presence
 
   embedded_schema do
@@ -47,6 +48,17 @@ defmodule RealtimeWeb.Channels.Payloads.Join do
 
   def private?(%__MODULE__{config: %Config{private: private}}), do: private
   def private?(_), do: false
+
+  @doc """
+  How long the join blocks waiting for the postgres_changes subscription, never above the server
+  maximum. `nil` when the join is not waiting.
+  """
+  def postgres_changes_wait_timeout(%__MODULE__{
+        config: %Config{postgres_changes_options: %PostgresChangesOptions{wait: true, timeout: timeout}}
+      }),
+      do: min(timeout, Application.fetch_env!(:realtime, :postgres_changes_wait_max_timeout))
+
+  def postgres_changes_wait_timeout(_), do: nil
 
   def error_message(_field, meta) do
     type = Keyword.get(meta, :type)

--- a/lib/realtime_web/channels/payloads/postgres_changes_options.ex
+++ b/lib/realtime_web/channels/payloads/postgres_changes_options.ex
@@ -1,0 +1,22 @@
+defmodule RealtimeWeb.Channels.Payloads.PostgresChangesOptions do
+  @moduledoc """
+  Validate postgres_changes_options field of the join payload.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias RealtimeWeb.Channels.Payloads.FlexibleBoolean
+  alias RealtimeWeb.Channels.Payloads.Join
+
+  @default_timeout :timer.seconds(15)
+
+  embedded_schema do
+    field :wait, FlexibleBoolean, default: false
+    field :timeout, :integer, default: @default_timeout
+  end
+
+  def changeset(postgres_changes_options, attrs) do
+    postgres_changes_options
+    |> cast(attrs, [:wait, :timeout], message: &Join.error_message/2)
+    |> validate_number(:timeout, greater_than: 0)
+  end
+end

--- a/lib/realtime_web/channels/payloads/postgres_changes_options.ex
+++ b/lib/realtime_web/channels/payloads/postgres_changes_options.ex
@@ -1,6 +1,12 @@
 defmodule RealtimeWeb.Channels.Payloads.PostgresChangesOptions do
   @moduledoc """
   Validate postgres_changes_options field of the join payload.
+
+  * `wait` - hold the join reply until the postgres_changes subscription is established.
+  * `timeout` - how long to hold it for. The server clamps this to
+    `:postgres_changes_wait_max_timeout`, so a client asking for more waits less; when the wait
+    runs out the join is rejected with `PostgresChangesSubscribeTimeout` naming the timeout that
+    was actually applied.
   """
   use Ecto.Schema
   import Ecto.Changeset

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -35,8 +35,8 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   @confirm_token_ms_interval :timer.minutes(5)
   @replication_ready_check_interval 500
-  @postgres_subscribe_first_retry 100
-  @postgres_subscribe_max_retry 1_000
+  @postgres_subscribe_backoff_min 100
+  @postgres_subscribe_backoff_max 1_000
   @postgres_subscribe_fatal_reasons [:malformed_subscription_params, :subscription_insert_failed]
   @postgres_subscribe_error_code "RealtimeDisabledForConfiguration"
   @fullsweep_after Application.compile_env!(:realtime, :websocket_fullsweep_after)
@@ -953,12 +953,22 @@ defmodule RealtimeWeb.RealtimeChannel do
         :ok
 
       timeout ->
-        deadline = System.monotonic_time(:millisecond) + timeout
-        await_postgres_subscribe(socket, tenant, pg_change_params, deadline, @postgres_subscribe_first_retry)
+        await_postgres_subscribe(socket, %{
+          tenant: tenant,
+          pg_change_params: pg_change_params,
+          timeout: timeout,
+          deadline: System.monotonic_time(:millisecond) + timeout,
+          backoff:
+            Backoff.new(
+              backoff_min: @postgres_subscribe_backoff_min,
+              backoff_max: @postgres_subscribe_backoff_max,
+              backoff_type: :rand_exp
+            )
+        })
     end
   end
 
-  defp await_postgres_subscribe(socket, tenant, pg_change_params, deadline, interval) do
+  defp await_postgres_subscribe(socket, %{tenant: tenant, pg_change_params: pg_change_params} = wait) do
     case postgres_subscribe_attempt(tenant, pg_change_params) do
       {:ok, _response} ->
         send(self(), :postgres_changes_subscribed)
@@ -968,23 +978,27 @@ defmodule RealtimeWeb.RealtimeChannel do
         maybe_log_warning(socket, @postgres_subscribe_error_code, error)
 
       {:error, :not_connected} ->
-        sleep_and_retry_postgres_subscribe(socket, tenant, pg_change_params, deadline, interval)
+        sleep_and_retry_postgres_subscribe(socket, wait)
 
       {:error, :retry, error} ->
         maybe_log_warning(socket, @postgres_subscribe_error_code, error)
-        sleep_and_retry_postgres_subscribe(socket, tenant, pg_change_params, deadline, interval)
+        sleep_and_retry_postgres_subscribe(socket, wait)
     end
   end
 
-  defp sleep_and_retry_postgres_subscribe(socket, tenant, pg_change_params, deadline, interval) do
+  defp sleep_and_retry_postgres_subscribe(socket, %{deadline: deadline, backoff: backoff, timeout: timeout} = wait) do
     case deadline - System.monotonic_time(:millisecond) do
       remaining when remaining > 0 ->
+        {interval, backoff} = Backoff.backoff(backoff)
         Process.sleep(min(interval, remaining))
-        next_interval = min(interval * 2, @postgres_subscribe_max_retry)
-        await_postgres_subscribe(socket, tenant, pg_change_params, deadline, next_interval)
+        await_postgres_subscribe(socket, %{wait | backoff: backoff})
 
       _ ->
-        log_error(socket, "PostgresChangesSubscribeTimeout", "Timed out waiting for postgres_changes subscription")
+        log_error(
+          socket,
+          "PostgresChangesSubscribeTimeout",
+          "Timed out after #{timeout}ms waiting for the postgres_changes subscription"
+        )
     end
   end
 

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -35,6 +35,10 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   @confirm_token_ms_interval :timer.minutes(5)
   @replication_ready_check_interval 500
+  @postgres_subscribe_first_retry 100
+  @postgres_subscribe_max_retry 1_000
+  @postgres_subscribe_fatal_reasons [:malformed_subscription_params, :subscription_insert_failed]
+  @postgres_subscribe_error_code "RealtimeDisabledForConfiguration"
   @fullsweep_after Application.compile_env!(:realtime, :websocket_fullsweep_after)
 
   @impl true
@@ -159,9 +163,9 @@ defmodule RealtimeWeb.RealtimeChannel do
 
       UsersCounter.add(transport_pid, tenant_id)
 
-      case await_muster_join(muster_join_task, socket) do
-        :ok -> {:ok, state, assign(socket, assigns)}
-        {:error, _} = error -> error
+      with :ok <- await_muster_join(muster_join_task, socket),
+           :ok <- start_postgres_subscribe(socket, join, tenant, pg_change_params) do
+        {:ok, state, assign(socket, assigns)}
       end
     else
       {:error, :expired_token, msg} ->
@@ -346,46 +350,36 @@ defmodule RealtimeWeb.RealtimeChannel do
     {:noreply, socket}
   end
 
+  def handle_info(:postgres_changes_subscribed, %{assigns: %{channel_name: channel_name}} = socket) do
+    push_postgres_changes_subscribed(socket, channel_name)
+    {:noreply, socket}
+  end
+
   def handle_info(:postgres_subscribe, %{assigns: %{channel_name: channel_name}} = socket) do
-    %{
-      assigns: %{
-        tenant: tenant_id,
-        pg_sub_ref: pg_sub_ref,
-        pg_change_params: pg_change_params
-      }
-    } = socket
+    %{assigns: %{tenant: tenant_id, pg_sub_ref: pg_sub_ref, pg_change_params: pg_change_params}} = socket
 
     Helpers.cancel_timer(pg_sub_ref)
 
     %Tenant{} = tenant = Cache.get_tenant_by_external_id(tenant_id)
-    {:ok, module} = PostgresCdc.driver(tenant.postgres_cdc_default)
-    postgres_extension = PostgresCdc.filter_settings(tenant.postgres_cdc_default, tenant.extensions)
 
-    args = %{"region" => postgres_extension["region"], "id" => tenant_id}
+    case postgres_subscribe_attempt(tenant, pg_change_params) do
+      {:ok, _response} ->
+        push_postgres_changes_subscribed(socket, channel_name)
+        {:noreply, assign(socket, :pg_sub_ref, nil)}
 
-    case PostgresCdc.connect(module, args) do
-      {:ok, response} ->
-        case PostgresCdc.after_connect(module, response, postgres_extension, pg_change_params, tenant_id) do
-          {:ok, _response} ->
-            message = "Subscribed to PostgreSQL"
-            maybe_log_info(socket, message)
-            push_system_message("postgres_changes", socket, "ok", message, channel_name)
-            {:noreply, assign(socket, :pg_sub_ref, nil)}
+      {:error, :fatal, error} ->
+        maybe_log_warning(socket, @postgres_subscribe_error_code, error)
+        push_system_message("postgres_changes", socket, "error", error, channel_name)
+        # No point in retrying if the params are invalid
+        {:noreply, assign(socket, :pg_sub_ref, nil)}
 
-          {:error, {reason, error}} when reason in [:malformed_subscription_params, :subscription_insert_failed] ->
-            maybe_log_warning(socket, "RealtimeDisabledForConfiguration", error)
-            push_system_message("postgres_changes", socket, "error", error, channel_name)
-            # No point in retrying if the params are invalid
-            {:noreply, assign(socket, :pg_sub_ref, nil)}
+      {:error, :retry, error} ->
+        maybe_log_warning(socket, @postgres_subscribe_error_code, error)
 
-          error ->
-            maybe_log_warning(socket, "RealtimeDisabledForConfiguration", error)
+        push_system_message("postgres_changes", socket, "error", error, channel_name)
+        {:noreply, assign(socket, :pg_sub_ref, postgres_subscribe(5, 10))}
 
-            push_system_message("postgres_changes", socket, "error", error, channel_name)
-            {:noreply, assign(socket, :pg_sub_ref, postgres_subscribe(5, 10))}
-        end
-
-      nil ->
+      {:error, :not_connected} ->
         maybe_log_warning(
           socket,
           "ReconnectSubscribeToPostgres",
@@ -393,11 +387,6 @@ defmodule RealtimeWeb.RealtimeChannel do
         )
 
         {:noreply, assign(socket, :pg_sub_ref, postgres_subscribe())}
-
-      error ->
-        maybe_log_error(socket, "UnableToSubscribeToPostgres", error)
-        push_system_message("postgres_changes", socket, "error", error, channel_name)
-        {:noreply, assign(socket, :pg_sub_ref, postgres_subscribe(5, 10))}
     end
   rescue
     error ->
@@ -935,9 +924,74 @@ defmodule RealtimeWeb.RealtimeChannel do
     {:ok, module} = PostgresCdc.driver(tenant.postgres_cdc_default)
     PostgresCdc.subscribe(module, pg_change_params, tenant.external_id, metadata)
 
-    send(self(), :postgres_subscribe)
-
     pg_change_params
+  end
+
+  @spec postgres_subscribe_attempt(Tenant.t(), list()) ::
+          {:ok, term()} | {:error, :not_connected} | {:error, :fatal | :retry, term()}
+  defp postgres_subscribe_attempt(%Tenant{external_id: tenant_id} = tenant, pg_change_params) do
+    {:ok, module} = PostgresCdc.driver(tenant.postgres_cdc_default)
+    settings = PostgresCdc.filter_settings(tenant.postgres_cdc_default, tenant.extensions)
+    args = %{"region" => settings["region"], "id" => tenant_id}
+
+    with {:ok, connection} <- PostgresCdc.connect(module, args),
+         {:ok, response} <- PostgresCdc.after_connect(module, connection, settings, pg_change_params, tenant_id) do
+      {:ok, response}
+    else
+      nil -> {:error, :not_connected}
+      {:error, {reason, error}} when reason in @postgres_subscribe_fatal_reasons -> {:error, :fatal, error}
+      error -> {:error, :retry, error}
+    end
+  end
+
+  defp start_postgres_subscribe(_socket, _join, _tenant, []), do: :ok
+
+  defp start_postgres_subscribe(socket, join, tenant, pg_change_params) do
+    case Join.postgres_changes_wait_timeout(join) do
+      nil ->
+        send(self(), :postgres_subscribe)
+        :ok
+
+      timeout ->
+        deadline = System.monotonic_time(:millisecond) + timeout
+        await_postgres_subscribe(socket, tenant, pg_change_params, deadline, @postgres_subscribe_first_retry)
+    end
+  end
+
+  defp await_postgres_subscribe(socket, tenant, pg_change_params, deadline, interval) do
+    case postgres_subscribe_attempt(tenant, pg_change_params) do
+      {:ok, _response} ->
+        send(self(), :postgres_changes_subscribed)
+        :ok
+
+      {:error, :fatal, error} ->
+        maybe_log_warning(socket, @postgres_subscribe_error_code, error)
+
+      {:error, :not_connected} ->
+        sleep_and_retry_postgres_subscribe(socket, tenant, pg_change_params, deadline, interval)
+
+      {:error, :retry, error} ->
+        maybe_log_warning(socket, @postgres_subscribe_error_code, error)
+        sleep_and_retry_postgres_subscribe(socket, tenant, pg_change_params, deadline, interval)
+    end
+  end
+
+  defp sleep_and_retry_postgres_subscribe(socket, tenant, pg_change_params, deadline, interval) do
+    case deadline - System.monotonic_time(:millisecond) do
+      remaining when remaining > 0 ->
+        Process.sleep(min(interval, remaining))
+        next_interval = min(interval * 2, @postgres_subscribe_max_retry)
+        await_postgres_subscribe(socket, tenant, pg_change_params, deadline, next_interval)
+
+      _ ->
+        log_error(socket, "PostgresChangesSubscribeTimeout", "Timed out waiting for postgres_changes subscription")
+    end
+  end
+
+  defp push_postgres_changes_subscribed(socket, channel_name) do
+    message = "Subscribed to PostgreSQL"
+    maybe_log_info(socket, message)
+    push_system_message("postgres_changes", socket, "ok", message, channel_name)
   end
 
   defp add_id_to_postgres_changes(pg_change_params) do

--- a/mise.lock
+++ b/mise.lock
@@ -74,6 +74,25 @@ checksum = "sha256:b01b0830076539b15e63e0bcecd71b38be7bd3784c4bcd0bf46339d579549
 url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_win64_28.5.0.4.zip"
 url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491644305"
 
+[[tools.erlang]]
+version = "28.5.0.4"
+backend = "core:erlang"
+
+[tools.erlang.options]
+precompiled_os = "ubuntu-24.04"
+
+[tools.erlang."platforms.linux-arm64"]
+checksum = "sha256:efb045f96ee56d274f6c1fe3a9612b45caa01d2f82e35fe4e0ac9b0c501f6e53"
+url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_src_28.5.0.4.tar.gz"
+url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491552679"
+install = "source"
+
+[tools.erlang."platforms.linux-x64"]
+checksum = "sha256:efb045f96ee56d274f6c1fe3a9612b45caa01d2f82e35fe4e0ac9b0c501f6e53"
+url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_src_28.5.0.4.tar.gz"
+url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491552679"
+install = "source"
+
 [[tools.node]]
 version = "24.14.1"
 backend = "core:node"

--- a/mise.lock
+++ b/mise.lock
@@ -74,25 +74,6 @@ checksum = "sha256:b01b0830076539b15e63e0bcecd71b38be7bd3784c4bcd0bf46339d579549
 url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_win64_28.5.0.4.zip"
 url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491644305"
 
-[[tools.erlang]]
-version = "28.5.0.4"
-backend = "core:erlang"
-
-[tools.erlang.options]
-precompiled_os = "ubuntu-24.04"
-
-[tools.erlang."platforms.linux-arm64"]
-checksum = "sha256:efb045f96ee56d274f6c1fe3a9612b45caa01d2f82e35fe4e0ac9b0c501f6e53"
-url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_src_28.5.0.4.tar.gz"
-url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491552679"
-install = "source"
-
-[tools.erlang."platforms.linux-x64"]
-checksum = "sha256:efb045f96ee56d274f6c1fe3a9612b45caa01d2f82e35fe4e0ac9b0c501f6e53"
-url = "https://github.com/erlang/otp/releases/download/OTP-28.5.0.4/otp_src_28.5.0.4.tar.gz"
-url_api = "https://api.github.com/repos/erlang/otp/releases/assets/491552679"
-install = "source"
-
 [[tools.node]]
 version = "24.14.1"
 backend = "core:node"

--- a/test/integration/rt_channel/postgres_changes_test.exs
+++ b/test/integration/rt_channel/postgres_changes_test.exs
@@ -85,6 +85,84 @@ defmodule Realtime.Integration.RtChannel.PostgresChangesTest do
     end
   end
 
+  describe "wait for subscription" do
+    test "a write straight after the join reply is not missed", %{tenant: tenant, serializer: serializer} do
+      assert_cdc_stopped(tenant)
+
+      {socket, _} = get_connection(tenant, serializer)
+      topic = "realtime:any"
+
+      config = %{
+        postgres_changes: [%{event: "INSERT", schema: "public"}],
+        postgres_changes_options: %{wait: true, timeout: 15_000}
+      }
+
+      WebsocketClient.join(socket, topic, %{config: config})
+      sub_id = :erlang.phash2(%{"event" => "INSERT", "schema" => "public"})
+
+      assert_receive %Message{
+                       event: "phx_reply",
+                       payload: %{
+                         "response" => %{
+                           "postgres_changes" => [%{"event" => "INSERT", "id" => ^sub_id, "schema" => "public"}]
+                         },
+                         "status" => "ok"
+                       },
+                       topic: ^topic
+                     },
+                     20_000
+
+      assert_receive %Message{
+                       event: "system",
+                       payload: %{
+                         "channel" => "any",
+                         "extension" => "postgres_changes",
+                         "message" => "Subscribed to PostgreSQL",
+                         "status" => "ok"
+                       },
+                       ref: nil,
+                       topic: ^topic
+                     },
+                     500
+
+      {:ok, _, conn} = PostgresCdcRls.get_manager_conn(tenant.external_id)
+      %{rows: [[id]]} = Postgrex.query!(conn, "insert into test (details) values ('test') returning id", [])
+
+      assert_receive %Message{
+                       event: "postgres_changes",
+                       payload: %{
+                         "data" => %{"record" => %{"details" => "test", "id" => ^id}, "type" => "INSERT"},
+                         "ids" => [^sub_id]
+                       },
+                       ref: nil,
+                       topic: ^topic
+                     },
+                     2000
+    end
+
+    test "join is rejected when the subscription params are malformed", %{tenant: tenant, serializer: serializer} do
+      {socket, _} = get_connection(tenant, serializer)
+      topic = "realtime:any"
+
+      config = %{
+        postgres_changes: [%{event: "INSERT", schema: "public", table: "test", filter: "wrong"}],
+        postgres_changes_options: %{wait: true, timeout: 15_000}
+      }
+
+      WebsocketClient.join(socket, topic, %{config: config})
+
+      assert_receive %Message{
+                       event: "phx_reply",
+                       payload: %{"status" => "error", "response" => %{"reason" => reason}},
+                       topic: ^topic
+                     },
+                     20_000
+
+      assert reason =~ "RealtimeDisabledForConfiguration"
+      assert reason =~ "Error parsing `filter` params"
+    end
+  end
+
   describe "bytea column" do
     test "handle insert with bytea data without double-encoding", %{
       tenant: tenant,
@@ -810,5 +888,10 @@ defmodule Realtime.Integration.RtChannel.PostgresChangesTest do
                      },
                      1000
     end
+  end
+
+  defp assert_cdc_stopped(tenant) do
+    PostgresCdcRls.handle_stop(tenant.external_id, 5000)
+    eventually(fn -> PostgresCdcRls.get_manager_conn(tenant.external_id) == {:error, nil} end)
   end
 end

--- a/test/realtime_web/channels/payloads/join_test.exs
+++ b/test/realtime_web/channels/payloads/join_test.exs
@@ -9,6 +9,7 @@ defmodule RealtimeWeb.Channels.Payloads.JoinTest do
   alias RealtimeWeb.Channels.Payloads.Broadcast.Replay
   alias RealtimeWeb.Channels.Payloads.Presence
   alias RealtimeWeb.Channels.Payloads.PostgresChange
+  alias RealtimeWeb.Channels.Payloads.PostgresChangesOptions
 
   describe "validate/1" do
     test "valid payload allows join" do
@@ -300,6 +301,59 @@ defmodule RealtimeWeb.Channels.Payloads.JoinTest do
 
     test "defaults to false when config is nil" do
       refute Join.private?(%Join{config: nil})
+    end
+  end
+
+  describe "postgres_changes_options" do
+    test "parses wait and timeout" do
+      config = %{"config" => %{"postgres_changes_options" => %{"wait" => true, "timeout" => 10_000}}}
+
+      assert {:ok, %Join{config: %Config{postgres_changes_options: options}} = join} = Join.validate(config)
+      assert %PostgresChangesOptions{wait: true, timeout: 10_000} = options
+      assert Join.postgres_changes_wait_timeout(join) == 10_000
+    end
+
+    test "does not wait when not asked to" do
+      for config <- [%{"config" => %{}}, %{"config" => %{"postgres_changes_options" => %{}}}] do
+        assert {:ok, join} = Join.validate(config)
+        assert Join.postgres_changes_wait_timeout(join) == nil
+      end
+    end
+
+    test "accepts string booleans for wait and defaults the timeout" do
+      config = %{"config" => %{"postgres_changes_options" => %{"wait" => "true"}}}
+
+      assert {:ok, join} = Join.validate(config)
+      assert Join.postgres_changes_wait_timeout(join) == 15_000
+    end
+
+    test "clamps the timeout to the server maximum" do
+      max = Application.fetch_env!(:realtime, :postgres_changes_wait_max_timeout)
+      config = %{"config" => %{"postgres_changes_options" => %{"wait" => true, "timeout" => max * 10}}}
+
+      assert {:ok, join} = Join.validate(config)
+      assert Join.postgres_changes_wait_timeout(join) == max
+    end
+
+    test "invalid timeout returns errors" do
+      config = %{"config" => %{"postgres_changes_options" => %{"timeout" => "soon"}}}
+
+      assert {:error, :invalid_join_payload, errors} = Join.validate(config)
+      assert errors == %{config: %{postgres_changes_options: %{timeout: ["unable to parse, expected integer"]}}}
+    end
+
+    test "non positive timeout returns errors" do
+      config = %{"config" => %{"postgres_changes_options" => %{"timeout" => 0}}}
+
+      assert {:error, :invalid_join_payload, %{config: %{postgres_changes_options: %{timeout: [_]}}}} =
+               Join.validate(config)
+    end
+
+    test "non map options returns errors" do
+      config = %{"config" => %{"postgres_changes_options" => 123}}
+
+      assert {:error, :invalid_join_payload, errors} = Join.validate(config)
+      assert errors == %{config: %{postgres_changes_options: ["unable to parse, expected a map"]}}
     end
   end
 

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -308,6 +308,74 @@ defmodule RealtimeWeb.RealtimeChannelTest do
       # It will try again in the future
       assert socket.assigns.pg_sub_ref != nil
     end
+
+    test "wait rejects the join when the subscription is not established in time", %{tenant: tenant} do
+      stub(Extensions.PostgresCdcRls, :handle_connect, fn _ -> nil end)
+
+      assert {:error, %{reason: "PostgresChangesSubscribeTimeout: Timed out waiting for postgres_changes subscription"}} =
+               join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 100})
+    end
+
+    test "wait does not start a connect attempt once the timeout has passed", %{tenant: tenant} do
+      test_pid = self()
+
+      stub(Extensions.PostgresCdcRls, :handle_connect, fn _ ->
+        send(test_pid, :connect_attempt)
+        Process.sleep(300)
+        nil
+      end)
+
+      assert {:error, %{reason: "PostgresChangesSubscribeTimeout: " <> _}} =
+               join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 200})
+
+      assert_received :connect_attempt
+      refute_received :connect_attempt
+    end
+
+    test "wait lets an in-flight subscription attempt finish before rejecting the join", %{tenant: tenant} do
+      test_pid = self()
+      stub(Extensions.PostgresCdcRls, :handle_connect, fn _ -> {:ok, {test_pid, test_pid}} end)
+
+      stub(Extensions.PostgresCdcRls, :handle_after_connect, fn _, _, _, _ ->
+        send(test_pid, :after_connect_attempt)
+        Process.sleep(300)
+        {:error, :boom}
+      end)
+
+      {elapsed, result} =
+        :timer.tc(
+          fn -> join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 200}) end,
+          :millisecond
+        )
+
+      assert {:error, %{reason: "PostgresChangesSubscribeTimeout: " <> _}} = result
+      assert elapsed >= 300
+      assert_received :after_connect_attempt
+      refute_received :after_connect_attempt
+    end
+
+    test "wait retries a transient subscribe failure until it succeeds", %{tenant: tenant} do
+      expect(Extensions.PostgresCdcRls, :handle_after_connect, fn _, _, _, _ ->
+        {:error, "Too many database timeouts"}
+      end)
+
+      expect(Extensions.PostgresCdcRls, :handle_after_connect, fn _, _, _, _ -> {:ok, []} end)
+
+      assert {:ok, _reply, _socket} = join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 5_000})
+    end
+
+    test "wait does not gate a join without postgres_changes bindings", %{tenant: tenant} do
+      stub(Extensions.PostgresCdcRls, :handle_connect, fn _ -> nil end)
+
+      assert {:ok, %{postgres_changes: []}, _socket} =
+               join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 100}, [])
+    end
+
+    test "join is not gated when wait is not requested", %{tenant: tenant} do
+      stub(Extensions.PostgresCdcRls, :handle_connect, fn _ -> nil end)
+
+      assert {:ok, _reply, _socket} = join_waiting_for_postgres_changes(tenant, %{"wait" => false})
+    end
   end
 
   describe "broadcast" do
@@ -1723,6 +1791,14 @@ defmodule RealtimeWeb.RealtimeChannelTest do
         x_headers: [{"x-api-key", token}]
       }
     ]
+  end
+
+  defp join_waiting_for_postgres_changes(tenant, options, changes \\ [%{"event" => "INSERT", "schema" => "public"}]) do
+    jwt = Generators.generate_jwt_token(tenant)
+    {:ok, %Socket{} = socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
+    config = %{"postgres_changes" => changes, "postgres_changes_options" => options}
+
+    subscribe_and_join(socket, "realtime:test", %{"config" => config})
   end
 
   defp update_extension(tenant, extension) do

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -310,34 +310,31 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     end
 
     test "wait rejects the join when the subscription is not established in time", %{tenant: tenant} do
+      expect(Extensions.PostgresCdcRls, :handle_connect, fn _ -> nil end)
       stub(Extensions.PostgresCdcRls, :handle_connect, fn _ -> nil end)
 
-      assert {:error, %{reason: "PostgresChangesSubscribeTimeout: Timed out waiting for postgres_changes subscription"}} =
-               join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 100})
+      assert {:error,
+              %{
+                reason:
+                  "PostgresChangesSubscribeTimeout: Timed out after 100ms waiting for the postgres_changes subscription"
+              }} = join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 100})
     end
 
     test "wait does not start a connect attempt once the timeout has passed", %{tenant: tenant} do
-      test_pid = self()
-
-      stub(Extensions.PostgresCdcRls, :handle_connect, fn _ ->
-        send(test_pid, :connect_attempt)
+      expect(Extensions.PostgresCdcRls, :handle_connect, fn _ ->
         Process.sleep(300)
         nil
       end)
 
       assert {:error, %{reason: "PostgresChangesSubscribeTimeout: " <> _}} =
                join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 200})
-
-      assert_received :connect_attempt
-      refute_received :connect_attempt
     end
 
     test "wait lets an in-flight subscription attempt finish before rejecting the join", %{tenant: tenant} do
       test_pid = self()
       stub(Extensions.PostgresCdcRls, :handle_connect, fn _ -> {:ok, {test_pid, test_pid}} end)
 
-      stub(Extensions.PostgresCdcRls, :handle_after_connect, fn _, _, _, _ ->
-        send(test_pid, :after_connect_attempt)
+      expect(Extensions.PostgresCdcRls, :handle_after_connect, fn _, _, _, _ ->
         Process.sleep(300)
         {:error, :boom}
       end)
@@ -350,8 +347,6 @@ defmodule RealtimeWeb.RealtimeChannelTest do
 
       assert {:error, %{reason: "PostgresChangesSubscribeTimeout: " <> _}} = result
       assert elapsed >= 300
-      assert_received :after_connect_attempt
-      refute_received :after_connect_attempt
     end
 
     test "wait retries a transient subscribe failure until it succeeds", %{tenant: tenant} do
@@ -365,14 +360,14 @@ defmodule RealtimeWeb.RealtimeChannelTest do
     end
 
     test "wait does not gate a join without postgres_changes bindings", %{tenant: tenant} do
-      stub(Extensions.PostgresCdcRls, :handle_connect, fn _ -> nil end)
+      reject(&Extensions.PostgresCdcRls.handle_connect/1)
 
       assert {:ok, %{postgres_changes: []}, _socket} =
                join_waiting_for_postgres_changes(tenant, %{"wait" => true, "timeout" => 100}, [])
     end
 
     test "join is not gated when wait is not requested", %{tenant: tenant} do
-      stub(Extensions.PostgresCdcRls, :handle_connect, fn _ -> nil end)
+      reject(&Extensions.PostgresCdcRls.handle_connect/1)
 
       assert {:ok, _reply, _socket} = join_waiting_for_postgres_changes(tenant, %{"wait" => false})
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

adds a new opt in wait for pg changes to accept the connection.

```js
channel.join({
  config: {
    postgres_changes: [],
    postgres_changes_options: {
      wait: true,
      timeout: 15000 // optional, ms; clamped server-side to `postgres_changes_wait_max_timeout`
    }
  }
})
```


