### PR TITLE
chore: enable Hex release-age cooldown

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule Realtime.MixProject do
       dialyzer: dialyzer(),
       test_coverage: [tool: ExCoveralls],
       hex: [
+        cooldown: "7d",
         ignore_advisories: ["CVE-2026-43969", "CVE-2026-43966"]
       ],
       releases: [


### PR DESCRIPTION
Some time to find that a package had been compromised or faulty, some stability we'd like to have.

7 days seems common/normal across the org.