### PR TITLE
chore: Fix tenant controller flaky spec

### DIFF
--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -307,7 +307,10 @@ defmodule RealtimeWeb.TenantControllerTest do
       {:ok, _pid} = Connect.lookup_or_start_connection(tenant.external_id)
 
       assert Connect.ready?(tenant.external_id)
-      assert Realtime.Tenants.ReplicationConnection.ready?(tenant.external_id)
+
+      # Replication Connections are launched async and can take a while,
+      # especially in CI environments.
+      assert eventually(fn -> Realtime.Tenants.ReplicationConnection.ready?(tenant.external_id) end)
 
       assert Cache.get_tenant_by_external_id(tenant.external_id)
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)


### PR DESCRIPTION
Connection isn't yet ready, wait for it.

Flakey:

```
              1) test delete tenant deletes chosen tenant (RealtimeWeb.TenantControllerTest)
Error:      test/realtime_web/controllers/tenant_controller_test.exs:306
     Expected truthy, got false
     code: assert Realtime.Tenants.ReplicationConnection.ready?(tenant.external_id)
     arguments:

         # 1
         "irb4ctg3354st4kggyhu5emkfc4vruth"

     stacktrace:
       test/realtime_web/controllers/tenant_controller_test.exs:310: (test)

     The following output was logged:
     06:16:01.594 [info] Exporter :otel_exporter_pid successfully initialized
     06:16:01.595 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     06:16:01.607 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     06:16:01.611 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     06:16:01.780 [info] Creating partitions for realtime.messages
     06:16:01.794 [info] Starting Elixir.Realtime.RateCounter for: {:database, :connect, "irb4ctg3354st4kggyhu5emkfc4vruth"}
     06:16:01.795 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Connection process starting up
     06:16:01.795 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Realtime.Tenants.Connect.GetTenant executed in 0 ms
     06:16:01.795 error_code=DatabaseIpVersionIsIpv4 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     06:16:01.800 error_code=DatabaseIpVersionIsIpv4 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     06:16:01.800 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Realtime.Tenants.Connect.CheckConnection executed in 4 ms
     06:16:01.800 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Realtime.Tenants.Connect.ReconcileMigrations executed in 0 ms
     06:16:01.800 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Realtime.Tenants.Connect.RegisterProcess executed in 0 ms
     06:16:01.800 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Tenant irb4ctg3354st4kggyhu5emkfc4vruth is initializing: :"main2@127.0.0.1"
     06:16:01.800 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Creating partitions for realtime.messages
     06:16:01.805 [info] Starting replication for Broadcast Changes
     06:16:01.805 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     06:16:01.805 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Initializing connection with the status: %Realtime.Tenants.ReplicationConnection{
       tenant_id: "irb4ctg3354st4kggyhu5emkfc4vruth",
       opts: [],
       step: :disconnected,
       publication_name: "supabase_realtime_messages_publication",
       replication_slot_name: "supabase_realtime_messages_replication_slot_",
       output_plugin: "pgoutput",
       proto_version: 2,
       relations: %{},
       buffer: [],
       monitored_pid: #PID<0.79401.0>,
       latency_committed_at: nil,
       query_timeout: 240000
     }
     06:16:01.807 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Checking if replication slot supabase_realtime_messages_replication_slot_ exists
     06:16:01.808 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Check publication supabase_realtime_messages_publication for table realtime.messages exists
     06:16:01.808 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Create publication supabase_realtime_messages_publication for table realtime.messages
     06:16:01.809 project=irb4ctg3354st4kggyhu5emkfc4vruth external_id=irb4ctg3354st4kggyhu5emkfc4vruth [info] Create replication slot supabase_realtime_messages_replication_slot_ using plugin pgoutput
     06:16:04.556 [info] nonode@nohost: replica down from :"peer-152547-5472@127.0.0.1"
```

