### PR TITLE
chore: define `TENANT` to isolate dev and tests

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -70,11 +70,12 @@ TENANT=review mise run db-start  # tenant named review, database on a port docke
 TENANT=review mise run db-rm     # removes its database
 ```
 
-`TENANT` defaults to `realtime-dev`, so those two commands reach the default tenant as well. Re-running `db-start`
-leaves an existing tenant's data and publication alone.
+You don't need to set `TENANT`, but you can. It defaults to the checkout's directory name, so a worktree in
+`realtime.review` is the `realtime-review` tenant already, and a plain `realtime` checkout is `realtime-dev`.
+Re-running `db-start` leaves an existing tenant's data and publication alone.
 
-`TENANT` isolates the test suite too, so `TENANT=review mix test` runs on its own database and tenant containers,
-next to that tenant's dev stack and clear of every other run.
+`TENANT` isolates the test suite too, so `mix test` runs on its own database and tenant containers, next to that
+tenant's dev stack and clear of every other run.
 
 > **Note**
 > Supabase runs Realtime in production with a separate database that keeps track of all tenants. For local development, the compose setup creates the `_realtime` schema for you.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -73,6 +73,9 @@ TENANT=review mise run db-rm     # removes its database
 `TENANT` defaults to `realtime-dev`, so those two commands reach the default tenant as well. Re-running `db-start`
 leaves an existing tenant's data and publication alone.
 
+`TENANT` isolates the test suite too, so `TENANT=review mix test` runs on its own database and tenant containers,
+next to that tenant's dev stack and clear of every other run.
+
 > **Note**
 > Supabase runs Realtime in production with a separate database that keeps track of all tenants. For local development, the compose setup creates the `_realtime` schema for you.
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,14 +33,29 @@ node_suffix =
     _ -> "_#{port}"
   end
 
-# Names this run's database and containers. TEST_RUN labels a run ("pr_1234"), and otherwise the
-# endpoint port does, which also lets a later run tell whether the run that left something
-# behind is gone.
+# Names this run's database and containers. One knob covers a whole environment: TENANT names a
+# test run just as it names the dev stack, so `TENANT=review mise run db-start` and
+# `TENANT=review mix test` are the same review environment. The default tenant is the unmarked
+# run, so a plain `mix test` keeps the names it always had. TEST_RUN overrides TENANT for a run
+# that wants a label without a tenant behind it ("pr_1234").
+default_tenant = "realtime-dev"
+
+run_name =
+  case {System.get_env("TEST_RUN", ""), System.get_env("TENANT", "")} do
+    {"", ^default_tenant} -> ""
+    {"", tenant} -> tenant
+    {run, _} -> run
+  end
+
+# An unnamed run is labelled by its endpoint port instead, which also lets a later run tell
+# whether the run that left something behind is gone. "port" keeps that label out of the
+# namespace of names, so a tenant called "4003" is never read as a run holding port 4003.
 run_tag =
-  case {offset, System.get_env("TEST_RUN", "")} do
+  case {offset, run_name} do
     {0, ""} -> ""
-    {_, ""} -> "_#{port}"
-    {_, run} -> "_#{run}"
+    {_, ""} -> "_port#{port}"
+    # A name reaches a database name and a container name, so keep it to what both take.
+    {_, name} -> "_" <> String.replace(name, ~r/[^A-Za-z0-9_]/, "_")
   end
 
 partition = System.get_env("MIX_TEST_PARTITION")

--- a/mise.toml
+++ b/mise.toml
@@ -31,6 +31,9 @@ description = "Start another dev server in a second region (orange)"
 run = "iex --name ${NODE_NAME}@127.0.0.1 --cookie cookie -S mix phx.server"
 env = { NODE_NAME = "orange", REGION = "eu-west-1" }
 
+# TENANT (default realtime-dev) names a whole environment, not just these tasks: the tenant's
+# database and row here, and the database and containers `mix test` uses (see config/test.exs).
+#
 # Fixed compose projects, so every checkout shares these instead of starting a set per directory.
 # Nothing stops or removes the realtime database: another checkout may be using it.
 [tasks.db-start]

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,12 @@ supabase = "2.105.0"
 "npm:@supabase/pg-delta" = "1.0.0-alpha.48"
 
 [env]
+# TENANT names a whole environment, not just the db tasks below: the tenant's database and row,
+# and the database and containers `mix test` uses (see config/test.exs). Every checkout gets one
+# without being told — its directory name is the tenant, with the plain checkout keeping the
+# default. Setting TENANT yourself wins. A dot becomes a dash: a tenant is a compose project name
+# and a subdomain, and neither takes dots.
+TENANT = "{% if env.TENANT %}{{ env.TENANT }}{% else %}{% set dir = config_root | split(pat='/') | last | replace(from='.', to='-') %}{% if dir == 'realtime' %}realtime-dev{% else %}{{ dir }}{% endif %}{% endif %}"
 REGION = "us-east-1"
 API_JWT_SECRET = "dev"
 DB_ENC_KEY = "1234567890123456"
@@ -31,13 +37,10 @@ description = "Start another dev server in a second region (orange)"
 run = "iex --name ${NODE_NAME}@127.0.0.1 --cookie cookie -S mix phx.server"
 env = { NODE_NAME = "orange", REGION = "eu-west-1" }
 
-# TENANT (default realtime-dev) names a whole environment, not just these tasks: the tenant's
-# database and row here, and the database and containers `mix test` uses (see config/test.exs).
-#
 # Fixed compose projects, so every checkout shares these instead of starting a set per directory.
 # Nothing stops or removes the realtime database: another checkout may be using it.
 [tasks.db-start]
-description = "Make the databases ready: the realtime database, its migrations, and TENANT's database and row (default realtime-dev)"
+description = "Make the databases ready: the realtime database, its migrations, and TENANT's database and row"
 dir = "{{cwd}}"
 run = '''
 set -eu
@@ -60,7 +63,7 @@ TENANT="$tenant" TENANT_DB_PORT="$port" mix seed
 '''
 
 [tasks.db-stop]
-description = "Stop TENANT's database (default realtime-dev)"
+description = "Stop TENANT's database"
 dir = "{{cwd}}"
 run = """
 set -eu
@@ -68,7 +71,7 @@ COMPOSE_PROJECT_NAME="tenant-${TENANT:-realtime-dev}" docker compose -f compose.
 """
 
 [tasks.db-rm]
-description = "Remove TENANT's database (default realtime-dev), discarding its data"
+description = "Remove TENANT's database, discarding its data"
 dir = "{{cwd}}"
 run = """
 set -eu

--- a/test/support/test_env.ex
+++ b/test/support/test_env.ex
@@ -32,8 +32,9 @@ defmodule TestEnv do
     bad_tcp: 11
   }
 
-  # Labels this run's databases and containers. Empty for the first run on a machine, which
-  # therefore looks exactly like it did before any of this.
+  # Labels this run's databases and containers. config/test.exs takes it from TENANT (or
+  # TEST_RUN), and otherwise from the endpoint port. Empty for the first run on a machine on the
+  # default tenant, which therefore looks exactly like it did before any of this.
   @spec run_tag() :: binary()
   def run_tag, do: Application.fetch_env!(:realtime, :test_run_tag)
 

--- a/test/support/test_tenant_db/backend/docker.ex
+++ b/test/support/test_tenant_db/backend/docker.ex
@@ -137,8 +137,8 @@ defmodule TestTenantDb.Backend.Docker do
   def container_name, do: "#{container_prefix()}-#{random_string(@container_suffix_length)}"
 
   # The docker name filter is a substring match: a run listing "realtime-test" also gets another
-  # run's "realtime-test_4003-...". A container is this run's only if its name is exactly this
-  # run's prefix followed by a random suffix.
+  # run's "realtime-test_port4003-...". A container is this run's only if its name is exactly
+  # this run's prefix followed by a random suffix.
   def own_container?(name) do
     prefix = container_prefix() <> "-"
 
@@ -146,9 +146,10 @@ defmodule TestTenantDb.Backend.Docker do
   end
 
   # A run whose tag is its endpoint port is gone once that port is free again. A named run
-  # (TEST_RUN) says nothing about liveness, so its containers are left for its owner.
+  # (TENANT or TEST_RUN) says nothing about liveness, so its containers are left for its owner,
+  # who clears them on its next run.
   def abandoned_container?(name) do
-    case Regex.run(~r/^#{@container_prefix}_(\d+)-(.+)$/, name) do
+    case Regex.run(~r/^#{@container_prefix}_port(\d+)-(.+)$/, name) do
       [_, port, suffix] when byte_size(suffix) == @container_suffix_length ->
         Env.port_available?(String.to_integer(port))
 

--- a/test/support/test_tenant_db/backend/docker_test.exs
+++ b/test/support/test_tenant_db/backend/docker_test.exs
@@ -23,13 +23,13 @@ defmodule TestTenantDb.Backend.DockerTest do
     end
 
     test "a second run puts its endpoint port in the name" do
-      put_run_tag("_4003")
+      put_run_tag("_port4003")
 
-      assert Docker.container_prefix() == "realtime-test_4003"
-      assert Docker.container_name() =~ ~r"^realtime-test_4003-.{12}$"
+      assert Docker.container_prefix() == "realtime-test_port4003"
+      assert Docker.container_name() =~ ~r"^realtime-test_port4003-.{12}$"
     end
 
-    test "a run named with NAME uses that name" do
+    test "a run named by TENANT or TEST_RUN uses that name" do
       put_run_tag("_pr_1234")
 
       assert Docker.container_prefix() == "realtime-test_pr_1234"
@@ -42,18 +42,18 @@ defmodule TestTenantDb.Backend.DockerTest do
       put_run_tag("")
 
       assert Docker.own_container?("realtime-test-" <> @suffix)
-      refute Docker.own_container?("realtime-test_4003-" <> @suffix)
+      refute Docker.own_container?("realtime-test_port4003-" <> @suffix)
       refute Docker.own_container?("some-other-container")
     end
   end
 
   describe "abandoned_container?/1" do
     test "false while the owning run still holds its port" do
-      refute Docker.abandoned_container?("realtime-test_#{TestEnv.http_port()}-#{@suffix}")
+      refute Docker.abandoned_container?("realtime-test_port#{TestEnv.http_port()}-#{@suffix}")
     end
 
     test "true once that port is free" do
-      assert Docker.abandoned_container?("realtime-test_#{Env.unused_port()}-#{@suffix}")
+      assert Docker.abandoned_container?("realtime-test_port#{Env.unused_port()}-#{@suffix}")
     end
 
     test "false for an untagged container, which belongs to whoever holds the default port" do
@@ -64,8 +64,12 @@ defmodule TestTenantDb.Backend.DockerTest do
       refute Docker.abandoned_container?("realtime-test_pr_1234-#{@suffix}")
     end
 
+    test "false for a run named after digits, which is a name and not a port" do
+      refute Docker.abandoned_container?("realtime-test_#{Env.unused_port()}-#{@suffix}")
+    end
+
     test "false for a name that only reads like a tagged one" do
-      refute Docker.abandoned_container?("realtime-test_4003-tooshort")
+      refute Docker.abandoned_container?("realtime-test_port4003-tooshort")
       refute Docker.abandoned_container?("some-other-container")
     end
   end


### PR DESCRIPTION
This is a small improvement to https://github.com/supabase/realtime/pull/2110

- Derive `TEST_RUN` from `TENANT` so that's the only var we need to define to create an isolated dev or test env
- Define `TENANT` from current dir so it "just works" but keep `realtime-dev` on `realtime` dir (default)