### PR TITLE
fix: update watch dog to check if slot is active

### DIFF
--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -181,28 +181,45 @@ defmodule Realtime.Database do
       {:error, e}
   end
 
-  @slot_lag_query """
+  @slot_check_query """
   SELECT
-    COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn), 0) >
-      (pg_size_bytes(current_setting('max_slot_wal_keep_size')) / 2)
+    active,
+    CASE
+      WHEN current_setting('max_slot_wal_keep_size') = '-1' THEN false
+      ELSE COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn), 0) >
+        (pg_size_bytes(current_setting('max_slot_wal_keep_size')) / 2)
+    END
   FROM pg_replication_slots
   WHERE slot_name = $1
-    AND current_setting('max_slot_wal_keep_size') != '-1'
   """
 
   @doc """
-  Checks if a replication slot's WAL lag exceeds 50% of max_slot_wal_keep_size.
+  Checks the health of a replication slot in a single query.
 
-  Returns :ok when the slot is within safe bounds, max_slot_wal_keep_size is disabled (-1),
-  or the slot does not exist. Returns {:error, :lag_too_high} only when the slot is confirmed
-  to be consuming more than 50% of the per-slot WAL limit.
+  It verifies that the slot exists, that its WAL lag does not exceed 50% of
+  max_slot_wal_keep_size, and that it is actively being consumed. The lag check is a no-op
+  when max_slot_wal_keep_size is disabled with -1, as there is no per-slot threshold to
+  enforce.
+
+  Errors are reported from most to least severe: an excessive WAL lag (a disk risk that
+  applies whether or not the slot is active) takes precedence over the slot merely being
+  inactive.
+
+  Returns:
+    * `:ok` - the slot exists, is active, and is within safe WAL bounds
+    * `{:error, :slot_not_found}` - the slot no longer exists
+    * `{:error, :lag_too_high}` - the slot is consuming more than 50% of the per-slot WAL limit
+    * `{:error, :slot_inactive}` - the slot exists and is within WAL bounds but is not being consumed
+    * `{:error, reason}` - the check itself failed
   """
-  @spec check_replication_slot_lag(pid(), String.t()) ::
-          :ok | {:error, :lag_too_high} | {:error, any()}
-  def check_replication_slot_lag(conn, slot_name) do
-    case Postgrex.query(conn, @slot_lag_query, [slot_name]) do
-      {:ok, %{rows: [[true]]}} -> {:error, :lag_too_high}
-      {:ok, %{rows: _}} -> :ok
+  @spec check_replication_slot(pid(), String.t()) ::
+          :ok | {:error, :slot_not_found | :slot_inactive | :lag_too_high | any()}
+  def check_replication_slot(conn, slot_name) do
+    case Postgrex.query(conn, @slot_check_query, [slot_name]) do
+      {:ok, %{rows: []}} -> {:error, :slot_not_found}
+      {:ok, %{rows: [[_active, true]]}} -> {:error, :lag_too_high}
+      {:ok, %{rows: [[false, false]]}} -> {:error, :slot_inactive}
+      {:ok, %{rows: [[true, false]]}} -> :ok
       {:error, _} = err -> err
     end
   end

--- a/lib/realtime/tenants/replication_connection/watchdog.ex
+++ b/lib/realtime/tenants/replication_connection/watchdog.ex
@@ -3,9 +3,15 @@ defmodule Realtime.Tenants.ReplicationConnection.Watchdog do
   Monitors ReplicationConnection health by performing periodic call checks.
   If the call times out, logs an error and terminates the ReplicationConnection process to trigger a restart.
 
-  On each interval it also queries the tenant database for replication slot WAL lag.
-  If the lag exceeds 50% of max_slot_wal_keep_size, the watchdog stops so the
-  ReplicationConnection (linked to this process) is stopped.
+  On each interval it also queries the tenant database to verify the replication slot
+  is alive: the slot still exists and is actively being consumed. A ReplicationConnection
+  can keep answering health checks while its temporary replication slot has silently
+  disappeared or gone inactive, in which case no changes are being streamed. When the
+  slot is not alive the watchdog stops so the ReplicationConnection (linked to this
+  process) is restarted.
+
+  It also checks the replication slot WAL lag. If the lag exceeds 50% of
+  max_slot_wal_keep_size, the watchdog stops so the ReplicationConnection is stopped.
   When max_slot_wal_keep_size = -1 (unlimited) the lag check is skipped entirely,
   as there is no per-slot enforcement threshold to reason against.
   """
@@ -63,10 +69,18 @@ defmodule Realtime.Tenants.ReplicationConnection.Watchdog do
     try do
       case ReplicationConnection.health_check(state.parent_pid, state.timeout) do
         :ok ->
-          case check_slot_lag(state) do
+          case check_slot(state) do
             :ok ->
               Process.send_after(self(), :health_check, state.check_interval)
               {:noreply, state}
+
+            {:error, reason} when reason in [:slot_not_found, :slot_inactive] ->
+              log_error(
+                "ReplicationSlotNotAlive",
+                "Replication slot #{state.replication_slot_name} is not alive (#{reason}), shutting down"
+              )
+
+              {:stop, :replication_slot_not_alive, state}
 
             {:error, :lag_too_high} ->
               log_error(
@@ -77,7 +91,7 @@ defmodule Realtime.Tenants.ReplicationConnection.Watchdog do
               {:stop, :slot_lag_too_high, state}
 
             {:error, reason} ->
-              log_warning("ReplicationSlotLagCheckSkipped", "Could not check slot lag: #{inspect(reason)}")
+              log_warning("ReplicationSlotCheckSkipped", "Could not check replication slot: #{inspect(reason)}")
               Process.send_after(self(), :health_check, state.check_interval)
               {:noreply, state}
           end
@@ -90,11 +104,11 @@ defmodule Realtime.Tenants.ReplicationConnection.Watchdog do
     end
   end
 
-  defp check_slot_lag(%{replication_slot_name: nil}), do: :ok
+  defp check_slot(%{replication_slot_name: nil}), do: :ok
 
-  defp check_slot_lag(%{tenant_id: tenant_id, replication_slot_name: slot_name}) do
+  defp check_slot(%{tenant_id: tenant_id, replication_slot_name: slot_name}) do
     case Connect.get_status(tenant_id) do
-      {:ok, conn} -> Database.check_replication_slot_lag(conn, slot_name)
+      {:ok, conn} -> Database.check_replication_slot(conn, slot_name)
       {:error, reason} -> {:error, reason}
     end
   end

--- a/test/realtime/database_test.exs
+++ b/test/realtime/database_test.exs
@@ -396,12 +396,12 @@ defmodule Realtime.DatabaseTest do
     end
   end
 
-  describe "check_replication_slot_lag/2" do
+  describe "check_replication_slot/2" do
     setup %{tenant: tenant} do
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)
       suffix = System.unique_integer([:positive])
-      slot_name = "test_lag_#{suffix}"
-      table_name = "lag_test_#{suffix}"
+      slot_name = "test_slot_#{suffix}"
+      table_name = "slot_test_#{suffix}"
 
       Postgrex.query!(db_conn, "SELECT pg_create_logical_replication_slot($1, 'pgoutput')", [slot_name])
       Postgrex.query!(db_conn, "CREATE TABLE IF NOT EXISTS #{table_name} (id INT, data TEXT)", [])
@@ -421,25 +421,33 @@ defmodule Realtime.DatabaseTest do
       %{db_conn: db_conn, slot_name: slot_name, table_name: table_name}
     end
 
-    test "returns :ok when slot lag is below threshold", %{db_conn: db_conn, slot_name: slot_name} do
-      assert :ok == Database.check_replication_slot_lag(db_conn, slot_name)
+    test "returns {:error, :slot_not_found} for unknown slot", %{db_conn: db_conn} do
+      assert {:error, :slot_not_found} == Database.check_replication_slot(db_conn, "nonexistent_slot_xyz")
     end
 
-    test "returns :ok when slot lag is non-zero but below threshold", %{
+    test "returns {:error, :slot_inactive} when slot exists but is not being consumed", %{
+      db_conn: db_conn,
+      slot_name: slot_name
+    } do
+      assert {:error, :slot_inactive} == Database.check_replication_slot(db_conn, slot_name)
+    end
+
+    test "returns {:error, :slot_inactive} when lag is non-zero but below threshold", %{
       db_conn: db_conn,
       slot_name: slot_name,
       table_name: table_name
     } do
       # Generate ~40% of the 32MB max_slot_wal_keep_size (test container value) by inserting
       # ~50k rows of 200 bytes each — produces roughly 12-13MB of WAL, safely under the 16MB
-      # (50%) shutdown threshold. The slot is inactive so restart_lsn stays pinned.
+      # (50%) lag threshold. The slot is inactive so restart_lsn stays pinned; with lag below
+      # the threshold, inactivity is the reported problem.
       Postgrex.query!(
         db_conn,
         "INSERT INTO #{table_name} SELECT generate_series(1, 50000), repeat('x', 200)",
         []
       )
 
-      assert :ok == Database.check_replication_slot_lag(db_conn, slot_name)
+      assert {:error, :slot_inactive} == Database.check_replication_slot(db_conn, slot_name)
     end
 
     test "returns {:error, :lag_too_high} when slot is far behind", %{
@@ -448,18 +456,15 @@ defmodule Realtime.DatabaseTest do
       table_name: table_name
     } do
       # Generate >16MB of WAL (50% of the 32MB max_slot_wal_keep_size in test containers).
-      # The slot is inactive so restart_lsn stays pinned at creation LSN.
+      # The slot is inactive so restart_lsn stays pinned at creation LSN. An excessive lag
+      # takes precedence over the slot being inactive.
       Postgrex.query!(
         db_conn,
         "INSERT INTO #{table_name} SELECT generate_series(1, 100000), repeat('x', 200)",
         []
       )
 
-      assert {:error, :lag_too_high} == Database.check_replication_slot_lag(db_conn, slot_name)
-    end
-
-    test "returns :ok for unknown slot", %{db_conn: db_conn} do
-      assert :ok == Database.check_replication_slot_lag(db_conn, "nonexistent_slot_xyz")
+      assert {:error, :lag_too_high} == Database.check_replication_slot(db_conn, slot_name)
     end
   end
 

--- a/test/realtime/tenants/replication_connection/watchdog_test.exs
+++ b/test/realtime/tenants/replication_connection/watchdog_test.exs
@@ -161,7 +161,7 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
 
     test "continues when slot lag is below threshold", %{fake_pid: fake_pid} do
       stub(Connect, :get_status, fn _tenant_id -> {:ok, :fake_conn} end)
-      stub(Database, :check_replication_slot_lag, fn _conn, _slot -> :ok end)
+      stub(Database, :check_replication_slot, fn _conn, _slot -> :ok end)
 
       watchdog_pid =
         start_supervised!(
@@ -183,7 +183,7 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
 
     test "stops with :slot_lag_too_high when lag exceeds threshold", %{fake_pid: fake_pid} do
       stub(Connect, :get_status, fn _tenant_id -> {:ok, :fake_conn} end)
-      stub(Database, :check_replication_slot_lag, fn _conn, _slot -> {:error, :lag_too_high} end)
+      stub(Database, :check_replication_slot, fn _conn, _slot -> {:error, :lag_too_high} end)
 
       logs =
         capture_log(fn ->
@@ -229,7 +229,65 @@ defmodule Realtime.Tenants.ReplicationConnection.WatchdogTest do
           assert Process.alive?(watchdog_pid)
         end)
 
-      assert logs =~ "ReplicationSlotLagCheckSkipped"
+      assert logs =~ "ReplicationSlotCheckSkipped"
+    end
+  end
+
+  describe "slot liveness monitoring" do
+    setup do
+      fake_pid = start_link_supervised!(FakeReplicationConnection)
+      %{fake_pid: fake_pid}
+    end
+
+    for {reason, description} <- [slot_not_found: "no longer exists", slot_inactive: "is inactive"] do
+      test "stops with :replication_slot_not_alive when slot #{description}", %{fake_pid: fake_pid} do
+        reason = unquote(reason)
+        stub(Connect, :get_status, fn _tenant_id -> {:ok, :fake_conn} end)
+        stub(Database, :check_replication_slot, fn _conn, _slot -> {:error, reason} end)
+
+        logs =
+          capture_log(fn ->
+            watchdog_pid =
+              start_supervised!(
+                {Watchdog,
+                 parent_pid: fake_pid,
+                 tenant_id: "slot-test",
+                 watchdog_interval: 50,
+                 watchdog_timeout: 100,
+                 replication_slot_name: "test_slot"}
+              )
+
+            Mimic.allow(Connect, self(), watchdog_pid)
+            Mimic.allow(Database, self(), watchdog_pid)
+
+            ref = Process.monitor(watchdog_pid)
+            assert_receive {:DOWN, ^ref, :process, ^watchdog_pid, :replication_slot_not_alive}, 500
+          end)
+
+        assert logs =~ "ReplicationSlotNotAlive"
+      end
+    end
+
+    test "continues when slot is alive and lag is below threshold", %{fake_pid: fake_pid} do
+      stub(Connect, :get_status, fn _tenant_id -> {:ok, :fake_conn} end)
+      stub(Database, :check_replication_slot, fn _conn, _slot -> :ok end)
+
+      watchdog_pid =
+        start_supervised!(
+          {Watchdog,
+           parent_pid: fake_pid,
+           tenant_id: "slot-test",
+           watchdog_interval: 50,
+           watchdog_timeout: 100,
+           replication_slot_name: "test_slot"}
+        )
+
+      Mimic.allow(Connect, self(), watchdog_pid)
+      Mimic.allow(Database, self(), watchdog_pid)
+
+      Process.sleep(120)
+
+      assert Process.alive?(watchdog_pid)
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

If for some reason the slot is not there (or not active=true) the Watchdog should restart the replication slot. 
