### PR TITLE
fix: cdc recovery

### DIFF
--- a/lib/realtime/postgres_cdc.ex
+++ b/lib/realtime/postgres_cdc.ex
@@ -1,5 +1,11 @@
 defmodule Realtime.PostgresCdc do
-  @moduledoc false
+  @moduledoc """
+  Behaviour and dispatch facade for the Postgres CDC drivers.
+
+  A tenant names its driver through `postgres_cdc_default`, which `driver/1` resolves against the
+  configured `:extensions`. Every function here delegates to that driver's `handle_*` callback, so
+  callers never reach for a driver module directly.
+  """
 
   alias Realtime.Api.Tenant
 
@@ -18,8 +24,16 @@ defmodule Realtime.PostgresCdc do
     apply(module, :handle_after_connect, [connect_response, extension, params, tenant])
   end
 
+  @doc """
+  Subscribes the calling channel to the tenant's Postgres changes.
+
+  It also subscribes to `Realtime.Syn.PostgresCdc.down_topic/1`, where a `postgres_cdc_down` event
+  tells the channel to re-subscribe. That re-subscribe is what starts the CDC tree again, as its
+  supervisor never restarts it.
+  """
+  @spec subscribe(module(), [map()], String.t(), keyword()) :: :ok
   def subscribe(module, pg_change_params, tenant, metadata) do
-    RealtimeWeb.Endpoint.subscribe("postgres_cdc_rls:" <> tenant)
+    RealtimeWeb.Endpoint.subscribe(Realtime.Syn.PostgresCdc.down_topic(tenant))
     apply(module, :handle_subscribe, [pg_change_params, tenant, metadata])
   end
 

--- a/lib/realtime/syn/postgres_cdc.ex
+++ b/lib/realtime/syn/postgres_cdc.ex
@@ -1,10 +1,14 @@
 defmodule Realtime.Syn.PostgresCdc do
   @moduledoc """
-  Scope for the PostgresCdc module.
+  Sharded `:syn` scopes for the Postgres CDC supervision trees.
+
+  Spreading tenants over several scopes keeps a single `:syn` table from holding every
+  registration. The shard comes from the tenant id, so every node resolves the same scope for a
+  given tenant.
   """
 
   @doc """
-  Returns the scope for a given tenant id.
+  Scope holding the CDC tree registration for `tenant_id`.
   """
   @spec scope(String.t()) :: atom()
   def scope(tenant_id) do
@@ -13,11 +17,39 @@ defmodule Realtime.Syn.PostgresCdc do
     :"realtime_postgres_cdc_#{shard}"
   end
 
+  @doc """
+  Every scope, so they can all be started and handed to `:syn` at boot.
+  """
+  @spec scopes() :: [atom()]
   def scopes() do
     shards = Application.fetch_env!(:realtime, :postgres_cdc_scope_shards)
     Enum.map(0..(shards - 1), fn shard -> :"realtime_postgres_cdc_#{shard}" end)
   end
 
+  @doc """
+  Prefix shared by the scope atoms and `syn_topic/1`, which `Realtime.SynHandler` matches on to
+  tell Postgres CDC registry events from the rest.
+  """
+  @spec syn_topic_prefix() :: String.t()
   def syn_topic_prefix(), do: "realtime_postgres_cdc_"
+
+  @doc """
+  PubSub topic carrying the `ready` event, whose payload holds the tree's own pids.
+
+  Broadcast locally on every node, since `:syn` fires its callbacks cluster-wide.
+  """
+  @spec syn_topic(String.t()) :: String.t()
   def syn_topic(tenant_id), do: "#{syn_topic_prefix()}#{tenant_id}"
+
+  @doc """
+  PubSub topic where channels learn the tenant's CDC tree is gone.
+  """
+  @spec down_topic(String.t()) :: String.t()
+  def down_topic(tenant_id), do: "#{syn_topic(tenant_id)}:down"
+
+  @doc """
+  Event saying the tenant's CDC tree is gone, so its subscribers must re-subscribe.
+  """
+  @spec down_event() :: String.t()
+  def down_event(), do: "postgres_cdc_down"
 end

--- a/lib/realtime/syn_handler.ex
+++ b/lib/realtime/syn_handler.ex
@@ -71,8 +71,8 @@ defmodule Realtime.SynHandler do
     :telemetry.execute([:syn, scope, :unregistered], %{}, %{name: name})
 
     case Atom.to_string(scope) do
-      @postgres_cdc_scope_prefix <> _ = scope ->
-        Endpoint.local_broadcast(PostgresCdc.syn_topic(name), scope <> "_down", %{pid: pid, reason: reason})
+      @postgres_cdc_scope_prefix <> _ ->
+        Endpoint.local_broadcast(PostgresCdc.down_topic(name), PostgresCdc.down_event(), %{pid: pid, reason: reason})
 
       _ ->
         topic = topic(scope)

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -39,6 +39,7 @@ defmodule RealtimeWeb.RealtimeChannel do
   @postgres_subscribe_backoff_max 1_000
   @postgres_subscribe_fatal_reasons [:malformed_subscription_params, :subscription_insert_failed]
   @postgres_subscribe_error_code "RealtimeDisabledForConfiguration"
+  @postgres_cdc_down Realtime.Syn.PostgresCdc.down_event()
   @fullsweep_after Application.compile_env!(:realtime, :websocket_fullsweep_after)
 
   @impl true
@@ -306,7 +307,7 @@ defmodule RealtimeWeb.RealtimeChannel do
     end
   end
 
-  def handle_info(%{event: "postgres_cdc_rls_down"}, socket) do
+  def handle_info(%{event: @postgres_cdc_down}, socket) do
     %{assigns: %{pg_sub_ref: pg_sub_ref}} = socket
     Helpers.cancel_timer(pg_sub_ref)
     pg_sub_ref = postgres_subscribe()

--- a/test/integration/rt_channel/postgres_changes_test.exs
+++ b/test/integration/rt_channel/postgres_changes_test.exs
@@ -862,6 +862,49 @@ defmodule Realtime.Integration.RtChannel.PostgresChangesTest do
       assert log =~ "Unable to subscribe to changes with given parameters"
     end
 
+    test "a joined channel re-subscribes after the cdc tree goes down", %{tenant: tenant, serializer: serializer} do
+      {socket, _} = get_connection(tenant, serializer)
+      topic = "realtime:any"
+      config = %{postgres_changes: [%{event: "INSERT", schema: "public"}]}
+      sub_id = :erlang.phash2(%{"event" => "INSERT", "schema" => "public"})
+
+      WebsocketClient.join(socket, topic, %{config: config})
+
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 200
+
+      assert_receive %Message{
+                       event: "system",
+                       payload: %{"extension" => "postgres_changes", "status" => "ok"},
+                       topic: ^topic
+                     },
+                     8000
+
+      assert_cdc_stopped(tenant)
+
+      assert_receive %Message{
+                       event: "system",
+                       payload: %{"extension" => "postgres_changes", "status" => "ok"},
+                       topic: ^topic
+                     },
+                     20_000
+
+      {:ok, _, conn} = PostgresCdcRls.get_manager_conn(tenant.external_id)
+
+      %{rows: [[id]]} =
+        Postgrex.query!(conn, "insert into test (details) values ('after down') returning id", [])
+
+      assert_receive %Message{
+                       event: "postgres_changes",
+                       payload: %{
+                         "data" => %{"record" => %{"details" => "after down", "id" => ^id}, "type" => "INSERT"},
+                         "ids" => [^sub_id]
+                       },
+                       ref: nil,
+                       topic: ^topic
+                     },
+                     2000
+    end
+
     test "handle nil postgres changes params as empty param changes", %{
       tenant: tenant,
       serializer: serializer

--- a/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
+++ b/test/realtime/extensions/cdc_rls/cdc_rls_test.exs
@@ -70,15 +70,16 @@ defmodule Realtime.Extensions.CdcRlsTest do
       Process.monitor(sup)
 
       RealtimeWeb.Endpoint.subscribe(Realtime.Syn.PostgresCdc.syn_topic(tenant.external_id))
+      RealtimeWeb.Endpoint.subscribe(Realtime.Syn.PostgresCdc.down_topic(tenant.external_id))
 
       Process.exit(sup, :kill)
-      scope_down = Atom.to_string(scope) <> "_down"
 
       assert_receive {:DOWN, _, :process, ^sup, _reason}, 5000
-      assert_receive %{event: ^scope_down}
+      down_event = Realtime.Syn.PostgresCdc.down_event()
+      assert_receive %{event: ^down_event}
       refute_receive %{event: "ready"}, 1000
 
-      :undefined = :syn.lookup(Realtime.Syn.PostgresCdc.scope(tenant.external_id), tenant.external_id)
+      assert :undefined == :syn.lookup(scope, tenant.external_id)
     end
 
     test "Subscription manager updates oids", %{tenant: tenant} do
@@ -177,7 +178,7 @@ defmodule Realtime.Extensions.CdcRlsTest do
                Postgrex.query!(conn, "SELECT count(*)::int FROM pg_replication_slots WHERE slot_name = $1", [slot_name])
     end
 
-    test "Stop tenant supervisor", %{tenant: tenant} do
+    test "stop tenant supervisor", %{tenant: tenant} do
       sup =
         Enum.reduce_while(1..10, nil, fn _, acc ->
           tenant.external_id
@@ -249,7 +250,7 @@ defmodule Realtime.Extensions.CdcRlsTest do
     end
   end
 
-  describe "Region rebalancing" do
+  describe "region rebalancing" do
     setup do
       tenant = TestTenantDb.checkout_tenant(run_migrations: true)
       %Tenant{extensions: extensions, external_id: external_id} = tenant
@@ -526,6 +527,21 @@ defmodule Realtime.Extensions.CdcRlsTest do
           target_node: ^node
         }
       }
+    end
+
+    test "cdc going down on another node notifies subscribers here", %{tenant: tenant, node: remote_node} do
+      %Tenant{external_id: external_id} = tenant
+
+      RealtimeWeb.Endpoint.subscribe(Realtime.Syn.PostgresCdc.down_topic(external_id))
+
+      assert eventually(fn -> match?({:ok, _, _}, PostgresCdcRls.get_manager_conn(external_id)) end)
+      assert {:ok, manager_pid, _conn} = PostgresCdcRls.get_manager_conn(external_id)
+      assert node(manager_pid) == remote_node
+
+      :ok = PostgresCdcRls.handle_stop(external_id, 5_000)
+
+      down_event = Realtime.Syn.PostgresCdc.down_event()
+      assert_receive %{event: ^down_event}, 5000
     end
 
     test "subscription error rate limit", %{tenant: tenant, node: node} do


### PR DESCRIPTION
PR #1594 introduced a drift that caused unroutable `down` events:

`SynHandler.on_process_unregistered/5` broadcast `realtime_postgres_cdc_<shard>_down` on `realtime_postgres_cdc_<tenant>` while `PostgresCdc.subscribe/4` subscribed to `postgres_cdc_rls:<tenant>` and `RealtimeChannel` matched `postgres_cdc_rls_down`.

Check the tests, all fails without the fix.

Closes REAL-1035

