### PR TITLE
fix: fix gen_rpc counter reset bug

### DIFF
--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -112,6 +112,7 @@ defmodule Realtime.Application do
       [
         Realtime.ErlSysMon,
         Realtime.GenCounter,
+        Realtime.GenRpcMetrics,
         Realtime.PromEx,
         Realtime.TenantPromEx,
         {Realtime.Telemetry.Logger, handler_id: "telemetry-logger"},

--- a/lib/realtime/monitoring/gen_rpc_metrics.ex
+++ b/lib/realtime/monitoring/gen_rpc_metrics.ex
@@ -1,85 +1,201 @@
 defmodule Realtime.GenRpcMetrics do
   @moduledoc """
-  Gather stats for gen_rpc TCP sockets
+  Gather stats for gen_rpc TCP sockets.
+
+  A node can have more than one gen_rpc Erlang port open to a given peer (a
+  client-side port and a server-side port, and gen_rpc may hold several). The
+  raw `:inet.getstat/1` counters (`recv_oct`, `recv_cnt`, `send_oct`,
+  `send_cnt`) are monotonic *per socket* but reset to 0 whenever a socket is
+  replaced (reconnect, port restart). Summing them across the live set of
+  sockets and exporting that sum would make the aggregate drop every time a
+  single port is recycled, which downstream Prometheus reads as a counter reset
+  followed by a spurious massive increment.
+
+  To avoid that, this module keeps state as a `GenServer`: it remembers the last
+  observed value of every socket and maintains a monotonic accumulator per peer
+  node. On each poll it adds only the per-socket deltas, so the exported counters
+  keep increasing across port restarts within the life of a connection. A socket
+  seen for the first time contributes 0 (it only establishes a baseline); a
+  socket whose value went backwards mid-connection (in-place reset) contributes
+  its current value.
+
+  When a peer node leaves the cluster its accumulator is dropped. If that node
+  later reconnects it starts again from 0 — a genuine reset (all sockets to the
+  peer are gone), which Prometheus recognises and handles via its counter-reset
+  logic. Because the first poll after a reconnect only establishes baselines and
+  reports 0, the exported counter always *drops* to 0 rather than resuming at the
+  fresh sockets' current value, so Prometheus can never mistake the reset for a
+  spurious increment.
+
+  Instantaneous gauges (`send_pend`, `queue_size`, and the `recv_*`/`send_*`
+  avg/max/dvi values) are still reported as the current sum across live sockets.
   """
+
+  use GenServer
 
   require Record
   Record.defrecordp(:net_address, Record.extract(:net_address, from_lib: "kernel/include/net_address.hrl"))
 
+  # Cumulative per-socket counters that must be accumulated across socket restarts.
+  @counter_keys [:recv_oct, :recv_cnt, :send_oct, :send_cnt]
+  @zero_counters %{recv_oct: 0, recv_cnt: 0, send_oct: 0, send_cnt: 0}
+
+  @typep counters :: %{
+           recv_oct: integer(),
+           recv_cnt: integer(),
+           send_oct: integer(),
+           send_cnt: integer()
+         }
+
+  # last_seen: last raw counter value per live socket
+  # totals: monotonic accumulator per peer node
+  @typep state :: %{
+           last_seen: %{port() => counters()},
+           totals: %{node() => counters()}
+         }
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
   @spec info() :: %{node() => %{inet_stats: %{:inet.stat_option() => integer}, queue_size: non_neg_integer()}}
-  def info do
+  def info, do: GenServer.call(__MODULE__, :info)
+
+  @impl true
+  @spec init(term()) :: {:ok, state()}
+  def init(_opts), do: {:ok, %{last_seen: %{}, totals: %{}}}
+
+  @impl true
+  def handle_call(:info, _from, state) do
+    {result, state} = collect(state)
+    {:reply, result, state}
+  end
+
+  @spec collect(state()) :: {map(), state()}
+  defp collect(%{last_seen: last_seen, totals: totals} = state) do
     if :net_kernel.get_state()[:started] != :no do
       {:ok, nodes_info} = :net_kernel.nodes_info()
       # Ignore "hidden" nodes (remote shell)
       nodes_info = Enum.filter(nodes_info, fn {_k, v} -> v[:type] == :normal end)
-      gen_rpc_server_port = server_port()
-      ip_address_node = ip_address_node(nodes_info)
+      ports_by_node = ports_by_node(nodes_info)
 
-      {client_ports, server_ports} =
-        :erlang.ports()
-        |> Stream.filter(fn port -> :erlang.port_info(port, :name) == {:name, ~c"tcp_inet"} end)
-        |> Stream.map(&{:inet.peername(&1), :inet.sockname(&1), &1})
-        |> Stream.filter(fn
-          {{:ok, _peername}, {:ok, _sockname}, _port} -> true
-          _ -> false
-        end)
-        |> Stream.map(fn {{:ok, {peername_ipaddress, peername_port}}, {:ok, {_, server_port}}, port} ->
-          {ip_address_node[peername_ipaddress], peername_port, server_port, port}
-        end)
-        |> Stream.filter(fn
-          {nil, _, _} ->
-            false
-
-          {node, peername_port, server_port, _port} ->
-            {_, client_tcp_or_ssl_port} = :gen_rpc_helper.get_client_config_per_node(node)
-            # Only keep Erlang ports that are either serving on the gen_rpc server tcp/ssl port or
-            # connecting to other nodes using the expected client tcp/ssl port for that node
-            peername_port == client_tcp_or_ssl_port or server_port == gen_rpc_server_port
-        end)
-        |> Enum.reduce({%{}, %{}}, fn {node, _peername_port, server_port, port}, {clients, servers} ->
-          if server_port == gen_rpc_server_port do
-            # This Erlang port is serving gen_rpc
-            {clients, update_in(servers, [node], fn value -> [port | value || []] end)}
-          else
-            # This Erlang port is requesting gen_rpc
-            {update_in(clients, [node], fn value -> [port | value || []] end), servers}
-          end
+      # `last_seen` and `totals` are both rebuilt from scratch every poll so
+      # sockets and nodes that are no longer present are pruned
+      # The old maps are only read to compute per-socket deltas and to carry forward each
+      # still-connected node's accumulator.
+      {result, new_totals, new_last_seen} =
+        Enum.reduce(nodes_info, {%{}, %{}, %{}}, fn {node, _}, {result, new_totals, new_last_seen} ->
+          ports = Map.get(ports_by_node, node, [])
+          {entry, new_totals, new_last_seen} = info(node, ports, last_seen, totals, new_totals, new_last_seen)
+          {Map.put(result, node, entry), new_totals, new_last_seen}
         end)
 
-      Map.new(nodes_info, &info(&1, client_ports, server_ports))
+      {result, %{state | last_seen: new_last_seen, totals: new_totals}}
     else
-      %{}
+      {%{}, state}
     end
   end
 
-  defp info({node, _}, client_ports, server_ports) do
-    gen_rpc_ports = Map.get(client_ports, node, []) ++ Map.get(server_ports, node, [])
+  defp info(node, ports, last_seen, totals, new_totals, new_last_seen) do
+    port_stats =
+      Enum.flat_map(ports, fn port ->
+        case :inet.getstat(port) do
+          {:ok, stats} -> [{port, Map.new(stats)}]
+          _ -> []
+        end
+      end)
 
-    if gen_rpc_ports != [] do
-      {node,
-       %{
-         inet_stats: inet_stats(gen_rpc_ports),
-         queue_size: queue_size(gen_rpc_ports),
-         connections: length(gen_rpc_ports)
-       }}
+    if port_stats == [] do
+      # No live sockets with readable stats, but the node is still connected, so
+      # its accumulator is carried forward unchanged and the counters resume
+      # where they left off once a socket reappears.
+      case Map.get(totals, node) do
+        nil -> {%{}, new_totals, new_last_seen}
+        node_total -> {%{}, Map.put(new_totals, node, node_total), new_last_seen}
+      end
     else
-      {node, %{}}
+      node_total = Map.get(totals, node, @zero_counters)
+
+      {node_total, new_last_seen} =
+        Enum.reduce(port_stats, {node_total, new_last_seen}, fn {port, stats}, {node_total, new_last_seen} ->
+          node_total = accumulate(node_total, Map.get(last_seen, port), stats)
+          {node_total, Map.put(new_last_seen, port, Map.take(stats, @counter_keys))}
+        end)
+
+      # Instantaneous values (gauges) are reported as the current sum across
+      # live sockets. The cumulative counters come from the accumulator.
+      current = Enum.reduce(port_stats, %{}, fn {_port, stats}, acc -> merge_sum(acc, stats) end)
+      inet_stats = Map.merge(current, node_total)
+
+      entry = %{inet_stats: inet_stats, queue_size: queue_size(ports), connections: length(ports)}
+
+      {entry, Map.put(new_totals, node, node_total), new_last_seen}
     end
   end
 
-  defp inet_stats(ports) do
-    Enum.reduce(ports, %{}, fn port, acc ->
-      case :inet.getstat(port) do
-        {:ok, stats} -> Map.merge(acc, Map.new(stats), fn _k, v1, v2 -> v1 + v2 end)
+  # Adds the per-socket deltas onto the running node total so it never decreases
+  # when a gen_rpc port is recycled.
+  #
+  # A socket seen for the first time (`previous == nil`) contributes 0: it only
+  # establishes a baseline. This matters on reconnect as a node whose accumulator
+  # was dropped comes back with all-new sockets, so the total stays at 0 for that
+  # first poll and the exported counter cleanly drops to 0 (a reset Prometheus
+  # understands) instead of resuming at the fresh sockets' current value, which
+  # could exceed the pre-disconnect total and read as a spurious increment.
+  #
+  # A socket whose value went backwards mid-connection (in-place reset) still
+  # contributes its current value, since we have no baseline to delta against and
+  # the node total is being carried forward.
+  @spec accumulate(counters(), counters() | nil, map()) :: counters()
+  defp accumulate(node_total, previous, stats) do
+    Enum.reduce(@counter_keys, node_total, fn key, node_total ->
+      current = Map.get(stats, key, 0)
+
+      delta =
+        case previous do
+          nil -> 0
+          previous -> if current >= previous[key], do: current - previous[key], else: current
+        end
+
+      Map.update(node_total, key, delta, &(&1 + delta))
+    end)
+  end
+
+  defp merge_sum(acc, stats), do: Map.merge(acc, stats, fn _k, v1, v2 -> v1 + v2 end)
+
+  defp queue_size(ports) do
+    Enum.reduce(ports, 0, fn port, acc ->
+      case :erlang.port_info(port, :queue_size) do
+        {:queue_size, queue_size} -> acc + queue_size
         _ -> acc
       end
     end)
   end
 
-  defp queue_size(ports) do
-    Enum.reduce(ports, 0, fn port, acc ->
-      {:queue_size, queue_size} = :erlang.port_info(port, :queue_size)
-      acc + queue_size
+  defp ports_by_node(nodes_info) do
+    gen_rpc_server_port = server_port()
+    ip_address_node = ip_address_node(nodes_info)
+
+    :erlang.ports()
+    |> Stream.filter(fn port -> :erlang.port_info(port, :name) == {:name, ~c"tcp_inet"} end)
+    |> Stream.map(&{:inet.peername(&1), :inet.sockname(&1), &1})
+    |> Stream.filter(fn
+      {{:ok, _peername}, {:ok, _sockname}, _port} -> true
+      _ -> false
+    end)
+    |> Stream.map(fn {{:ok, {peername_ipaddress, peername_port}}, {:ok, {_, server_port}}, port} ->
+      {ip_address_node[peername_ipaddress], peername_port, server_port, port}
+    end)
+    |> Stream.filter(fn
+      {nil, _, _, _} ->
+        false
+
+      {node, peername_port, server_port, _port} ->
+        {_, client_tcp_or_ssl_port} = :gen_rpc_helper.get_client_config_per_node(node)
+        # Only keep Erlang ports that are either serving on the gen_rpc server tcp/ssl port or
+        # connecting to other nodes using the expected client tcp/ssl port for that node
+        peername_port == client_tcp_or_ssl_port or server_port == gen_rpc_server_port
+    end)
+    |> Enum.reduce(%{}, fn {node, _peername_port, _server_port, port}, acc ->
+      update_in(acc, [Access.key(node, [])], fn ports -> [port | ports] end)
     end)
   end
 

--- a/test/realtime/monitoring/gen_rpc_metrics_test.exs
+++ b/test/realtime/monitoring/gen_rpc_metrics_test.exs
@@ -36,10 +36,17 @@ defmodule Realtime.GenRpcMetricsTest do
     end
 
     test "metric matches on both sides", %{node: node} do
-      # We need to generate some load on gen_rpc first
+      # Establish a baseline on both accumulators first. A socket seen for the
+      # first time contributes 0, so the cumulative counters are only comparable
+      # across the window *after* both sides have observed the sockets once.
+      Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 1)
+      :erpc.call(node, Realtime.GenRpc, :call, [node(), String, :to_integer, ["25"], [key: 1]])
+      local_before = GenRpcMetrics.info()[node][:inet_stats]
+      remote_before = :erpc.call(node, GenRpcMetrics, :info, [])[node()][:inet_stats]
+
+      # Generate a known amount of bidirectional load.
       Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 1)
       Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 2)
-
       :erpc.call(node, Realtime.GenRpc, :call, [node(), String, :to_integer, ["25"], [key: 1]])
 
       local_metrics = GenRpcMetrics.info()[node][:inet_stats]
@@ -60,17 +67,131 @@ defmodule Realtime.GenRpcMetricsTest do
 
       assert local_metrics[:connections] == remote_metrics[:connections]
 
+      # avg/max are instantaneous gauges (current sum across live sockets), so
+      # they are compared as absolute values.
       assert_in_delta local_metrics[:send_avg], remote_metrics[:recv_avg], 200
       assert_in_delta local_metrics[:recv_avg], remote_metrics[:send_avg], 200
-
-      assert_in_delta local_metrics[:send_oct], remote_metrics[:recv_oct], 1000
-      assert_in_delta local_metrics[:recv_oct], remote_metrics[:send_oct], 1000
-
-      assert_in_delta local_metrics[:send_cnt], remote_metrics[:recv_cnt], 10
-      assert_in_delta local_metrics[:recv_cnt], remote_metrics[:send_cnt], 10
-
       assert_in_delta local_metrics[:send_max], remote_metrics[:recv_max], 1000
       assert_in_delta local_metrics[:recv_max], remote_metrics[:send_max], 1000
+
+      # oct/cnt are cumulative counters carrying a per-accumulator baseline
+      # offset, so the invariant is that the *delta* over the window matches:
+      # what one side sent equals what the other received.
+      local_sent_oct = local_metrics[:send_oct] - local_before[:send_oct]
+      local_recv_oct = local_metrics[:recv_oct] - local_before[:recv_oct]
+      remote_sent_oct = remote_metrics[:send_oct] - remote_before[:send_oct]
+      remote_recv_oct = remote_metrics[:recv_oct] - remote_before[:recv_oct]
+
+      assert_in_delta local_sent_oct, remote_recv_oct, 1000
+      assert_in_delta local_recv_oct, remote_sent_oct, 1000
+
+      local_sent_cnt = local_metrics[:send_cnt] - local_before[:send_cnt]
+      local_recv_cnt = local_metrics[:recv_cnt] - local_before[:recv_cnt]
+      remote_sent_cnt = remote_metrics[:send_cnt] - remote_before[:send_cnt]
+      remote_recv_cnt = remote_metrics[:recv_cnt] - remote_before[:recv_cnt]
+
+      assert_in_delta local_sent_cnt, remote_recv_cnt, 10
+      assert_in_delta local_recv_cnt, remote_sent_cnt, 10
+    end
+
+    test "cumulative counters are monotonic across polls", %{node: node} do
+      Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 1)
+      before = GenRpcMetrics.info()[node][:inet_stats]
+
+      for i <- 1..10, do: Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: i)
+      later = GenRpcMetrics.info()[node][:inet_stats]
+
+      for key <- [:recv_oct, :recv_cnt, :send_oct, :send_cnt] do
+        assert later[key] >= before[key],
+               "#{key} decreased across polls: #{before[key]} -> #{later[key]}"
+      end
+    end
+
+    test "counters keep accumulating when the gen_rpc client is killed and reconnects", %{node: node} do
+      # ~1MB payload sent to the remote node, so send_oct grows by a clear ~1MB
+      # per call. A large first batch builds up a substantial send_oct total.
+      payload = String.duplicate("x", 1_000_000)
+
+      # Warm up so the current socket has a baseline; otherwise the first sight
+      # of it contributes 0 and the batch below would not be counted into `before`.
+      GenRpcMetrics.info()
+      for _ <- 1..8, do: Realtime.GenRpc.call(node, String, :length, [payload], key: 1)
+      before = GenRpcMetrics.info()[node][:inet_stats]
+      # Let the remote node poll the current socket too, so the imminent reset
+      # doesn't under-count bytes that only our side had observed (keeps the
+      # shared peer's local/remote counters in sync for other tests).
+      :erpc.call(node, GenRpcMetrics, :info, [])
+
+      # Kill the gen_rpc client process for this node. Its TCP socket dies with
+      # it and the next call spins up a fresh client whose :inet.getstat counters
+      # restart from 0. Summing only live sockets would collapse send_oct back to
+      # a single small batch. The per-node accumulator must carry the old total.
+      client = :gen_rpc_client.where_is({node, {:call, 1}})
+      assert is_pid(client), "expected a gen_rpc call client for #{inspect(node)}"
+      ref = Process.monitor(client)
+      Process.exit(client, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^client, _}, 1_000
+
+      # Reconnect on a brand-new socket. This first poll retains the pre-kill
+      # total AND establishes a baseline for the fresh socket: a socket seen for
+      # the first time contributes 0, so the traffic it carries only starts
+      # counting from the *next* poll.
+      for _ <- 1..2, do: Realtime.GenRpc.call(node, String, :length, [payload], key: 1)
+      after_reconnect = GenRpcMetrics.info()[node][:inet_stats]
+
+      # Every cumulative counter must be monotonic across the reset. send_oct is
+      # the strong signal here: it was ~8MB before, and a fresh socket carrying
+      # only the small post-kill batch could never reach that on its own, so this
+      # only holds because the accumulator retained the pre-kill total.
+      for key <- [:recv_oct, :recv_cnt, :send_oct, :send_cnt] do
+        assert after_reconnect[key] >= before[key],
+               "#{key} dropped after gen_rpc client restart: #{before[key]} -> #{after_reconnect[key]}"
+      end
+
+      # Push more traffic on the now-baselined socket and poll again. This proves
+      # the accumulator doesn't just retain the old total but keeps counting on
+      # top of it after the restart. send_oct must grow by ~2MB (the two 1MB
+      # calls), which the fresh socket can only contribute once it has a baseline.
+      for _ <- 1..2, do: Realtime.GenRpc.call(node, String, :length, [payload], key: 1)
+      later = GenRpcMetrics.info()[node][:inet_stats]
+
+      for key <- [:recv_oct, :recv_cnt, :send_oct, :send_cnt] do
+        assert later[key] >= after_reconnect[key],
+               "#{key} dropped across post-restart polls: #{after_reconnect[key]} -> #{later[key]}"
+      end
+
+      assert later[:send_oct] - after_reconnect[:send_oct] >= 1_000_000,
+             "post-restart send_oct did not accumulate new traffic: " <>
+               "#{after_reconnect[:send_oct]} -> #{later[:send_oct]}"
+    end
+  end
+
+  describe "info/0 pruning" do
+    test "drops the accumulator for a node that leaves the cluster", %{node: node} do
+      # Generate load and poll so a real accumulator exists for the connected node.
+      Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 1)
+      Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 2)
+      GenRpcMetrics.info()
+      assert Map.has_key?(:sys.get_state(GenRpcMetrics).totals, node)
+
+      # Actually drop the node from the cluster. A second peer can't be spun up
+      # (it would need the same gen_rpc port as the shared node), so we take the
+      # shared node down and reconnect it below so the rest of the suite is
+      # unaffected regardless of test run order.
+      :ok = :net_kernel.monitor_nodes(true)
+      true = :erlang.disconnect_node(node)
+      assert_receive {:nodedown, ^node}, 5_000
+
+      # A poll rebuilds `totals` from the live node set, so a node that has left
+      # the cluster is pruned instead of accumulating forever.
+      GenRpcMetrics.info()
+      refute Map.has_key?(:sys.get_state(GenRpcMetrics).totals, node)
+
+      # Restore the shared node (and its gen_rpc client) for the other tests.
+      true = Node.connect(node)
+      assert_receive {:nodeup, ^node}, 5_000
+      :ok = :net_kernel.monitor_nodes(false)
+      Realtime.GenRpc.call(node, String, :to_integer, ["25"], key: 1)
     end
   end
 end

--- a/test/realtime/monitoring/prom_ex/plugins/gen_rpc_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/gen_rpc_test.exs
@@ -14,8 +14,17 @@ defmodule Realtime.PromEx.Plugins.GenRpcTest do
   setup_all do
     {:ok, node} = Clustered.start()
     start_supervised!(MetricsTest)
-    # Send some data back and forth
-    25 = :gen_rpc.call(node, String, :to_integer, ["25"])
+
+    # The cumulative counters (recv/send oct/cnt) are accumulated as per-socket
+    # deltas across polls: the first poll after a socket appears only establishes
+    # a baseline and contributes 0. Generate traffic spanning several poll cycles
+    # (poll_rate: 100) so the deltas are captured and the exported counters become
+    # non-zero.
+    for _ <- 1..20 do
+      25 = :gen_rpc.call(node, String, :to_integer, ["25"])
+      Process.sleep(50)
+    end
+
     # Wait for MetricsTest to fetch metrics
     Process.sleep(200)
     %{node: node}


### PR DESCRIPTION
## What kind of change does this PR introduce?

`Realtime.GenRpcMetrics.info/0` summed the monotonic `:inet.getstat/1` counters (`recv_oct`, `recv_cnt`, `send_oct`, `send_cnt`) across the live set of `gen_rpc` sockets and the `PromEx` plugin exported that sum as a last_value gauge per `{origin_node, target_node}`. Because a host has more than one `gen_rpc` port, whenever one port was recycled its per-socket counter reset to 0, so the summed value dropped which Prometheus `rate()/increase()` reads as a counter reset followed by a spurious massive increment.

Now we keep track of what we have reported and increment deltas to have a monotonic counter instead. When there is a proper reset (node disconnect -> reconnect) we report 0 to cause a proper counter reset and start incrementing again.