### PR TITLE
chore: whack a mole ReplicationConnection.ready? flaky tests (make sure replication connection shuts down)

### DIFF
--- a/lib/realtime/tenants/replication_connection.ex
+++ b/lib/realtime/tenants/replication_connection.ex
@@ -126,7 +126,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
     end
   end
 
-  def ready?(tenant_id) do
+  def ready?(tenant_id, wait_time \\ 5_000) do
     RealtimeWeb.Endpoint.subscribe(Connect.syn_topic(tenant_id))
     # We do a lookup after subscribing because we could've missed a message while subscribing
     case Connect.replication_status(tenant_id) do
@@ -139,7 +139,7 @@ defmodule Realtime.Tenants.ReplicationConnection do
           %{event: "ready", payload: %{replication_conn: conn}} when is_pid(conn) ->
             true
         after
-          5_000 -> false
+          wait_time -> false
         end
     end
   after

--- a/test/realtime_web/controllers/tenant_controller_test.exs
+++ b/test/realtime_web/controllers/tenant_controller_test.exs
@@ -308,9 +308,9 @@ defmodule RealtimeWeb.TenantControllerTest do
 
       assert Connect.ready?(tenant.external_id)
 
-      # Replication Connections are launched async and can take a while,
-      # especially in CI environments.
-      assert eventually(fn -> Realtime.Tenants.ReplicationConnection.ready?(tenant.external_id) end)
+      # ready?/1 already waits, we just increase the time here
+      # there's a comment saying it might take up to 30 seconds
+      assert Realtime.Tenants.ReplicationConnection.ready?(tenant.external_id, to_timeout(second: 30))
 
       assert Cache.get_tenant_by_external_id(tenant.external_id)
       {:ok, db_conn} = Database.connect(tenant, "realtime_test", :stop)

--- a/test/support/test_tenant_db.ex
+++ b/test/support/test_tenant_db.ex
@@ -4,6 +4,7 @@ defmodule TestTenantDb do
 
   alias Extensions.PostgresCdcRls
   alias Realtime.Tenants.Connect
+  alias Realtime.Tenants.ReplicationConnection
   alias TestTenantDb.Backend
   alias Realtime.Database
 
@@ -106,6 +107,14 @@ defmodule TestTenantDb do
             supervisor = {:via, PartitionSupervisor, {Realtime.Tenants.Connect.DynamicSupervisor, tenant.external_id}}
 
             DynamicSupervisor.terminate_child(supervisor, connect_pid)
+          end
+
+          # Connect's own replication connection is torn down asynchronously
+          # so terminating Connect above doesn't guarantee the
+          # replication slot is free yet.
+          # Stop it here explicitly to avoid race conditions and collisions.
+          if replication_pid = ReplicationConnection.whereis(tenant.external_id) do
+            ReplicationConnection.stop(tenant.external_id, replication_pid)
           end
 
           try do


### PR DESCRIPTION
So, the first fix was good/helpful but a bit overeager.

I didn't realize that `ReplicationConnection.ready?` already waited 5 seconds so that + `eventually` could make the test time out. Meanwhile, according to the code base, connection establishing might also take 30 seconds. So, make the wait time adjustable.

That doesn't explain why it hung forever though - that'd mean the ReplicationConnection never really gets ready.

The leading theory here is that since `ReplicationConnection` is shut down async from `Connection` and in the test suite many other values are the same is that a "zombie" replication connection  survives, confuses some check and we wait forever.

timed out test:

```
       1) test delete tenant deletes chosen tenant (RealtimeWeb.TenantControllerTest)
Error:      test/realtime_web/controllers/tenant_controller_test.exs:306
     ** (ExUnit.TimeoutError) test timed out after 60000ms. You can change the timeout:

       1. per test by setting "@tag timeout: x" (accepts :infinity)
       2. per test module by setting "@moduletag timeout: x" (accepts :infinity)
       3. globally via "ExUnit.start(timeout: x)" configuration
       4. by running "mix test --timeout x" which sets timeout
       5. or by running "mix test --trace" which sets timeout to infinity
          (useful when using IEx.pry/0)

     where "x" is the timeout given as integer in milliseconds (defaults to 60_000).

     code: assert eventually(fn -> Realtime.Tenants.ReplicationConnection.ready?(tenant.external_id) end)
     stacktrace:
       lib/realtime/tenants/replication_connection.ex:138: Realtime.Tenants.ReplicationConnection.Mimic.Original.Module.ready?/1
       (realtime 2.129.8) test/support/test_helpers.ex:21: TestHelpers.eventually/2
       test/realtime_web/controllers/tenant_controller_test.exs:313: (test)
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:528: ExUnit.Runner.exec_test/2
       (ex_unit 1.19.5) lib/ex_unit/capture_log.ex:121: ExUnit.CaptureLog.with_log/2
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:477: anonymous fn/3 in ExUnit.Runner.maybe_capture_log/3
       (stdlib 7.3.0.1) timer.erl:599: :timer.tc/2
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:450: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
```