### PR TITLE
fix: report zero connections on vacant tenants

### DIFF
--- a/lib/realtime/metrics_cleaner.ex
+++ b/lib/realtime/metrics_cleaner.ex
@@ -26,6 +26,36 @@ defmodule Realtime.MetricsCleaner do
 
   # 10 minutes
   @default_vacant_metric_threshold_in_seconds 600
+  @vacant_websockets_table :vacant_websockets
+
+  # Vacated tenants closer than this to the cleanup threshold are not reported by
+  # `recently_vacated_tenants/2`. It must cover the time between reading the table and emitting the
+  # metrics so a poll can't recreate a tenant tag that the cleaner has just pruned.
+  @recently_vacated_margin_in_seconds 60
+
+  @doc """
+  Tenants that recently lost their last websocket on this node and still have metrics for this node.
+
+  Returns an empty list when the MetricsCleaner is not running.
+  """
+  @spec recently_vacated_tenants(atom(), non_neg_integer()) :: [String.t()]
+  def recently_vacated_tenants(
+        table \\ @vacant_websockets_table,
+        vacant_metric_threshold_in_seconds \\ @default_vacant_metric_threshold_in_seconds
+      ) do
+    case :ets.whereis(table) do
+      :undefined ->
+        []
+
+      _tid ->
+        cutoff =
+          DateTime.utc_now()
+          |> DateTime.add(-(vacant_metric_threshold_in_seconds - @recently_vacated_margin_in_seconds), :second)
+          |> DateTime.to_unix(:second)
+
+        :ets.select(table, [{{:"$1", :"$2"}, [{:>=, :"$2", cutoff}], [:"$1"]}])
+    end
+  end
 
   @impl true
   def init(opts) do
@@ -38,7 +68,14 @@ defmodule Realtime.MetricsCleaner do
 
     Logger.info("Starting MetricsCleaner")
 
-    vacant_websockets = :ets.new(:vacant_websockets, [:set, :public, read_concurrency: false, write_concurrency: :auto])
+    vacant_websockets =
+      :ets.new(opts[:vacant_websockets_table] || @vacant_websockets_table, [
+        :named_table,
+        :set,
+        :public,
+        read_concurrency: false,
+        write_concurrency: :auto
+      ])
 
     disconnected_tenants =
       :ets.new(:disconnected_tenants, [:set, :public, read_concurrency: false, write_concurrency: :auto])

--- a/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
+++ b/lib/realtime/monitoring/prom_ex/plugins/tenant.ex
@@ -3,6 +3,7 @@ defmodule Realtime.PromEx.Plugins.Tenant do
 
   use PromEx.Plugin
   alias Realtime.FeatureFlags
+  alias Realtime.MetricsCleaner
   alias Realtime.Telemetry
   alias Realtime.Tenants
   alias Realtime.UsersCounter
@@ -103,19 +104,30 @@ defmodule Realtime.PromEx.Plugins.Tenant do
     local_tenant_counts = UsersCounter.local_tenant_counts()
 
     for {t, count} <- local_tenant_counts do
-      tenant = Tenants.Cache.get_tenant_by_external_id(t)
+      execute_connections(t, count, cluster_counts)
+    end
 
-      if tenant != nil do
-        Telemetry.execute(
-          [:realtime, :connections],
-          %{
-            connected: count,
-            connected_cluster: Map.get(cluster_counts, t, 0),
-            limit: tenant.max_concurrent_users
-          },
-          %{tenant: t}
-        )
-      end
+    # These are `last_value` metrics, so a tenant that lost its last local websocket would keep
+    # exporting its previous count until MetricsCleaner prunes the tenant tag. Report zero for them in
+    # the meantime. A tenant that got a websocket back was already reported above.
+    for t <- MetricsCleaner.recently_vacated_tenants(), not Map.has_key?(local_tenant_counts, t) do
+      execute_connections(t, 0, cluster_counts)
+    end
+  end
+
+  defp execute_connections(tenant_id, count, cluster_counts) do
+    tenant = Tenants.Cache.get_tenant_by_external_id(tenant_id)
+
+    if tenant != nil do
+      Telemetry.execute(
+        [:realtime, :connections],
+        %{
+          connected: count,
+          connected_cluster: Map.get(cluster_counts, tenant_id, 0),
+          limit: tenant.max_concurrent_users
+        },
+        %{tenant: tenant_id}
+      )
     end
   end
 

--- a/test/realtime/metrics_cleaner_test.exs
+++ b/test/realtime/metrics_cleaner_test.exs
@@ -211,6 +211,48 @@ defmodule Realtime.MetricsCleanerTest do
     end
   end
 
+  describe "recently_vacated_tenants/2" do
+    test "returns tenants that vacated within the threshold minus the margin" do
+      table = :ets.new(:test_recently_vacated, [:set, :public, :named_table])
+      now = DateTime.to_unix(DateTime.utc_now(), :second)
+
+      # threshold 600s, margin 60s: only vacancies younger than 540s are returned
+      :ets.insert(table, {"just-vacated", now})
+      :ets.insert(table, {"vacated-a-while-ago", now - 500})
+      :ets.insert(table, {"about-to-be-pruned", now - 580})
+      :ets.insert(table, {"past-threshold", now - 700})
+
+      assert Enum.sort(MetricsCleaner.recently_vacated_tenants(table, 600)) == ["just-vacated", "vacated-a-while-ago"]
+    end
+
+    test "returns an empty list when the table does not exist" do
+      assert MetricsCleaner.recently_vacated_tenants(:does_not_exist, 600) == []
+    end
+
+    test "tracks vacancies from the running MetricsCleaner" do
+      start_supervised!(
+        {MetricsCleaner,
+         [
+           metrics_cleaner_schedule_timer_in_ms: 60_000,
+           vacant_metric_threshold_in_seconds: 600,
+           vacant_websockets_table: :test_running_vacant
+         ]}
+      )
+
+      pid = spawn_link(fn -> Process.sleep(:infinity) end)
+      Census.join(:users, "running-tenant", pid)
+      Census.leave(:users, "running-tenant", pid)
+
+      assert MetricsCleaner.recently_vacated_tenants(:test_running_vacant, 600) == ["running-tenant"]
+
+      # Getting a websocket back removes the vacancy
+      pid2 = spawn_link(fn -> Process.sleep(:infinity) end)
+      Census.join(:users, "running-tenant", pid2)
+
+      assert MetricsCleaner.recently_vacated_tenants(:test_running_vacant, 600) == []
+    end
+  end
+
   describe "handle_forum_event/4" do
     test "inserts and deletes from ETS table" do
       table = :ets.new(:test_forum, [:set, :public])

--- a/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
+++ b/test/realtime/monitoring/prom_ex/plugins/tenant_test.exs
@@ -121,6 +121,32 @@ defmodule Realtime.PromEx.Plugins.TenantTest do
       refute_receive {[:realtime, :connections], %{connected: 1, limit: 200, connected_cluster: 2},
                       %{tenant: ^bad_tenant_id}}
     end
+
+    test "reports zero for tenants that recently lost their last local websocket", %{
+      tenant: %{external_id: external_id},
+      node: node
+    } do
+      start_supervised!({Realtime.MetricsCleaner, [metrics_cleaner_schedule_timer_in_ms: 60_000]})
+
+      pid = spawn_link(fn -> Process.sleep(:infinity) end)
+      :ok = Census.join(:users, external_id, pid)
+      _ = Rpc.call(node, FakeUserCounter, :fake_add, [external_id])
+
+      Process.sleep(500)
+      Tenant.execute_tenant_metrics()
+
+      assert_receive {[:realtime, :connections], %{connected: 1, limit: 200, connected_cluster: 2},
+                      %{tenant: ^external_id}},
+                     500
+
+      :ok = Census.leave(:users, external_id, pid)
+      Tenant.execute_tenant_metrics()
+
+      # Local count is zero, the other node still holds one connection
+      assert_receive {[:realtime, :connections], %{connected: 0, limit: 200, connected_cluster: 1},
+                      %{tenant: ^external_id}},
+                     500
+    end
   end
 
   describe "event_metrics/0" do


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make sure that we updated the number of connections to 0 when a tenant goes vacant instead of waiting for the metric to be cleaned