### PR TITLE
chore: Flaky test retry and notification script

### DIFF
--- a/.github/scripts/run_tests_with_retry.sh
+++ b/.github/scripts/run_tests_with_retry.sh
@@ -35,10 +35,26 @@ fi
 
 echo "::warning::Tests failed, retrying only the failed tests once"
 
+ATTEMPT2_LOG="$(mktemp)"
 set +e
-mix test --failed --color
-ATTEMPT2_EXIT=$?
+mix test --failed --color 2>&1 | tee "$ATTEMPT2_LOG"
+ATTEMPT2_EXIT="${PIPESTATUS[0]}"
 set -e
+
+# ExUnit's --failed manifest does not respect :parameterize params. 
+# If a failing parameter variant's manifest entry gets
+# overwritten --failed selects nothing, prints this message, and exits
+# cleanly without rerunning.
+# Treat it as inconclusive rather than trust the exit code, so a genuinely broken
+# variant can't hide behind an always-passing sibling forever.
+#
+# Will fix in ExUnit separately but we then also need to wait for the release of that.
+# This is also a good/safe fallback for other such/similar issues, so we don't
+# accidentally leak failing tests.
+if grep -q "There are no tests to run" "$ATTEMPT2_LOG"; then
+  echo "::error::Retry selected no tests to re-run (see script comment for why) - treating as a genuine failure"
+  exit 1
+fi
 
 if [ "$ATTEMPT2_EXIT" -ne 0 ]; then
   echo "::error::Retry also failed with exit code $ATTEMPT2_EXIT - genuine failure"

--- a/.github/scripts/run_tests_with_retry.sh
+++ b/.github/scripts/run_tests_with_retry.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Runs the test suite; if it fails with ExUnit test failures, retries
+# only the failed tests once. If the retry passes, the failure was a flake:
+# report it but exit 0 so CI stays green.
+# Any other outcome (compile/infra error, or retry also fails) exits non-zero.
+#
+# The report is uploading artifacts with a summary of the failure, a daily job 
+# picks them up, summarizes them and posts them to slack (`flaky-digest.yml`).
+set -euo pipefail
+
+EXPORT_COVERAGE_SUFFIX="$1"
+
+ATTEMPT1_LOG="$(mktemp)"
+FLAKY_REPORT="flaky-report.md"
+FLAKY_EVENTS="flaky-events.jsonl"
+MAX_SNIPPET_CHARS=4000
+
+# mix's exit code is data we need to branch on, not an error - suspend
+# errexit so a nonzero PIPESTATUS doesn't abort the script before we read it.
+set +e
+mix coveralls.lcov --partitions 4 --export-coverage "$EXPORT_COVERAGE_SUFFIX" --color 2>&1 | tee "$ATTEMPT1_LOG"
+ATTEMPT1_EXIT="${PIPESTATUS[0]}"
+set -e
+
+if [ "$ATTEMPT1_EXIT" -eq 0 ]; then
+  exit 0
+fi
+
+if [ "$ATTEMPT1_EXIT" -ne 2 ]; then
+  # ::error::/::warning:: are GitHub Actions workflow commands - the runner
+  # turns them into annotations on the job instead of plain log lines.
+  echo "::error::Test run failed with exit code $ATTEMPT1_EXIT (not a test failure) - no retry"
+  exit "$ATTEMPT1_EXIT"
+fi
+
+echo "::warning::Tests failed, retrying only the failed tests once"
+
+set +e
+mix test --failed --color
+ATTEMPT2_EXIT=$?
+set -e
+
+if [ "$ATTEMPT2_EXIT" -ne 0 ]; then
+  echo "::error::Retry also failed with exit code $ATTEMPT2_EXIT - genuine failure"
+  exit "$ATTEMPT2_EXIT"
+fi
+
+echo "Retry passed - the original failure was a flake, reporting it"
+
+SNIPPET="$(sed -n '/^ *[0-9][0-9]*)/,/^Finished in/p' "$ATTEMPT1_LOG" | \
+  sed -r 's/\x1b\[[0-9;]*m//g' | \
+  head -c "$MAX_SNIPPET_CHARS")"
+
+{
+  echo "## Flaky test detected"
+  echo '```'
+  echo "$SNIPPET"
+  echo '```'
+} > "$FLAKY_REPORT"
+
+cat "$FLAKY_REPORT" >> "$GITHUB_STEP_SUMMARY"
+
+# Code that extracts the relevant data from the detected flakies and writes them into a JSON file
+
+# Create empty flakey file
+: > "$FLAKY_EVENTS"
+
+# Structured, one-JSON-object-per-failed-test sibling of the report above -
+# lets the daily digest workflow group occurrences by file:line across runs.
+# Each ExUnit failure looks like:
+#   N) test <name> (<Module>)
+#      <file>:<line>
+#   ...rest of the block...
+# (parameterized tests insert a "Parameters: ..." line before the location;
+# module-level failures, e.g. setup_all, have no "test" keyword and no
+# location line at all - those are skipped here but still show up in
+# flaky-report.md above.)
+# `boundaries` is a "<start> <end>" line pair per block (1-indexed, inclusive).
+boundaries="$(awk '
+  /^ *[0-9]+\) test / { if (start) print start, NR - 1; start = NR; next }
+  start && /^Finished in/ { print start, NR - 1; start = 0 }
+  END { if (start) print start, NR }
+' "$ATTEMPT1_LOG")"
+
+while read -r block_start block_end; do
+  [ -z "$block_start" ] && continue
+
+  block="$(sed -n "${block_start},${block_end}p" "$ATTEMPT1_LOG" | sed -r 's/\x1b\[[0-9;]*m//g')"
+  header="$(printf '%s\n' "$block" | head -n 1)"
+  # The location is a bare "path:line" - strip its indentation before matching.
+  error_line="$(printf '%s\n' "$block" | sed -n '2,4p' | sed -E 's/^[[:space:]]*(Error:[[:space:]]*)?//' | grep -m1 -E '^.+:[0-9]+$' || true)"
+
+  test_name="$(printf '%s' "$header" | sed -E 's/^ *[0-9]+\) test (.*) \(([A-Za-z0-9_.]+)\)[[:space:]]*$/\2 \1/')"
+  file="$(printf '%s' "$error_line" | sed -E 's/^(.+):[0-9]+$/\1/')"
+  line="$(printf '%s' "$error_line" | sed -E 's/^.+:([0-9]+)$/\1/')"
+  snippet="$(printf '%s' "$block" | head -c "$MAX_SNIPPET_CHARS")"
+
+  jq -n \
+    --arg file "${file:-}" \
+    --argjson line "${line:-0}" \
+    --arg test "$test_name" \
+    --arg run_id "${GITHUB_RUN_ID:-}" \
+    --arg snippet "$snippet" \
+    '{file: $file, line: $line, test: $test, run_id: $run_id, snippet: $snippet}' \
+    >> "$FLAKY_EVENTS"
+done <<< "$boundaries"
+
+exit 0

--- a/.github/scripts/run_tests_with_retry.sh
+++ b/.github/scripts/run_tests_with_retry.sh
@@ -13,7 +13,7 @@ EXPORT_COVERAGE_SUFFIX="$1"
 ATTEMPT1_LOG="$(mktemp)"
 FLAKY_REPORT="flaky-report.md"
 FLAKY_EVENTS="flaky-events.jsonl"
-MAX_SNIPPET_CHARS=4000
+MAX_SNIPPET_CHARS=8000
 
 # mix's exit code is data we need to branch on, not an error - suspend
 # errexit so a nonzero PIPESTATUS doesn't abort the script before we read it.
@@ -47,9 +47,13 @@ fi
 
 echo "Retry passed - the original failure was a flake, reporting it"
 
+# Truncate as a bash substring, not via a piped `head -c` - if the sed output
+# is longer than the limit, head closes the pipe early and SIGPIPEs sed,
+# which then exits non-zero and aborts the whole script even though the
+# retry already passed.
 SNIPPET="$(sed -n '/^ *[0-9][0-9]*)/,/^Finished in/p' "$ATTEMPT1_LOG" | \
-  sed -r 's/\x1b\[[0-9;]*m//g' | \
-  head -c "$MAX_SNIPPET_CHARS")"
+  sed -r 's/\x1b\[[0-9;]*m//g')"
+SNIPPET="${SNIPPET:0:$MAX_SNIPPET_CHARS}"
 
 {
   echo "## Flaky test detected"
@@ -93,7 +97,7 @@ while read -r block_start block_end; do
   test_name="$(printf '%s' "$header" | sed -E 's/^ *[0-9]+\) test (.*) \(([A-Za-z0-9_.]+)\)[[:space:]]*$/\2 \1/')"
   file="$(printf '%s' "$error_line" | sed -E 's/^(.+):[0-9]+$/\1/')"
   line="$(printf '%s' "$error_line" | sed -E 's/^.+:([0-9]+)$/\1/')"
-  snippet="$(printf '%s' "$block" | head -c "$MAX_SNIPPET_CHARS")"
+  snippet="${block:0:$MAX_SNIPPET_CHARS}"
 
   jq -n \
     --arg file "${file:-}" \

--- a/.github/scripts/run_tests_with_retry.sh
+++ b/.github/scripts/run_tests_with_retry.sh
@@ -106,7 +106,8 @@ while read -r block_start block_end; do
   [ -z "$block_start" ] && continue
 
   block="$(sed -n "${block_start},${block_end}p" "$ATTEMPT1_LOG" | sed -r 's/\x1b\[[0-9;]*m//g')"
-  header="$(printf '%s\n' "$block" | head -n 1)"
+  # Same broken-pipe risk as the MAX_SNIPPET_CHARS truncation above, so workaround.
+  header="${block%%$'\n'*}"
   # The location is a bare "path:line" - strip its indentation before matching.
   error_line="$(printf '%s\n' "$block" | sed -n '2,4p' | sed -E 's/^[[:space:]]*(Error:[[:space:]]*)?//' | grep -m1 -E '^.+:[0-9]+$' || true)"
 

--- a/.github/workflows/flaky-digest.yml
+++ b/.github/workflows/flaky-digest.yml
@@ -1,0 +1,124 @@
+name: Flaky Test Digest
+
+# Drains whatever flaky-*.jsonl artifacts tests.yml's "Run tests" step has
+# uploaded, groups occurrences by file:line, sends at most one Slack message
+# per workday, then deletes the artifacts it just reported on. 
+# Should catch up on a failed run.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1-5" # 08:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  actions: write # write (not just read) is required to delete artifacts
+
+jobs:
+  collect:
+    name: Collect and report flaky events
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      has_flaky: ${{ steps.aggregate.outputs.has_flaky }}
+      message: ${{ steps.aggregate.outputs.message }}
+    steps:
+      - name: List and download outstanding flaky artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p flaky-artifacts
+          : > matched_artifacts.jsonl
+
+          # Repo-wide `.../actions/artifacts` returns every artifact ever
+          # created, including coverage-partition-* (which this workflow
+          # never deletes) - so paginating that directly would still mean
+          # scanning up to 90 days of history every run, deletion or not.
+          # Scope to runs instead: list tests.yml runs from a generous fixed
+          # lookback then each run's own small list.
+          SINCE="$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)"
+          RUN_IDS="$(gh run list --repo "${{ github.repository }}" --workflow=tests.yml \
+            --created ">=${SINCE}" -L 1000 --json databaseId --jq '.[].databaseId')"
+
+          for RUN_ID in $RUN_IDS; do
+            gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+              | jq -c '.artifacts[] | select(.expired == false) | select(.name | startswith("flaky-"))' \
+              >> matched_artifacts.jsonl
+          done
+
+          jq -r '.id' matched_artifacts.jsonl > artifact_ids.txt || true
+
+          if [ ! -s matched_artifacts.jsonl ]; then
+            echo "No outstanding flaky artifacts"
+            exit 0
+          fi
+
+          while read -r ARTIFACT_ID; do
+            curl -sSL -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}/zip" \
+              -o "flaky-artifacts/${ARTIFACT_ID}.zip"
+            unzip -o -q "flaky-artifacts/${ARTIFACT_ID}.zip" -d "flaky-artifacts/${ARTIFACT_ID}"
+          done < artifact_ids.txt
+
+      - name: Aggregate by file:line and build Slack message
+        id: aggregate
+        run: |
+          set -euo pipefail
+
+          find flaky-artifacts -name 'flaky-events.jsonl' -exec cat {} + > all_events.jsonl 2>/dev/null || true
+
+          if [ ! -s all_events.jsonl ]; then
+            echo "has_flaky=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          jq -s '
+            group_by(if (.file // "") != "" then (.file + ":" + (.line|tostring)) else .test end)
+            | map({
+                key: (if (.[0].file // "") != "" then (.[0].file + ":" + (.[0].line|tostring)) else .[0].test end),
+                count: length,
+                test: .[0].test,
+                snippet: (sort_by(.run_id | tonumber? // 0) | last | .snippet)
+              })
+            | sort_by(-.count)
+          ' all_events.jsonl > grouped.json
+
+          TOTAL_GROUPS="$(jq 'length' grouped.json)"
+
+          jq -r '
+            .[:10][] | "*\(.key)* — \(.count)x\n> \(.test)\n```\n\(.snippet[0:500])\n```\n"
+          ' grouped.json > message.txt
+
+          if [ "$TOTAL_GROUPS" -gt 10 ]; then
+            echo "…and $((TOTAL_GROUPS - 10)) more distinct flaky test location(s) today." >> message.txt
+          fi
+
+          echo "has_flaky=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "message<<FLAKY_DIGEST_EOF"
+            cat message.txt
+            echo "FLAKY_DIGEST_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Delete reported-on artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [ -s artifact_ids.txt ] || exit 0
+
+          while read -r ARTIFACT_ID; do
+            gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}" || true
+          done < artifact_ids.txt
+
+  notify:
+    name: Notify Slack
+    needs: collect
+    if: ${{ needs.collect.outputs.has_flaky == 'true' }}
+    uses: ./.github/workflows/slack-notify.yml
+    with:
+      title: "Daily flaky test digest"
+      status: "partial"
+      details: ${{ needs.collect.outputs.message }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERTS_WEBHOOK }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -57,4 +57,4 @@ jobs:
       title: 'Hex Audit'
       status: 'failure'
     secrets:
-      SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERTS_WEBHOOK }}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -12,8 +12,14 @@ on:
         required: false
         default: 'info'
         type: string
+      details:
+        description: 'Optional extra text (e.g. a failure snippet) appended as a code block'
+        required: false
+        default: ''
+        type: string
     secrets:
-      SLACK_ALERTS_WEBHOOK:
+      SLACK_WEBHOOK_URL:
+        description: 'Webhook to post to - caller decides which one'
         required: true
 
 jobs:
@@ -24,13 +30,14 @@ jobs:
         env:
           TITLE: ${{ inputs.title }}
           STATUS: ${{ inputs.status }}
+          DETAILS: ${{ inputs.details }}
           GITHUB_REPO: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_REFNAME: ${{ github.ref_name }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_SHA: ${{ github.sha }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERTS_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           STATUS_ICON=""
           STATUS_PREFIX=""
@@ -57,48 +64,45 @@ jobs:
             TITLE_SUFFIX=" ${STATUS_PREFIX}"
           fi
 
-          payload=$(cat <<EOF
-          {
-            "text": "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX} in ${GITHUB_REPO}",
-            "blocks": [
-              {
-                "type": "header",
-                "text": { "type": "plain_text", "text": "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX}", "emoji": true }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  { "type": "mrkdwn", "text": "*Repository*\n${GITHUB_REPO}" },
-                  { "type": "mrkdwn", "text": "*Workflow*\n${GITHUB_WORKFLOW}" },
-                  { "type": "mrkdwn", "text": "*Ref*\n${GITHUB_REFNAME}" },
-                  { "type": "mrkdwn", "text": "*Actor*\n${GITHUB_ACTOR}" }
+          # DETAILS may contain stack traces with quotes/backslashes/newlines,
+          # so build the payload with jq rather than raw string interpolation.
+          TRUNCATED_DETAILS="$(printf '%s' "$DETAILS" | head -c 3000)"
+
+          payload=$(jq -n \
+            --arg text "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX} in ${GITHUB_REPO}" \
+            --arg header_text "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX}" \
+            --arg repo "$GITHUB_REPO" \
+            --arg workflow "$GITHUB_WORKFLOW" \
+            --arg ref "$GITHUB_REFNAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg run_url "https://github.com/${GITHUB_REPO}/actions/runs/${GITHUB_RUN_ID}" \
+            --arg commit_url "https://github.com/${GITHUB_REPO}/commit/${GITHUB_SHA}" \
+            --arg sha "$GITHUB_SHA" \
+            --arg details "$TRUNCATED_DETAILS" \
+            '{
+              text: $text,
+              blocks: (
+                [
+                  { type: "header", text: { type: "plain_text", text: $header_text, emoji: true } },
+                  { type: "section", fields: [
+                    { type: "mrkdwn", text: "*Repository*\n\($repo)" },
+                    { type: "mrkdwn", text: "*Workflow*\n\($workflow)" },
+                    { type: "mrkdwn", text: "*Ref*\n\($ref)" },
+                    { type: "mrkdwn", text: "*Actor*\n\($actor)" }
+                  ] }
                 ]
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": { "type": "plain_text", "text": "View Run" },
-                    "url": "https://github.com/${GITHUB_REPO}/actions/runs/${GITHUB_RUN_ID}"
-                  },
-                  {
-                    "type": "button",
-                    "text": { "type": "plain_text", "text": "View Commit" },
-                    "url": "https://github.com/${GITHUB_REPO}/commit/${GITHUB_SHA}"
-                  }
+                + (if ($details | length) > 0 then
+                    [{ type: "section", text: { type: "mrkdwn", text: "```\($details)```" } }]
+                  else [] end)
+                + [
+                  { type: "actions", elements: [
+                    { type: "button", text: { type: "plain_text", text: "View Run" }, url: $run_url },
+                    { type: "button", text: { type: "plain_text", text: "View Commit" }, url: $commit_url }
+                  ] },
+                  { type: "context", elements: [ { type: "mrkdwn", text: "Commit: \($sha)" } ] }
                 ]
-              },
-              {
-                "type": "context",
-                "elements": [
-                  { "type": "mrkdwn", "text": "Commit: ${GITHUB_SHA}" }
-                ]
-              }
-            ]
-          }
-          EOF
-          )
+              )
+            }')
 
           # Check delivery explicitly, there is a history of access being removed and silent failures.
           http_status=$(curl -sS -o /tmp/slack_response.txt -w "%{http_code}" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,9 @@ jobs:
       - name: Start epmd
         run: epmd -daemon
       - name: Run tests
-        run: MIX_TEST_PARTITION=${{ matrix.partition }} mix coveralls.lcov --partitions 4 --export-coverage partition-${{ matrix.partition }}
+        env:
+          MIX_TEST_PARTITION: ${{ matrix.partition }}
+        run: .github/scripts/run_tests_with_retry.sh partition-${{ matrix.partition }}
       - name: Upload coverage artifact
         if: matrix.postgres == 'pg17'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -114,6 +116,14 @@ jobs:
           path: |
             cover/lcov.info
             cover/partition-${{ matrix.partition }}.coverdata
+      - name: Upload flaky test report
+        if: hashFiles('flaky-report.md') != ''
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: flaky-${{ matrix.postgres }}-p${{ matrix.partition }}
+          path: |
+            flaky-report.md
+            flaky-events.jsonl
 
   assets_tests:
     name: Asset Tests

--- a/test/ci_retry_script_genuine_failure_probe_test.exs
+++ b/test/ci_retry_script_genuine_failure_probe_test.exs
@@ -1,7 +1,0 @@
-defmodule CiRetryScriptGenuineFailureProbeTest do
-  use ExUnit.Case, async: true
-
-  test "always fails on purpose" do
-    assert false
-  end
-end

--- a/test/ci_retry_script_genuine_failure_probe_test.exs
+++ b/test/ci_retry_script_genuine_failure_probe_test.exs
@@ -1,0 +1,7 @@
+defmodule CiRetryScriptGenuineFailureProbeTest do
+  use ExUnit.Case, async: true
+
+  test "always fails on purpose" do
+    assert false
+  end
+end


### PR DESCRIPTION
Automatically retry failed tests with `mix test --failed`. If retries pass, report the flaky failure for follow-up while allowing the build to pass.

This is a fancy version that aggregates the reported failures into a daily digest.

Also I know, lots of bash code - but most of it is in the retry scenario and so worst case if it failed we're back where we started from.

Please do not ask me about the regexes, those were mostly driven by examples given to the clanker and we'll see how well they work 😅 

✅ Checked out all the runs and saw multiple retried correctly
⚠️  needed to fix for an upstream bug where `mix test --failed` doesn't correctly retry, we fail if it says there are no test to retry and I'll submit a patch upstream
❓ if the report works is a question for after the merge
✅  did check the correct files produced
✅ checked that failures actually fail it all

<details>
  <summary>Example of an artifact generated</summary>

```
{
  "file": "test/realtime_web/controllers/tenant_controller_test.exs",
  "line": 306,
  "test": "RealtimeWeb.TenantControllerTest delete tenant deletes chosen tenant",
  "run_id": "33379815865",
  "snippet": "  1) test delete tenant deletes chosen tenant (RealtimeWeb.TenantControllerTest)\n     test/realtime_web/controllers/tenant_controller_test.exs:306\n     ** (ExUnit.TimeoutError) test timed out after 60000ms. You can change the timeout:\n\n       1. per test by setting \"@tag timeout: x\" (accepts :infinity)\n       2. per test module by setting \"@moduletag timeout: x\" (accepts :infinity)\n       3. globally via \"ExUnit.start(timeout: x)\" configuration\n       4. by running \"mix test --timeout x\" which sets timeout\n       5. or by running \"mix test --trace\" which sets timeout to infinity\n          (useful when using IEx.pry/0)\n\n     where \"x\" is the timeout given as integer in milliseconds (defaults to 60_000).\n     \n     code: assert eventually(fn -> Realtime.Tenants.ReplicationConnection.ready?(tenant.external_id) end)\n     stacktrace:\n       lib/realtime/tenants/replication_connection.ex:138: Realtime.Tenants.ReplicationConnection.Mimic.Original.Module.ready?/1\n       (realtime 2.130.2) test/support/test_helpers.ex:21: TestHelpers.eventually/2\n       test/realtime_web/controllers/tenant_controller_test.exs:313: (test)\n       (ex_unit 1.19.5) lib/ex_unit/runner.ex:528: ExUnit.Runner.exec_test/2\n       (ex_unit 1.19.5) lib/ex_unit/capture_log.ex:121: ExUnit.CaptureLog.with_log/2\n       (ex_unit 1.19.5) lib/ex_unit/runner.ex:477: anonymous fn/3 in ExUnit.Runner.maybe_capture_log/3\n       (stdlib 7.3.0.1) timer.erl:599: :timer.tc/2\n       (ex_unit 1.19.5) lib/ex_unit/runner.ex:450: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4\n\n..........."
}
```

</details>
