### PR TITLE
chore: Better flaky digest report

### DIFF
--- a/.github/scripts/run_tests_with_retry.sh
+++ b/.github/scripts/run_tests_with_retry.sh
@@ -105,7 +105,9 @@ boundaries="$(awk '
 while read -r block_start block_end; do
   [ -z "$block_start" ] && continue
 
-  block="$(sed -n "${block_start},${block_end}p" "$ATTEMPT1_LOG" | sed -r 's/\x1b\[[0-9;]*m//g')"
+  # Drop bare progress-dot lines - ExUnit's CLI formatter prints these for passing tests as
+  # they complete concurrently, and they can land inside a failure block with no diagnostic value.
+  block="$(sed -n "${block_start},${block_end}p" "$ATTEMPT1_LOG" | sed -r 's/\x1b\[[0-9;]*m//g' | grep -v -E '^\.+$' || true)"
   # Same broken-pipe risk as the MAX_SNIPPET_CHARS truncation above, so workaround.
   header="${block%%$'\n'*}"
   # The location is a bare "path:line" - strip its indentation before matching.
@@ -122,7 +124,10 @@ while read -r block_start block_end; do
     --arg test "$test_name" \
     --arg run_id "${GITHUB_RUN_ID:-}" \
     --arg snippet "$snippet" \
-    '{file: $file, line: $line, test: $test, run_id: $run_id, snippet: $snippet}' \
+    --arg postgres "${MATRIX_POSTGRES:-}" \
+    --arg partition "${MIX_TEST_PARTITION:-}" \
+    --arg job_url "${JOB_URL:-}" \
+    '{file: $file, line: $line, test: $test, run_id: $run_id, snippet: $snippet, postgres: $postgres, partition: $partition, job_url: $job_url}' \
     >> "$FLAKY_EVENTS"
 done <<< "$boundaries"
 

--- a/.github/workflows/flaky-digest.yml
+++ b/.github/workflows/flaky-digest.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       has_flaky: ${{ steps.aggregate.outputs.has_flaky }}
-      message: ${{ steps.aggregate.outputs.message }}
+      blocks: ${{ steps.aggregate.outputs.blocks }}
     steps:
       - name: List and download outstanding flaky artifacts
         env:
@@ -60,7 +60,7 @@ jobs:
             unzip -o -q "flaky-artifacts/${ARTIFACT_ID}.zip" -d "flaky-artifacts/${ARTIFACT_ID}"
           done < artifact_ids.txt
 
-      - name: Aggregate by file:line and build Slack message
+      - name: Aggregate by file:line and build Slack blocks
         id: aggregate
         run: |
           set -euo pipefail
@@ -72,33 +72,76 @@ jobs:
             exit 0
           fi
 
-          jq -s '
-            group_by(if (.file // "") != "" then (.file + ":" + (.line|tostring)) else .test end)
-            | map({
-                key: (if (.[0].file // "") != "" then (.[0].file + ":" + (.[0].line|tostring)) else .[0].test end),
-                count: length,
-                test: .[0].test,
-                snippet: (sort_by(.run_id | tonumber? // 0) | last | .snippet)
-              })
-            | sort_by(-.count)
-          ' all_events.jsonl > grouped.json
+          # Builds one Slack section block per distinct file:line (instead of one giant string)
+          # so a snippet truncation can only ever clip that one entry, never the whole message,
+          # and so markdown (*bold*, links) isn't nested inside an outer code fence that disables
+          # it.
+          #
+          # postgres/partition/job_url may be absent from previous runs or `job_url` failures
+          # - every use below tolerates that via `// ""`/`// empty`.
+          BLOCKS_JSON="$(jq -sc --argjson max_entries 20 '
+            def truncate_at_line($budget):
+              if (. | length) <= $budget then .
+              else
+                .[0:$budget] as $cut
+                | ($cut | rindex("\n")) as $idx
+                | (if $idx then $cut[0:$idx] else $cut end) + "\n… (truncated)"
+              end;
 
-          TOTAL_GROUPS="$(jq 'length' grouped.json)"
+            def env_pairs:
+              map(select((.postgres // "") != "" and (.partition // "") != ""))
+              | map(.postgres + "/" + .partition)
+              | unique;
 
-          jq -r '
-            .[:10][] | "*\(.key)* — \(.count)x\n> \(.test)\n```\n\(.snippet[0:500])\n```\n"
-          ' grouped.json > message.txt
-
-          if [ "$TOTAL_GROUPS" -gt 10 ]; then
-            echo "…and $((TOTAL_GROUPS - 10)) more distinct flaky test location(s) today." >> message.txt
-          fi
+            (group_by(if (.file // "") != "" then (.file + ":" + (.line|tostring)) else .test end)
+             | map(
+                 . as $events
+                 | ($events[0]) as $first
+                 | ($events | sort_by(.run_id | tonumber? // 0) | last) as $latest
+                 | {
+                     key: (if ($first.file // "") != "" then ($first.file + ":" + ($first.line|tostring)) else $first.test end),
+                     count: ($events | length),
+                     test: $first.test,
+                     snippet: ($latest.snippet // ""),
+                     job_url: ($latest.job_url // ""),
+                     envs: ($events | env_pairs)
+                   }
+               )
+             | sort_by(-.count)
+            ) as $groups
+            | ($groups | length) as $total_groups
+            | ($groups | map(.count) | add) as $total_occurrences
+            | ($groups[0:$max_entries]) as $shown
+            | (
+                [
+                  { type: "section", text: { type: "mrkdwn",
+                      text: "*\($total_groups) distinct flaky test(s), \($total_occurrences) total occurrence(s) today*" } }
+                ]
+                + ($shown | map(
+                    . as $g
+                    | (if ($g.envs | length) > 0 then "  _(seen on: \($g.envs | join(", ")))_" else "" end) as $envs_suffix
+                    | (if ($g.job_url // "") != "" then "<\($g.job_url)|Job log> · " else "" end) as $link_prefix
+                    # Slack rejects the whole message if any one section's text exceeds 3000 chars,
+                    # so size the snippet budget off this block's actual fixed overhead (not a flat
+                    # guess) - a long test/key/env list must not be able to push the total over.
+                    | ("*\($g.key)* — \($g.count)x\($envs_suffix)\n\($link_prefix)\($g.test)\n```\n\n```") as $overhead
+                    | ([50, 2900 - ($overhead | length)] | max) as $budget
+                    | ($g.snippet | truncate_at_line($budget)) as $snippet
+                    | {
+                        type: "section",
+                        text: { type: "mrkdwn",
+                          text: "*\($g.key)* — \($g.count)x\($envs_suffix)\n\($link_prefix)\($g.test)\n```\n\($snippet)\n```" }
+                      }
+                  ))
+                + (if $total_groups > $max_entries then
+                    [{ type: "context", elements: [ { type: "mrkdwn",
+                        text: "…and \($total_groups - $max_entries) more distinct flaky test location(s) today." } ] }]
+                  else [] end)
+              )
+          ' all_events.jsonl)"
 
           echo "has_flaky=true" >> "$GITHUB_OUTPUT"
-          {
-            echo "message<<FLAKY_DIGEST_EOF"
-            cat message.txt
-            echo "FLAKY_DIGEST_EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "blocks=$BLOCKS_JSON" >> "$GITHUB_OUTPUT"
 
       - name: Delete reported-on artifacts
         env:
@@ -119,6 +162,6 @@ jobs:
     with:
       title: "Daily flaky test digest"
       status: "partial"
-      details: ${{ needs.collect.outputs.message }}
+      details_blocks: ${{ needs.collect.outputs.blocks }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERTS_WEBHOOK }}

--- a/.github/workflows/flaky-digest.yml
+++ b/.github/workflows/flaky-digest.yml
@@ -121,9 +121,9 @@ jobs:
                     . as $g
                     | (if ($g.envs | length) > 0 then "  _(seen on: \($g.envs | join(", ")))_" else "" end) as $envs_suffix
                     | (if ($g.job_url // "") != "" then "<\($g.job_url)|Job log> · " else "" end) as $link_prefix
-                    # Slack rejects the whole message if any one section's text exceeds 3000 chars,
-                    # so size the snippet budget off this block's actual fixed overhead (not a flat
-                    # guess) - a long test/key/env list must not be able to push the total over.
+                    # Slack rejects the whole message if the text in any one section exceeds
+                    # 3000 chars, so size the snippet budget off the fixed overhead of this
+                    # block (not a flat guess) - a long test/key/env list must not push the total over.
                     | ("*\($g.key)* — \($g.count)x\($envs_suffix)\n\($link_prefix)\($g.test)\n```\n\n```") as $overhead
                     | ([50, 2900 - ($overhead | length)] | max) as $budget
                     | ($g.snippet | truncate_at_line($budget)) as $snippet

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: ''
         type: string
+      details_blocks:
+        description: 'Optional pre-built Slack Block Kit blocks (JSON array), spliced in as-is instead of the details code block'
+        required: false
+        default: '[]'
+        type: string
     secrets:
       SLACK_WEBHOOK_URL:
         description: 'Webhook to post to - caller decides which one'
@@ -31,6 +36,7 @@ jobs:
           TITLE: ${{ inputs.title }}
           STATUS: ${{ inputs.status }}
           DETAILS: ${{ inputs.details }}
+          DETAILS_BLOCKS: ${{ inputs.details_blocks }}
           GITHUB_REPO: ${{ github.repository }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_REFNAME: ${{ github.ref_name }}
@@ -68,6 +74,12 @@ jobs:
           # so build the payload with jq rather than raw string interpolation.
           TRUNCATED_DETAILS="$(printf '%s' "$DETAILS" | head -c 3000)"
 
+          # DETAILS_BLOCKS lets a caller pass pre-built Block Kit blocks (e.g. one block per
+          # entry, each with its own truncation budget) instead of one opaque code-fenced
+          # string. Fall back to [] if empty/not a JSON array, so a malformed input can't break
+          # the whole notification.
+          DETAILS_BLOCKS_JSON="$(printf '%s' "$DETAILS_BLOCKS" | jq -c 'if type == "array" then . else [] end' 2>/dev/null || echo '[]')"
+
           payload=$(jq -n \
             --arg text "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX} in ${GITHUB_REPO}" \
             --arg header_text "${STATUS_ICON} ${TITLE}${TITLE_SUFFIX}" \
@@ -79,6 +91,7 @@ jobs:
             --arg commit_url "https://github.com/${GITHUB_REPO}/commit/${GITHUB_SHA}" \
             --arg sha "$GITHUB_SHA" \
             --arg details "$TRUNCATED_DETAILS" \
+            --argjson details_blocks "$DETAILS_BLOCKS_JSON" \
             '{
               text: $text,
               blocks: (
@@ -91,7 +104,9 @@ jobs:
                     { type: "mrkdwn", text: "*Actor*\n\($actor)" }
                   ] }
                 ]
-                + (if ($details | length) > 0 then
+                + (if ($details_blocks | length) > 0 then
+                    $details_blocks
+                  elif ($details | length) > 0 then
                     [{ type: "section", text: { type: "mrkdwn", text: "```\($details)```" } }]
                   else [] end)
                 + [

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  actions: read # needed to resolve this job's own numeric ID for the flaky digest's job link
 
 env:
   MIX_ENV: test
@@ -104,9 +105,27 @@ jobs:
         run: docker compose -f compose.dbs.yml up -d --wait
       - name: Start epmd
         run: epmd -daemon
+      # flaky test reporter wants to provide full job URLs, no easier way to allow this found
+      - name: Resolve job URL
+        id: job_url
+        continue-on-error: true # best-effort metadata for the flaky digest; never fail the test job over this
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          # github.job is the YAML job key ("tests"), not the per-matrix-cell numeric job ID
+          # the /job/<id> URL needs - resolve it by matching this runner against the run's job
+          # list (each job in a run gets a distinct runner; RUNNER_NAME is set by the runner).
+          JOB_ID="$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
+            --paginate --jq ".jobs[] | select(.runner_name == \"$RUNNER_NAME\") | .id" | head -n1)"
+          if [ -n "$JOB_ID" ]; then
+            echo "url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${JOB_ID}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run tests
         env:
           MIX_TEST_PARTITION: ${{ matrix.partition }}
+          MATRIX_POSTGRES: ${{ matrix.postgres }}
+          JOB_URL: ${{ steps.job_url.outputs.url }}
         run: .github/scripts/run_tests_with_retry.sh partition-${{ matrix.partition }}
       - name: Upload coverage artifact
         if: matrix.postgres == 'pg17'


### PR DESCRIPTION
* truncate better (by splitting our budget on multiple blocks and being more precise in our estimation)
* include links to concrete jobs with the failures (which is surprisingly hard) to be able to link to full traces
* strip random successful test output from the middle
* visually should be easier to parse now