### PR TITLE
chore: dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,8 @@ updates:
     # Let's not flood ourselves with PRs
     open-pull-requests-limit: 3
 
-    # while the docs say versioning-strategy is supported by hex, seemingly only the default
-    # option is
-    versioning-strategy: "lockfile-only"
+    # not setting versioning strategy seemingly gives us, what we want,
+    # see: https://github.com/supabase/realtime/pull/2123#discussion_r3832772340
 
     cooldown:
       # same as in our hex config

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,9 @@ updates:
     # Let's not flood ourselves with PRs
     open-pull-requests-limit: 3
 
-    # May widen `~>` constraints, but only when the latest resolvable version
-    # does not already satisfy them: in-range bumps touch mix.lock only.
-    versioning-strategy: "increase-if-necessary"
+    # while the docs say versioning-strategy is supported by hex, seemingly only the default
+    # option is
+    versioning-strategy: "lockfile-only"
 
     cooldown:
       # same as in our hex config


### PR DESCRIPTION
odd one, docs say the option is supported but it fails and says only this one is supported:

```
The property '#/updates/0/versioning-strategy' value "increase-if-necessary" did not match one of the following values: lockfile-only, auto
```

