### PR TITLE
fix: PG changes empty select returns just primary keys

### DIFF
--- a/lib/extensions/postgres_cdc_rls/subscriptions.ex
+++ b/lib/extensions/postgres_cdc_rls/subscriptions.ex
@@ -352,10 +352,10 @@ defmodule Extensions.PostgresCdcRls.Subscriptions do
   end
 
   defp parse_select(%{"select" => cols}) when is_list(cols) do
-    case Enum.filter(cols, &is_binary/1) do
-      [] -> {:ok, nil}
-      valid -> {:ok, valid}
-    end
+    # An empty select list means "primary keys only" (stored as '{}'), which is
+    # distinct from omitting select entirely (nil = all columns). Keep the empty
+    # list so it reaches the database as '{}' instead of collapsing to nil.
+    {:ok, Enum.filter(cols, &is_binary/1)}
   end
 
   defp parse_select(%{"select" => str}) when is_binary(str) do

--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -99,7 +99,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_260_706_120_000, Migrations.GrantCheckEqualityOp5Arg},
     {20_260_707_120_000, Migrations.RestrictRealtimeSchema},
     {20_260_709_120_000, Migrations.FixApplyRlsFilterRoleLeak},
-    {20_260_714_120_000, Migrations.AddBroadcastPersistence}
+    {20_260_714_120_000, Migrations.AddBroadcastPersistence},
+    {20_260_827_120_000, Migrations.EmptySelectColumnsReturnPrimaryKeys}
   ]
 
   defstruct [:tenant_external_id, :settings, migrations_ran: 0]

--- a/lib/realtime/tenants/repo/migrations/20260827120000_empty_select_columns_return_primary_keys.ex
+++ b/lib/realtime/tenants/repo/migrations/20260827120000_empty_select_columns_return_primary_keys.ex
@@ -1,0 +1,151 @@
+defmodule Realtime.Tenants.Migrations.EmptySelectColumnsReturnPrimaryKeys do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    # Treat an empty selected_columns array ('{}') as "primary keys only" instead
+    # of silently collapsing it to NULL ("all columns"). apply_rls already emits
+    # just the primary key columns for a non-null selected_columns array (a column
+    # is kept when it is selected OR it is a pkey), so the only change needed in the
+    # trigger is to stop the normalization step from turning '{}' back into NULL.
+    execute("""
+    create or replace function realtime.subscription_check_filters()
+        returns trigger
+        language plpgsql
+    as $$
+    declare
+        col_names text[] = coalesce(
+                array_agg(a.attname order by a.attnum),
+                '{}'::text[]
+            )
+            from
+                pg_catalog.pg_attribute a
+            where
+                a.attrelid = new.entity
+                and a.attnum > 0
+                and not a.attisdropped
+                and pg_catalog.has_column_privilege(
+                    (new.claims ->> 'role'),
+                    a.attrelid,
+                    a.attnum,
+                    'SELECT'
+                );
+        filter realtime.user_defined_filter;
+        col_type regtype;
+        in_val jsonb;
+        selected_col text;
+    begin
+        for filter in select * from unnest(new.filters) loop
+            if not filter.column_name = any(col_names) then
+                raise exception 'invalid column for filter %', filter.column_name;
+            end if;
+
+            col_type = (
+                select atttypid::regtype
+                from pg_catalog.pg_attribute
+                where attrelid = new.entity
+                      and attname = filter.column_name
+            );
+            if col_type is null then
+                raise exception 'failed to lookup type for column %', filter.column_name;
+            end if;
+
+            if filter.op = 'in'::realtime.equality_op then
+                in_val = realtime.cast(filter.value, (col_type::text || '[]')::regtype);
+                if coalesce(jsonb_array_length(in_val), 0) > 100 then
+                    raise exception 'too many values for `in` filter. Maximum 100';
+                end if;
+            elsif filter.op = 'is'::realtime.equality_op then
+                -- `is` requires a keyword RHS rather than a typed literal
+                if filter.value not in ('null', 'true', 'false', 'unknown') then
+                    raise exception 'invalid value for is filter: must be null, true, false, or unknown';
+                end if;
+                -- IS NULL works for any type, but IS TRUE/FALSE/UNKNOWN require a boolean
+                -- operand. Reject the non-null keywords on non-boolean columns here so they
+                -- don't abort apply_rls at WAL time.
+                if filter.value <> 'null' and col_type <> 'boolean'::regtype then
+                    raise exception 'is % filter requires a boolean column, got %', filter.value, col_type::text;
+                end if;
+            elsif filter.op in ('like'::realtime.equality_op, 'ilike'::realtime.equality_op) then
+                -- like/ilike apply the text pattern operator (~~); reject column types that
+                -- have no such operator instead of failing at WAL time
+                if not exists (
+                    select 1 from pg_catalog.pg_operator
+                    where oprname = '~~' and oprleft = col_type
+                ) then
+                    raise exception 'operator % requires a text-compatible column type, got %', filter.op::text, col_type::text;
+                end if;
+            elsif filter.op in ('match'::realtime.equality_op, 'imatch'::realtime.equality_op) then
+                -- match/imatch apply the regex operators ~ / ~*; reject column types that have
+                -- no such operator (e.g. integer) instead of failing at WAL time, mirroring the
+                -- like/ilike guard above.
+                if not exists (
+                    select 1 from pg_catalog.pg_operator
+                    where oprname = case when filter.op = 'imatch'::realtime.equality_op then '~*' else '~' end
+                      and oprleft = col_type
+                      and oprright = col_type
+                      and oprresult = 'boolean'::regtype
+                ) then
+                    raise exception 'operator % requires a text-compatible column type, got %', filter.op::text, col_type::text;
+                end if;
+                -- validate the regex eagerly so a bad pattern is rejected here, not inside
+                -- apply_rls where it would abort the WAL stream for the entity
+                begin
+                    perform '' ~ filter.value;
+                exception when others then
+                    raise exception 'invalid regular expression for % filter: %', filter.op::text, sqlerrm;
+                end;
+            else
+                -- eq/neq/lt/lte/gt/gte: value must be coercable to the type
+                perform realtime.cast(filter.value, col_type);
+            end if;
+        end loop;
+
+        if new.selected_columns is not null then
+            for selected_col in select * from unnest(new.selected_columns) loop
+                if not selected_col = any(col_names) then
+                    raise exception 'invalid column for select %', selected_col;
+                end if;
+            end loop;
+        end if;
+
+        -- Apply consistent order to filters so the unique constraint can't be tricked by a
+        -- different filter order. negate is part of the sort key.
+        new.filters = coalesce(
+            array_agg(f order by f.column_name, f.op, f.value, f.negate),
+            '{}'
+        ) from unnest(new.filters) f;
+
+        -- Normalize selected_columns order so ARRAY['a','b'] and ARRAY['b','a'] are treated
+        -- as the same subscription group in apply_rls. Preserve an empty array as '{}'
+        -- ("primary keys only") so it stays distinct from NULL ("all columns"); array_agg
+        -- over an empty set would otherwise collapse '{}' back to NULL.
+        if new.selected_columns is not null then
+            new.selected_columns = coalesce(
+                (
+                    select array_agg(c order by c)
+                    from unnest(new.selected_columns) c
+                ),
+                '{}'::text[]
+            );
+        end if;
+
+        return new;
+    end;
+    $$;
+    """)
+
+    # NOTE: the unique index is intentionally left unchanged. Its
+    # `coalesce(selected_columns, '{}')` expression treats a NULL ("all columns")
+    # row and a '{}' ("primary keys only") row as equal, but they still can't be
+    # merged because subscription_id is a distinct `UUID.uuid1/0` per
+    # postgres_changes entry (RealtimeChannel `pg_change_params/5`), so two distinct
+    # subscriptions never share the leading column of the index. (The
+    # `:erlang.phash2(params)` id in `add_id_to_postgres_changes` is only the
+    # client-facing routing id and never reaches this table.) The coalesce exists
+    # solely to dedupe the same subscription's reconnect upsert when
+    # selected_columns is NULL (NULL != NULL in a unique index would otherwise
+    # insert a duplicate instead of updating), which it still does.
+  end
+end

--- a/priv/repo/tenant_db_dump_15.sql
+++ b/priv/repo/tenant_db_dump_15.sql
@@ -1008,10 +1008,19 @@ begin
         '{}'
     ) from unnest(new.filters) f;
 
-    new.selected_columns = (
-        select array_agg(c order by c)
-        from unnest(new.selected_columns) c
-    );
+    -- Normalize selected_columns order so ARRAY['a','b'] and ARRAY['b','a'] are treated
+    -- as the same subscription group in apply_rls. Preserve an empty array as '{}'
+    -- ("primary keys only") so it stays distinct from NULL ("all columns"); array_agg
+    -- over an empty set would otherwise collapse '{}' back to NULL.
+    if new.selected_columns is not null then
+        new.selected_columns = coalesce(
+            (
+                select array_agg(c order by c)
+                from unnest(new.selected_columns) c
+            ),
+            '{}'::text[]
+        );
+    end if;
 
     return new;
 end;
@@ -1498,3 +1507,4 @@ INSERT INTO realtime."schema_migrations" (version) VALUES (20260706120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260707120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260709120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260714120000);
+INSERT INTO realtime."schema_migrations" (version) VALUES (20260827120000);

--- a/priv/repo/tenant_db_dump_17.sql
+++ b/priv/repo/tenant_db_dump_17.sql
@@ -1009,10 +1009,19 @@ begin
         '{}'
     ) from unnest(new.filters) f;
 
-    new.selected_columns = (
-        select array_agg(c order by c)
-        from unnest(new.selected_columns) c
-    );
+    -- Normalize selected_columns order so ARRAY['a','b'] and ARRAY['b','a'] are treated
+    -- as the same subscription group in apply_rls. Preserve an empty array as '{}'
+    -- ("primary keys only") so it stays distinct from NULL ("all columns"); array_agg
+    -- over an empty set would otherwise collapse '{}' back to NULL.
+    if new.selected_columns is not null then
+        new.selected_columns = coalesce(
+            (
+                select array_agg(c order by c)
+                from unnest(new.selected_columns) c
+            ),
+            '{}'::text[]
+        );
+    end if;
 
     return new;
 end;
@@ -1499,3 +1508,4 @@ INSERT INTO realtime."schema_migrations" (version) VALUES (20260706120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260707120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260709120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260714120000);
+INSERT INTO realtime."schema_migrations" (version) VALUES (20260827120000);

--- a/priv/repo/tenant_schema/realtime/functions/subscription_check_filters.sql
+++ b/priv/repo/tenant_schema/realtime/functions/subscription_check_filters.sql
@@ -105,10 +105,19 @@ begin
         '{}'
     ) from unnest(new.filters) f;
 
-    new.selected_columns = (
-        select array_agg(c order by c)
-        from unnest(new.selected_columns) c
-    );
+    -- Normalize selected_columns order so ARRAY['a','b'] and ARRAY['b','a'] are treated
+    -- as the same subscription group in apply_rls. Preserve an empty array as '{}'
+    -- ("primary keys only") so it stays distinct from NULL ("all columns"); array_agg
+    -- over an empty set would otherwise collapse '{}' back to NULL.
+    if new.selected_columns is not null then
+        new.selected_columns = coalesce(
+            (
+                select array_agg(c order by c)
+                from unnest(new.selected_columns) c
+            ),
+            '{}'::text[]
+        );
+    end if;
 
     return new;
 end;

--- a/test/integration/rt_channel/postgres_changes_test.exs
+++ b/test/integration/rt_channel/postgres_changes_test.exs
@@ -544,6 +544,65 @@ defmodule Realtime.Integration.RtChannel.PostgresChangesTest do
       refute "binary_data" in column_names
     end
 
+    test "subscribe with an empty select delivers primary keys only — INSERT", %{
+      tenant: tenant,
+      serializer: serializer
+    } do
+      {socket, _} = get_connection(tenant, serializer)
+      topic = "realtime:any"
+
+      config = %{
+        postgres_changes: [
+          %{event: "INSERT", schema: "public", table: "test", select: []}
+        ]
+      }
+
+      WebsocketClient.join(socket, topic, %{config: config})
+      sub_id = :erlang.phash2(%{"event" => "INSERT", "schema" => "public", "table" => "test", "select" => []})
+
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic},
+                     200
+
+      assert_receive %Message{
+                       event: "system",
+                       payload: %{
+                         "extension" => "postgres_changes",
+                         "message" => "Subscribed to PostgreSQL",
+                         "status" => "ok"
+                       },
+                       topic: ^topic
+                     },
+                     8000
+
+      {:ok, _, conn} = PostgresCdcRls.get_manager_conn(tenant.external_id)
+
+      %{rows: [[id]]} =
+        Postgrex.query!(conn, "insert into test (details) values ('hello') returning id", [])
+
+      assert_receive %Message{
+                       event: "postgres_changes",
+                       payload: %{
+                         "data" => %{
+                           "columns" => columns,
+                           "record" => record,
+                           "type" => "INSERT"
+                         },
+                         "ids" => [^sub_id]
+                       },
+                       topic: ^topic
+                     },
+                     500
+
+      # An empty select means primary keys only: the PK is present and every
+      # non-pkey column is excluded (distinct from omitting select, which delivers
+      # all columns).
+      assert record["id"] == id
+      refute Map.has_key?(record, "details")
+      refute Map.has_key?(record, "binary_data")
+      # columns metadata reflects the same: only the PK column is present
+      assert Enum.map(columns, & &1["name"]) == ["id"]
+    end
+
     test "subscribe with select filters payload columns — UPDATE", %{
       tenant: tenant,
       serializer: serializer

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -1115,8 +1115,8 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
     end
 
     @tag without_db: true
-    test "passing an empty select list is treated as no column selection" do
-      assert {:ok, {"*", "public", "messages", [], nil}} =
+    test "passing an empty select list means primary keys only (distinct from no select)" do
+      assert {:ok, {"*", "public", "messages", [], []}} =
                Subscriptions.parse_subscription_params(%{
                  "schema" => "public",
                  "table" => "messages",
@@ -1172,6 +1172,87 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
         [wal_result, _] = matching
         assert Map.has_key?(wal_result["record"], "id")
         assert Map.has_key?(wal_result["record"], "details")
+      after
+        Postgrex.query(conn, "SELECT pg_drop_replication_slot($1)", [slot_name])
+      end
+    end
+
+    test "subscription with an empty select stores '{}' in the database (primary keys only)", %{conn: conn} do
+      {:ok, subscription_params} =
+        Subscriptions.parse_subscription_params(%{"schema" => "public", "table" => "test", "select" => []})
+
+      params_list = [
+        %{claims: %{"role" => "anon"}, id: UUID.uuid1(), subscription_params: subscription_params}
+      ]
+
+      assert {:ok, [%Postgrex.Result{}]} =
+               Subscriptions.create(conn, "supabase_realtime_test", params_list, self(), self())
+
+      # '{}' is preserved rather than collapsed to NULL, so it stays distinct from
+      # "no select" (all columns)
+      assert %Postgrex.Result{rows: [[[]]]} =
+               Postgrex.query!(conn, "select selected_columns from realtime.subscription", [])
+    end
+
+    test "a NULL (all columns) and a '{}' (primary keys only) subscription for the same table coexist", %{conn: conn} do
+      # A client can subscribe to the same table both without a select (all columns)
+      # and with select: [] (primary keys only). Each postgres_changes entry gets its
+      # own subscription_id (UUID.uuid1/0 in RealtimeChannel), so the two rows never
+      # share the leading column of the unique index and are never merged by its
+      # `coalesce(selected_columns, '{}')` expression, which otherwise treats NULL and
+      # '{}' as equal. Guard that invariant here: if subscription_id ever stopped being
+      # unique per entry, the coalesce would silently upsert one of these over the other.
+      {:ok, all_columns_params} = Subscriptions.parse_subscription_params(%{"schema" => "public", "table" => "test"})
+
+      {:ok, pkeys_only_params} =
+        Subscriptions.parse_subscription_params(%{"schema" => "public", "table" => "test", "select" => []})
+
+      params_list = [
+        %{claims: %{"role" => "anon"}, id: UUID.uuid1(), subscription_params: all_columns_params},
+        %{claims: %{"role" => "anon"}, id: UUID.uuid1(), subscription_params: pkeys_only_params}
+      ]
+
+      assert {:ok, [%Postgrex.Result{}, %Postgrex.Result{}]} =
+               Subscriptions.create(conn, "supabase_realtime_test", params_list, self(), self())
+
+      # Two distinct rows survive: NULL (all columns) and '{}' (primary keys only).
+      assert %Postgrex.Result{rows: [[nil], [[]]]} =
+               Postgrex.query!(
+                 conn,
+                 "select selected_columns from realtime.subscription order by selected_columns nulls first",
+                 []
+               )
+    end
+
+    test "apply_rls returns only primary keys in the payload when select is empty", %{conn: conn} do
+      sub_id = UUID.uuid1()
+      slot_name = "test_apply_rls_empty_select_#{:rand.uniform(999_999)}"
+
+      Postgrex.query!(
+        conn,
+        "insert into realtime.subscription (subscription_id, entity, claims, selected_columns) values ($1::text::uuid, 'public.test'::regclass, $2, '{}')",
+        [sub_id, %{"role" => "anon"}]
+      )
+
+      Postgrex.query!(conn, "SELECT pg_create_logical_replication_slot($1, 'wal2json')", [slot_name])
+
+      try do
+        Postgrex.query!(conn, "insert into test (details) values ('hello')", [])
+
+        %{rows: rows} =
+          Postgrex.query!(
+            conn,
+            "select wal, subscription_ids from realtime.list_changes($1, $2, 100, 1048576)",
+            ["supabase_realtime_test", slot_name]
+          )
+
+        bin_sub_id = UUID.string_to_binary!(sub_id)
+        matching = Enum.find(rows, fn [_wal, sub_ids] -> bin_sub_id in (sub_ids || []) end)
+        assert matching != nil, "Expected sub_id in list_changes result. rows=#{inspect(rows)}"
+        [wal_result, _] = matching
+        # Only the primary key (id) is present; the non-pkey column is excluded
+        assert Map.has_key?(wal_result["record"], "id")
+        refute Map.has_key?(wal_result["record"], "details")
       after
         Postgrex.query(conn, "SELECT pg_drop_replication_slot($1)", [slot_name])
       end


### PR DESCRIPTION
## What kind of change does this PR introduce?

PG changes empty select should return just primary keys instead of all columns

This also syncs up Walrus & Realtime 

Connected to https://github.com/supabase/walrus/pull/85

## What is the current behavior?

