### PR TITLE
chore: fix flaky jwt test

### DIFF
--- a/test/realtime_web/channels/auth/jwt_verification_test.exs
+++ b/test/realtime_web/channels/auth/jwt_verification_test.exs
@@ -16,7 +16,23 @@ defmodule RealtimeWeb.JwtVerificationTest do
 
   setup do
     start_supervised(Mock)
-    on_exit(fn -> Application.put_env(:realtime, :jwt_claim_validators, %{}) end)
+
+    # Route Joken's current_time/0 through the Mock so Mock.freeze/0 actually
+    # controls the clock the code under test sees. Without this the mock is a
+    # no-op and exp/iat assertions flake on second boundaries.
+    previous_adapter = Application.get_env(:joken, :current_time_adapter)
+    Application.put_env(:joken, :current_time_adapter, Mock)
+
+    on_exit(fn ->
+      Application.put_env(:realtime, :jwt_claim_validators, %{})
+
+      if previous_adapter do
+        Application.put_env(:joken, :current_time_adapter, previous_adapter)
+      else
+        Application.delete_env(:joken, :current_time_adapter)
+      end
+    end)
+
     :ok
   end
 


### PR DESCRIPTION

## What kind of change does this PR introduce?

Override Joken's time adapter so time can freeze

Test was failing sometimes:

```
 1. test verify/3 rejects token with future exp encoded as a string (RealtimeWeb.JwtVerificationTest)
     Error:      test/realtime_web/channels/auth/jwt_verification_test.exs:169
      match (=) failed
      The following variables were pinned:
        claim_val = "1787663274"
        current_time = 1787662274
      code:  assert {:error, message: ^current_time, claim: "exp", claim_val: ^claim_val} =
           JwtVerification.verify(token, @jwt_secret, nil)
      left:  {:error, message: ^current_time, claim: "exp", claim_val: ^claim_val}
      right: {:error,
          [
            message: 1787662275,
            claim: "exp",
            claim_val: "1787663274"
          ]}
      stacktrace:
        test/realtime_web/channels/auth/jwt_verification_test.exs:183: (test)
       ```