### PR TITLE
fix: Alert in alerts channel on known CVE, do not fail lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Credo checks
         run: mix credo
       - name: Run hex audit
+        # Advisories are informational here: fixing/updating dependencies isn't
+        # in scope for an arbitrary PR, so don't block merges on this. 
+        continue-on-error: true
         run: mix hex.audit
       - name: Check for unused deps
         run: mix deps.unlock --check-unused

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,60 @@
+name: Security Advisories
+
+# Runs mix hex.audit outside of PR gating so a newly published CVE never
+# blocks unrelated PRs. Deliberately never triggered by pull_request: that keeps
+# SLACK_ALERTS_WEBHOOK out of reach of forked-repo runs.
+# Scheduled so advisories are caught even when mix.lock hasn't
+# changed, not just on push.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "mix.lock"
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+# don't run 2 of the same runs at the same time, makes no sense
+concurrency:
+  group: security-audit
+
+permissions:
+  contents: read
+
+jobs:
+  hex-audit:
+    name: Hex Audit
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup elixir
+        id: beam
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          otp-version: 28.5.0.4
+          elixir-version: 1.19.5
+      - name: Cache Mix
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ github.workflow }}-${{ runner.os }}-mix-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ github.workflow }}-${{ runner.os }}-mix-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Run hex audit
+        run: mix hex.audit
+
+  notify-slack:
+    name: Notify Slack
+    needs: hex-audit
+    if: always() && needs.hex-audit.result == 'failure'
+    uses: ./.github/workflows/slack-notify.yml
+    with:
+      title: 'Hex Audit'
+      status: 'failure'
+    secrets:
+      SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK }}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,110 @@
+name: Reusable Slack Notification
+
+on:
+  workflow_call:
+    inputs:
+      title:
+        description: 'Short title (e.g., Hex Audit, Deploy)'
+        required: true
+        type: string
+      status:
+        description: 'Status for the notification (success|failure|info|partial)'
+        required: false
+        default: 'info'
+        type: string
+    secrets:
+      SLACK_ALERTS_WEBHOOK:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        env:
+          TITLE: ${{ inputs.title }}
+          STATUS: ${{ inputs.status }}
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_REFNAME: ${{ github.ref_name }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA: ${{ github.sha }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERTS_WEBHOOK }}
+        run: |
+          STATUS_ICON=""
+          STATUS_PREFIX=""
+          case "$STATUS" in
+            success)
+              STATUS_ICON="✅";
+              STATUS_PREFIX="succeeded";
+              ;;
+            failure)
+              STATUS_ICON="❌";
+              STATUS_PREFIX="failed";
+              ;;
+            partial)
+              STATUS_ICON="⚠️";
+              STATUS_PREFIX="";
+              ;;
+            *)
+              STATUS_ICON="ℹ️";
+              STATUS_PREFIX="update";
+              ;;
+          esac
+          TITLE_SUFFIX=""
+          if [ -n "$STATUS_PREFIX" ]; then
+            TITLE_SUFFIX=" ${STATUS_PREFIX}"
+          fi
+
+          payload=$(cat <<EOF
+          {
+            "text": "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX} in ${GITHUB_REPO}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": { "type": "plain_text", "text": "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX}", "emoji": true }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  { "type": "mrkdwn", "text": "*Repository*\n${GITHUB_REPO}" },
+                  { "type": "mrkdwn", "text": "*Workflow*\n${GITHUB_WORKFLOW}" },
+                  { "type": "mrkdwn", "text": "*Ref*\n${GITHUB_REFNAME}" },
+                  { "type": "mrkdwn", "text": "*Actor*\n${GITHUB_ACTOR}" }
+                ]
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": { "type": "plain_text", "text": "View Run" },
+                    "url": "https://github.com/${GITHUB_REPO}/actions/runs/${GITHUB_RUN_ID}"
+                  },
+                  {
+                    "type": "button",
+                    "text": { "type": "plain_text", "text": "View Commit" },
+                    "url": "https://github.com/${GITHUB_REPO}/commit/${GITHUB_SHA}"
+                  }
+                ]
+              },
+              {
+                "type": "context",
+                "elements": [
+                  { "type": "mrkdwn", "text": "Commit: ${GITHUB_SHA}" }
+                ]
+              }
+            ]
+          }
+          EOF
+          )
+
+          # Check delivery explicitly, there is a history of access being removed and silent failures.
+          http_status=$(curl -sS -o /tmp/slack_response.txt -w "%{http_code}" \
+            -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL")
+          cat /tmp/slack_response.txt
+          if [ "$http_status" -ne 200 ]; then
+            echo "Slack notification failed with HTTP $http_status — webhook may be dead/rotated"
+            exit 1
+          fi


### PR DESCRIPTION
This aims to give us automatic reporting (on push and daily) if `mix hex.audit` finds vulnerable dependencies.
We still run the check on PRs, but allow to continue after failure.

This has become more relevant due to all the CVEs flying around.

This should gain us a couple:

* Lint shouldn't be marked as failing any more, meaning we don't get in the habit of merging with failing checks
  * also better for collaborators, who shouldn't fix these to get their PR green
* Lint actually aborted after, meaning a bunch of other lints didn't run which means we might actually have some things to fix right now as they slipped through.
* even if we don't get PRs the check will run so we should always learn about new CVEs automatically even with no repo activity
* It should also still be noisy and annoying enough to push us towards fixing it
  * right now there is one on main, which is great to help demonstrate that the workflows here work

I've already added the needed secret to the github actions env.