### PR TITLE
fix: use runuser to drop privileges to nobody in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -99,7 +99,7 @@ run_as_nobody() {
         if command -v runuser >/dev/null 2>&1; then
             runuser -u nobody -- "$@"
         elif command -v su >/dev/null 2>&1; then
-            su -s /bin/sh nobody -c '"$@"' -- "$@"
+            su -s /bin/sh nobody -c 'exec "$@"' _ "$@"
         else
             sudo -E -u nobody "$@"
         fi

--- a/run.sh
+++ b/run.sh
@@ -94,12 +94,26 @@ if [[ -n "${GENERATE_CLUSTER_CERTS:-}" ]] ; then
     generate_certs
 fi
 
+run_as_nobody() {
+    if [ "$(id -u)" = "0" ]; then
+        if command -v runuser >/dev/null 2>&1; then
+            runuser -u nobody -- "$@"
+        elif command -v su >/dev/null 2>&1; then
+            su -s /bin/sh nobody -c '"$@"' -- "$@"
+        else
+            sudo -E -u nobody "$@"
+        fi
+    else
+        "$@"
+    fi
+}
+
 echo "Running migrations"
-sudo -E -u nobody /app/bin/migrate
+run_as_nobody /app/bin/migrate
 
 if [ "${SEED_SELF_HOST-}" = true ]; then
     echo "Seeding selfhosted Realtime"
-    sudo -E -u nobody /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)'
+    run_as_nobody /app/bin/realtime eval 'Realtime.Release.seeds(Realtime.Repo)'
 fi
 
 echo "Starting Realtime"

--- a/run.sh
+++ b/run.sh
@@ -96,13 +96,7 @@ fi
 
 run_as_nobody() {
     if [ "$(id -u)" = "0" ]; then
-        if command -v runuser >/dev/null 2>&1; then
-            runuser -u nobody -- "$@"
-        elif command -v su >/dev/null 2>&1; then
-            su -s /bin/sh nobody -c 'exec "$@"' _ "$@"
-        else
-            sudo -E -u nobody "$@"
-        fi
+        runuser -u nobody -- "$@"
     else
         "$@"
     fi

--- a/run.sh
+++ b/run.sh
@@ -96,7 +96,7 @@ fi
 
 run_as_nobody() {
     if [ "$(id -u)" = "0" ]; then
-        runuser -u nobody -- "$@"
+        runuser -m -u nobody -- "$@"
     else
         "$@"
     fi


### PR DESCRIPTION
small fix : sudo -u nobody fails when the nobody account is locked (PAM checks it, runuser doesn't). Switched to runuser -m -u nobody — same env passthrough as before, tested on both root and non-root.

closes supabase/cli#6462