### PR TITLE
fix: cast params and respect defaults on join payload

### DIFF
--- a/lib/realtime_web/channels/payloads/broadcast/replay.ex
+++ b/lib/realtime_web/channels/payloads/broadcast/replay.ex
@@ -7,10 +7,17 @@ defmodule RealtimeWeb.Channels.Payloads.Broadcast.Replay do
   alias RealtimeWeb.Channels.Payloads.Join
 
   embedded_schema do
-    field :limit, :integer, default: 10
+    field :limit, :integer, default: 25
     field :since, :integer, default: 0
   end
 
+  @typedoc """
+  * `limit` - How many messages to replay, counting back from the most recent.
+  * `since` - Only replay messages inserted after this Unix timestamp in milliseconds.
+  """
+  @type t :: %__MODULE__{limit: non_neg_integer(), since: non_neg_integer()}
+
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(broadcast, attrs) do
     cast(broadcast, attrs, [:limit, :since], message: &Join.error_message/2)
   end

--- a/lib/realtime_web/channels/payloads/join.ex
+++ b/lib/realtime_web/channels/payloads/join.ex
@@ -15,6 +15,8 @@ defmodule RealtimeWeb.Channels.Payloads.Join do
     field :user_token, :string
   end
 
+  @type t :: %__MODULE__{}
+
   def changeset(join, attrs) do
     join
     |> cast(attrs, [:access_token, :user_token], message: &error_message/2)
@@ -46,6 +48,21 @@ defmodule RealtimeWeb.Channels.Payloads.Join do
   def self_broadcast?(%__MODULE__{config: %Config{broadcast: %Broadcast{self: self}}}), do: self
   def self_broadcast?(_), do: false
 
+  @doc """
+  Whether the client opted in to the replication ready handshake.
+
+  The value is cast by `RealtimeWeb.Channels.Payloads.FlexibleBoolean`.
+  """
+  @spec replication_ready?(t() | any()) :: boolean()
+  def replication_ready?(%__MODULE__{config: %Config{broadcast: %Broadcast{replication_ready: ready}}}), do: ready
+  def replication_ready?(_), do: false
+
+  @doc """
+  Whether the client asked to join a private channel, which is the channel that runs RLS authorization.
+
+  The value is cast by `RealtimeWeb.Channels.Payloads.FlexibleBoolean`.
+  """
+  @spec private?(t() | any()) :: boolean()
   def private?(%__MODULE__{config: %Config{private: private}}), do: private
   def private?(_), do: false
 

--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -26,6 +26,7 @@ defmodule RealtimeWeb.RealtimeChannel do
   alias Realtime.Tenants.Connect
   alias Realtime.UsersCounter
 
+  alias RealtimeWeb.Channels.Payloads.Broadcast.Replay
   alias RealtimeWeb.Channels.Payloads.Join
   alias RealtimeWeb.ChannelsAuthorization
   alias RealtimeWeb.RealtimeChannel.BroadcastHandler
@@ -106,7 +107,7 @@ defmodule RealtimeWeb.RealtimeChannel do
       RealtimeWeb.Endpoint.subscribe(tenant_topic, metadata: metadata)
       RealtimeWeb.Endpoint.subscribe("realtime:operations:" <> tenant_id, metadata: metadata)
 
-      replication_ready_opt_in? = !!get_in(params, ["config", "broadcast", "replication_ready"])
+      replication_ready_opt_in? = Join.replication_ready?(join)
 
       is_new_api = new_api?(params)
       presence_enabled? = socket.assigns.presence_enabled?
@@ -1147,13 +1148,15 @@ defmodule RealtimeWeb.RealtimeChannel do
          true = _private?
        )
        when is_map(replay_params) do
+    replay_defaults = %Replay{}
+
     with {:ok, messages, message_ids} <-
            Realtime.Messages.replay(
              db_conn,
              tenant_id,
              sub_topic,
-             replay_params["since"],
-             replay_params["limit"] || 25
+             replay_params["since"] || replay_defaults.since,
+             replay_params["limit"] || replay_defaults.limit
            ) do
       # Send to self because we can't write to the socket before finishing the join process
       send(self(), {:replay, messages})

--- a/test/realtime_web/channels/realtime_channel_replication_ready_test.exs
+++ b/test/realtime_web/channels/realtime_channel_replication_ready_test.exs
@@ -86,10 +86,42 @@ defmodule RealtimeWeb.RealtimeChannelReplicationReadyTest do
     refute_receive %Socket.Message{event: "system"}, 1000
   end
 
-  defp join(tenant) do
+  test "opts in when replication_ready is the string \"true\"", %{tenant: tenant} do
+    expect(Connect, :lookup_or_start_connection, fn _ -> {:ok, self()} end)
+    expect(Connect, :replication_status, fn _ -> {:ok, self()} end)
+
+    assert {:ok, _, _} = join_with(tenant, "true")
+
+    assert_receive %Socket.Message{event: "system", payload: %{message: "Replication connection established"}}, 500
+  end
+
+  test "does not opt in when replication_ready is the string \"false\"", %{tenant: tenant} do
+    expect(Connect, :lookup_or_start_connection, fn _ -> {:ok, self()} end)
+    reject(&Connect.replication_status/1)
+
+    assert {:ok, _, _} = join_with(tenant, "false")
+
+    refute_receive %Socket.Message{event: "system"}, 1000
+  end
+
+  test "does not opt in when replication_ready is not a boolean", %{tenant: tenant} do
+    expect(Connect, :lookup_or_start_connection, fn _ -> {:ok, self()} end)
+    reject(&Connect.replication_status/1)
+
+    assert {:ok, _, _} = join_with(tenant, "maybe")
+
+    refute_receive %Socket.Message{event: "system"}, 1000
+  end
+
+  defp join(tenant), do: join_with(tenant, true)
+
+  defp join_with(tenant, replication_ready) do
     jwt = generate_jwt_token(tenant)
     {:ok, socket} = connect(UserSocket, %{}, conn_opts(tenant, jwt))
-    subscribe_and_join(socket, "realtime:test", %{"config" => %{"broadcast" => %{"replication_ready" => true}}})
+
+    subscribe_and_join(socket, "realtime:test", %{
+      "config" => %{"broadcast" => %{"replication_ready" => replication_ready}}
+    })
   end
 
   defp conn_opts(tenant, token) do

--- a/test/realtime_web/channels/realtime_channel_test.exs
+++ b/test/realtime_web/channels/realtime_channel_test.exs
@@ -437,16 +437,62 @@ defmodule RealtimeWeb.RealtimeChannelTest do
 
       assert {:error, %{reason: "UnableToReplayMessages: Replay params are not valid"}} =
                subscribe_and_join(socket, "realtime:test", %{"config" => config})
+    end
 
-      config = %{
-        "private" => true,
-        "broadcast" => %{
-          "replay" => %{}
-        }
+    test "replay params fall back to the schema defaults when omitted", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{"log_level" => "warning"}, conn_opts(tenant, jwt))
+
+      %{id: message_id} =
+        message_fixture(tenant, %{
+          "private" => true,
+          "inserted_at" => NaiveDateTime.utc_now() |> NaiveDateTime.shift(minute: -1),
+          "event" => "only",
+          "extension" => "broadcast",
+          "topic" => "test",
+          "payload" => %{"value" => "only"}
+        })
+
+      # An empty replay map is valid and defaults to schema
+      config = %{"private" => true, "broadcast" => %{"replay" => %{}}}
+
+      assert {:ok, _, %Socket{}} = subscribe_and_join(socket, "realtime:test", %{"config" => config})
+
+      assert_receive %Phoenix.Socket.Message{
+        event: "broadcast",
+        payload: %{"event" => "only", "meta" => %{"id" => ^message_id, "replayed" => true}}
       }
+    end
 
-      assert {:error, %{reason: "UnableToReplayMessages: Replay params are not valid"}} =
-               subscribe_and_join(socket, "realtime:test", %{"config" => config})
+    test "replay limit defaults to the schema default when only since is given", %{tenant: tenant} do
+      jwt = Generators.generate_jwt_token(tenant)
+      {:ok, %Socket{} = socket} = connect(UserSocket, %{"log_level" => "warning"}, conn_opts(tenant, jwt))
+
+      for i <- 1..3 do
+        message_fixture(tenant, %{
+          "private" => true,
+          "inserted_at" => NaiveDateTime.utc_now() |> NaiveDateTime.shift(minute: -i),
+          "event" => "event_#{i}",
+          "extension" => "broadcast",
+          "topic" => "test",
+          "payload" => %{"value" => i}
+        })
+      end
+
+      # `since` is an epoch timestamp in milliseconds, so all three messages are within the window.
+      five_minutes_ago = DateTime.utc_now() |> DateTime.shift(minute: -5) |> DateTime.to_unix(:millisecond)
+
+      config = %{"private" => true, "broadcast" => %{"replay" => %{"since" => five_minutes_ago}}}
+
+      assert {:ok, _, %Socket{}} = subscribe_and_join(socket, "realtime:test", %{"config" => config})
+
+      # All three are under the default limit, so all three replay.
+      for event <- ["event_3", "event_2", "event_1"] do
+        assert_receive %Phoenix.Socket.Message{
+          event: "broadcast",
+          payload: %{"event" => ^event, "meta" => %{"replayed" => true}}
+        }
+      end
     end
 
     test "failure to replay", %{tenant: tenant} do


### PR DESCRIPTION
- Respect `Payloads.Broadcast.Replay` default values
- Correctly cast params so `"false"` is not interpreted as a truth value
- Add tests, spec, and docs