### PR TITLE
chore: fix flaky wal bloat test

### DIFF
--- a/test/integration/rt_channel/wal_bloat_test.exs
+++ b/test/integration/rt_channel/wal_bloat_test.exs
@@ -141,15 +141,17 @@ defmodule Realtime.Integration.RtChannel.WalBloatTest do
     pid
   end
 
+  # Waits for the slot to be not just active, but caught up (lag back under the
+  # watchdog's threshold). A slot can briefly show an active_pid while still
+  # replaying leftover WAL from the bloat, only for the watchdog to kill it again
+  # moments later - checking the same condition the watchdog checks avoids that race.
   defp await_replication_slot_active(db_conn, retries, interval_ms) do
+    slot_name = "supabase_realtime_messages_replication_slot_"
+
     Enum.reduce_while(1..retries, nil, fn _, _ ->
-      case Postgrex.query!(
-             db_conn,
-             "SELECT active_pid FROM pg_replication_slots WHERE active_pid IS NOT NULL AND slot_name = 'supabase_realtime_messages_replication_slot_'",
-             []
-           ) do
-        %{rows: [[pid]]} ->
-          {:halt, pid}
+      case Database.check_replication_slot(db_conn, slot_name) do
+        :ok ->
+          {:halt, active_replication_slot_pid!(db_conn)}
 
         _ ->
           Process.sleep(interval_ms)


### PR DESCRIPTION
In the logs below notice how there are 2 `** (stop) :slot_lag_too_high` - so the theory is that one was intermittently active, the watchdog killed it again and hence the tests failed the way they did.

Workaround is to wait for the same condition the Watchdog waits for to make sure it doesn't kill the one we're testing again.

```
1) test WAL bloat handling track PID changes during WAL bloat creation (Realtime.Integration.RtChannel.WalBloatTest)
Error:      test/integration/rt_channel/wal_bloat_test.exs:75
     Assertion failed, no matching message after 5000ms
     The following variables were pinned:
       full_topic = "realtime:xexxgwza2culyfjbpk5sw2bzo2vwnjqj"
     The process mailbox is empty.
     code: assert_receive %Message{
             event: "broadcast",
             payload: %{"event" => "test", "payload" => %{"value" => "test"}, "type" => "broadcast"},
             join_ref: nil,
     09:27:08.951 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] #PID<0.49568.0> Starting stream replication for slot supabase_realtime_messages_replication_slot_ using publication supabase_realtime_messages_publication and protocol version 2
     09:27:08.954 [info] Starting Elixir.Realtime.RateCounter for: {:channel, :joins, "vz25y4mz427vc65r6ph6eennz2ddu2ua"}
     09:27:08.957 [info] Starting Elixir.Realtime.RateCounter for: {:channel, :events, "vz25y4mz427vc65r6ph6eennz2ddu2ua"}
     09:27:08.957 [info] Starting Elixir.Realtime.RateCounter for: {:channel, :presence_events, "vz25y4mz427vc65r6ph6eennz2ddu2ua"}
     09:27:08.959 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     09:27:08.959 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     09:27:08.959 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     09:27:08.959 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     09:27:08.959 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     09:27:09.045 error_code=ReplicationSlotLagTooHigh project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [error] ReplicationSlotLagTooHigh: Replication slot lag exceeds 50% of max_slot_wal_keep_size, shutting down
     09:27:09.045 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [error] GenServer #PID<0.49570.0> terminating
     ** (stop) :slot_lag_too_high
     Last message: :health_check
     09:27:09.045 error_code=ReplicationConnectionDown project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [warning] ReplicationConnectionDown: Replication connection has been terminated, recovery window opened
     09:27:11.741 project=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Billing metrics: [:realtime, :connections]
     09:27:16.223 [info] Starting replication for Broadcast Changes
     09:27:16.223 error_code=DatabaseIpVersionIsIpv4 [warning] DatabaseIpVersionIsIpv4: Tenant database host 127.0.0.1 resolved to an IPv4 address
     09:27:16.224 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Initializing connection with the status: %Realtime.Tenants.ReplicationConnection{
       tenant_id: "vz25y4mz427vc65r6ph6eennz2ddu2ua",
       opts: [],
       step: :disconnected,
       publication_name: "supabase_realtime_messages_publication",
       replication_slot_name: "supabase_realtime_messages_replication_slot_",
       output_plugin: "pgoutput",
       proto_version: 2,
       relations: %{},
       buffer: [],
       monitored_pid: #PID<0.49548.0>,
       latency_committed_at: nil,
       query_timeout: 240000
     }
     09:27:16.227 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Checking if replication slot supabase_realtime_messages_replication_slot_ exists
     09:27:16.229 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Check publication supabase_realtime_messages_publication for table realtime.messages exists
     09:27:16.230 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Publication supabase_realtime_messages_publication exists, validating contents
     09:27:16.233 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Create replication slot supabase_realtime_messages_replication_slot_ using plugin pgoutput
     09:27:16.742 project=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Billing metrics: [:realtime, :connections]
     09:27:17.231 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] #PID<0.49621.0> Starting stream replication for slot supabase_realtime_messages_replication_slot_ using publication supabase_realtime_messages_publication and protocol version 2
     09:27:17.233 error_code=ReplicationSlotLagTooHigh project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [error] ReplicationSlotLagTooHigh: Replication slot lag exceeds 50% of max_slot_wal_keep_size, shutting down
     09:27:17.233 project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [error] GenServer #PID<0.49622.0> terminating
     ** (stop) :slot_lag_too_high
     Last message: :health_check
     09:27:17.233 error_code=ReplicationConnectionDown project=vz25y4mz427vc65r6ph6eennz2ddu2ua external_id=vz25y4mz427vc65r6ph6eennz2ddu2ua [warning] ReplicationConnectionDown: Replication connection has been terminated, recovery window opened
     09:27:18.961 project=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Billing metrics: [:realtime, :rate_counter, :channel, :events]
     09:27:21.743 project=vz25y4mz427vc65r6ph6eennz2ddu2ua [info] Billing metrics: [:realtime, :connections]
```
