### PR TITLE
fix: add missing :listeners config

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Realtime.MixProject do
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix_live_view] ++ Mix.compilers(),
+      listeners: [Phoenix.CodeReloader],
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),


### PR DESCRIPTION
```
iex(pink@127.0.0.1)> warning: a Mix listener expected by Phoenix.CodeReloader is missing.

  Please add the listener to your mix.exs configuration, like so:

  def project do
    [
      ...,
      listeners: [Phoenix.CodeReloader]
    ]
  end
    (phoenix 1.8.11) lib/phoenix/code_reloader/server.ex:128: anonymous fn/5 in Phoenix.CodeReloader.Server.handle_call/3
    (mix 1.19.5) lib/mix/sync/lock.ex:122: Mix.Sync.Lock.with_lock/3
    (phoenix 1.8.11) lib/phoenix/code_reloader/server.ex:122: Phoenix.CodeReloader.Server.handle_call/3
    (stdlib 7.3.0.1) gen_server.erl:2470: :gen_server.try_handle_call/4
    (stdlib 7.3.0.1) gen_server.erl:2499: :gen_server.handle_msg/3
    (stdlib 7.3.0.1) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
```

https://github.com/phoenixframework/phoenix/blob/be77755e1cc3ec80bce10ee0e1a31e760361a2ac/installer/templates/phx_single/mix.exs.eex#L18