### PR TITLE
chore: fix flaky bad_tcp test

### DIFF
--- a/test/realtime/gen_rpc_bad_tcp_test.exs
+++ b/test/realtime/gen_rpc_bad_tcp_test.exs
@@ -14,7 +14,7 @@ defmodule Realtime.GenRpcBadTcpTest do
   @moduletag extra_config: [{:gen_rpc, :tcp_server_port, 9999}]
 
   setup context do
-    {:ok, node} = Clustered.start(nil, extra_config: context[:extra_config])
+    {:ok, node} = Clustered.start(nil, extra_config: context[:extra_config], warm_clients: false)
     %{node: node}
   end
 

--- a/test/support/clustered.ex
+++ b/test/support/clustered.ex
@@ -22,6 +22,14 @@ defmodule Clustered do
     assert ok = :rpc.call(node, Aux, :checker, [:ok])
   end
   ```
+
+  ## Options
+
+  - `:warm_clients` - Whether to eagerly establish the gen_rpc client pool against the node
+    before returning, defaulting to `true`. Set to `false` when the node is intentionally
+    unreachable (e.g. a broken gen_rpc port), so warming doesn't leave dead client processes
+    that can race with the test's own calls.
+
   """
   @spec start(any(), keyword()) :: {:ok, node}
   def start(aux_mod \\ nil, opts \\ []) do
@@ -31,15 +39,17 @@ defmodule Clustered do
 
     true = Node.connect(node)
 
-    max_cast_clients = Application.get_env(:realtime, :max_gen_rpc_clients, 5)
-    max_call_clients = Application.get_env(:realtime, :max_gen_rpc_call_clients, 1)
+    if Access.get(opts, :warm_clients, true) do
+      max_cast_clients = Application.get_env(:realtime, :max_gen_rpc_clients, 5)
+      max_call_clients = Application.get_env(:realtime, :max_gen_rpc_call_clients, 1)
 
-    for key <- 1..max_cast_clients do
-      _ = :gen_rpc.call({node, {:cast, key}}, :erlang, :node, [], 5_000)
-    end
+      for key <- 1..max_cast_clients do
+        _ = :gen_rpc.call({node, {:cast, key}}, :erlang, :node, [], 5_000)
+      end
 
-    for key <- 1..max_call_clients do
-      _ = :gen_rpc.call({node, {:call, key}}, :erlang, :node, [], 5_000)
+      for key <- 1..max_call_clients do
+        _ = :gen_rpc.call({node, {:call, key}}, :erlang, :node, [], 5_000)
+      end
     end
 
     {:ok, node}


### PR DESCRIPTION
The error stems from `econnrefused` vs. `:noproc` which, best as I could tell, stems from the warming of clients that `Clustered` does as the processes are cleaned up async from the registry which may lead to this `:noproc`.

Hence, avoid this issue by instructing Clustered not to warm the TCP connections.

```
 1) test multicall/4 partial results with bad tcp error (Realtime.GenRpcBadTcpTest)
Error:      test/realtime/gen_rpc_bad_tcp_test.exs:108
     Assertion with == failed
     code:  assert GenRpc.multicall(Map, :fetch, [%{a: 1}, :a], tenant_id: 123) == [
              {node(), {:ok, 1}},
              {node, {:error, :rpc_error, :econnrefused}}
            ]
     left:  [
              "main4@127.0.0.1": {:ok, 1},
              "peer-571426-5497@127.0.0.1": {:error, :rpc_error,
               :noproc}
            ]
     right: [
              "main4@127.0.0.1": {:ok, 1},
              "peer-571426-5497@127.0.0.1": {:error, :rpc_error,
               :econnrefused}
            ]
     stacktrace:
       (ex_unit 1.19.5) lib/ex_unit/capture_log.ex:121: ExUnit.CaptureLog.with_log/2
       (ex_unit 1.19.5) lib/ex_unit/capture_log.ex:83: ExUnit.CaptureLog.capture_log/2
       test/realtime/gen_rpc_bad_tcp_test.exs:112: (test)
```
