### PR TITLE
fix: contain a raising RLS policy to the subscription it came from

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -99,7 +99,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_260_706_120_000, Migrations.GrantCheckEqualityOp5Arg},
     {20_260_707_120_000, Migrations.RestrictRealtimeSchema},
     {20_260_709_120_000, Migrations.FixApplyRlsFilterRoleLeak},
-    {20_260_714_120_000, Migrations.AddBroadcastPersistence}
+    {20_260_714_120_000, Migrations.AddBroadcastPersistence},
+    {20_260_815_120_000, Migrations.IsolateSubscriptionRlsErrors}
   ]
 
   defstruct [:tenant_external_id, :settings, migrations_ran: 0]

--- a/lib/realtime/tenants/repo/migrations/20260815120000_isolate_subscription_rls_errors.ex
+++ b/lib/realtime/tenants/repo/migrations/20260815120000_isolate_subscription_rls_errors.ex
@@ -1,0 +1,433 @@
+defmodule Realtime.Tenants.Migrations.IsolateSubscriptionRlsErrors do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+        returns setof realtime.wal_rls
+        language plpgsql
+        volatile
+    as $$
+    declare
+        -- Regclass of the table e.g. public.notes
+        entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
+
+        -- I, U, D, T: insert, update ...
+        action realtime.action = (
+            case wal ->> 'action'
+                when 'I' then 'INSERT'
+                when 'U' then 'UPDATE'
+                when 'D' then 'DELETE'
+                else 'ERROR'
+            end
+        );
+
+        -- Is row level security enabled for the table
+        is_rls_enabled bool = relrowsecurity from pg_class where oid = entity_;
+
+        subscriptions realtime.subscription[] = array_agg(subs)
+            from
+                realtime.subscription subs
+            where
+                subs.entity = entity_
+                -- Filter by action early - only get subscriptions interested in this action
+                -- action_filter column can be: '*' (all), 'INSERT', 'UPDATE', or 'DELETE'
+                and (subs.action_filter = '*' or subs.action_filter = action::text);
+
+        -- Subscription vars
+        working_role regrole;
+        working_selected_columns text[];
+        claimed_role regrole;
+        claims jsonb;
+
+        subscription_id uuid;
+        subscription_has_access bool;
+        visible_to_subscription_ids uuid[] = '{}';
+
+        -- structured info for wal's columns
+        columns realtime.wal_column[];
+        -- previous identity values for update/delete
+        old_columns realtime.wal_column[];
+
+        error_record_exceeds_max_size boolean = octet_length(wal::text) > max_record_bytes;
+
+        -- Primary jsonb output for record
+        output jsonb;
+
+        -- Loop record for iterating unique roles (outer loop)
+        role_record record;
+        -- Loop record for iterating unique selected_columns within a role (inner loop)
+        cols_record record;
+        -- Subscription ids visible at the role level (before fanning out by selected_columns)
+        visible_role_sub_ids uuid[] = '{}';
+        -- Subscription ids whose RLS evaluation raised at the role level
+        errored_role_sub_ids uuid[] = '{}';
+
+    begin
+        perform set_config('role', null, true);
+
+        columns =
+            array_agg(
+                (
+                    x->>'name',
+                    x->>'type',
+                    x->>'typeoid',
+                    realtime.cast(
+                        (x->'value') #>> '{}',
+                        coalesce(
+                            (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                            (x->>'type')::regtype
+                        )
+                    ),
+                    (pks ->> 'name') is not null,
+                    true
+                )::realtime.wal_column
+            )
+            from
+                jsonb_array_elements(wal -> 'columns') x
+                left join jsonb_array_elements(wal -> 'pk') pks
+                    on (x ->> 'name') = (pks ->> 'name');
+
+        old_columns =
+            array_agg(
+                (
+                    x->>'name',
+                    x->>'type',
+                    x->>'typeoid',
+                    realtime.cast(
+                        (x->'value') #>> '{}',
+                        coalesce(
+                            (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                            (x->>'type')::regtype
+                        )
+                    ),
+                    (pks ->> 'name') is not null,
+                    true
+                )::realtime.wal_column
+            )
+            from
+                jsonb_array_elements(wal -> 'identity') x
+                left join jsonb_array_elements(wal -> 'pk') pks
+                    on (x ->> 'name') = (pks ->> 'name');
+
+        for role_record in
+            select claims_role
+            from (select distinct claims_role from unnest(subscriptions)) t
+            order by claims_role::text
+        loop
+            working_role := role_record.claims_role;
+
+            -- Update `is_selectable` for columns and old_columns (once per role)
+            columns =
+                array_agg(
+                    (
+                        c.name,
+                        c.type_name,
+                        c.type_oid,
+                        c.value,
+                        c.is_pkey,
+                        pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                    )::realtime.wal_column
+                )
+                from
+                    unnest(columns) c;
+
+            old_columns =
+                    array_agg(
+                        (
+                            c.name,
+                            c.type_name,
+                            c.type_oid,
+                            c.value,
+                            c.is_pkey,
+                            pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                        )::realtime.wal_column
+                    )
+                    from
+                        unnest(old_columns) c;
+
+            if action <> 'DELETE' and count(1) = 0 from unnest(columns) c where c.is_pkey then
+                -- Fan out 400 error per distinct selected_columns for this role
+                for cols_record in
+                    select selected_columns
+                    from (select distinct selected_columns from unnest(subscriptions) s where s.claims_role = working_role) t
+                    order by coalesce(array_to_string(selected_columns, ','), '')
+                loop
+                    working_selected_columns := cols_record.selected_columns;
+                    return next (
+                        jsonb_build_object(
+                            'schema', wal ->> 'schema',
+                            'table', wal ->> 'table',
+                            'type', action
+                        ),
+                        is_rls_enabled,
+                        (select array_agg(s.subscription_id) from unnest(subscriptions) as s where s.claims_role = working_role and (s.selected_columns is not distinct from working_selected_columns)),
+                        array['Error 400: Bad Request, no primary key']
+                    )::realtime.wal_rls;
+                end loop;
+
+            -- The claims role does not have SELECT permission to the primary key of entity
+            elsif action <> 'DELETE' and sum(c.is_selectable::int) <> count(1) from unnest(columns) c where c.is_pkey then
+                -- Fan out 401 error per distinct selected_columns for this role
+                for cols_record in
+                    select selected_columns
+                    from (select distinct selected_columns from unnest(subscriptions) s where s.claims_role = working_role) t
+                    order by coalesce(array_to_string(selected_columns, ','), '')
+                loop
+                    working_selected_columns := cols_record.selected_columns;
+                    return next (
+                        jsonb_build_object(
+                            'schema', wal ->> 'schema',
+                            'table', wal ->> 'table',
+                            'type', action
+                        ),
+                        is_rls_enabled,
+                        (select array_agg(s.subscription_id) from unnest(subscriptions) as s where s.claims_role = working_role and (s.selected_columns is not distinct from working_selected_columns)),
+                        array['Error 401: Unauthorized']
+                    )::realtime.wal_rls;
+                end loop;
+
+            else
+                -- Create the prepared statement (once per role)
+                if is_rls_enabled and action <> 'DELETE' then
+                    if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
+                        deallocate walrus_rls_stmt;
+                    end if;
+                    execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+                end if;
+
+                -- Collect all visible subscription IDs for this role (filter check + RLS check)
+                visible_role_sub_ids = '{}';
+                errored_role_sub_ids = '{}';
+
+                for subscription_id, claims in (
+                        select
+                            subs.subscription_id,
+                            subs.claims
+                        from
+                            unnest(subscriptions) subs
+                        where
+                            subs.entity = entity_
+                            and subs.claims_role = working_role
+                            and (
+                                realtime.is_visible_through_filters(columns, subs.filters)
+                                or (
+                                  action = 'DELETE'
+                                  and realtime.is_visible_through_filters(old_columns, subs.filters)
+                                )
+                            )
+                ) loop
+
+                    if not is_rls_enabled or action = 'DELETE' then
+                        visible_role_sub_ids = visible_role_sub_ids || subscription_id;
+                    else
+                        -- Check if RLS allows the role to see the record.
+                        --
+                        -- A policy (or any function it calls) can raise on this subscription's
+                        -- stored claims - a cast of a malformed claim is enough. Contain that to
+                        -- the subscription it came from: uncaught, the exception propagates out
+                        -- of apply_rls and takes down the whole list_changes call, so every
+                        -- subscriber on the tenant loses the batch - and because the slot's
+                        -- confirmed_flush advances during decoding, those changes are gone
+                        -- rather than replayed on the next poll.
+                        begin
+                            perform
+                                -- Trim leading and trailing quotes from working_role because set_config
+                                -- doesn't recognize the role as valid if they are included
+                                set_config('role', trim(both '"' from working_role::text), true),
+                                set_config('request.jwt.claims', claims::text, true);
+
+                            execute 'execute walrus_rls_stmt' into subscription_has_access;
+                        exception
+                            when others then
+                                subscription_has_access = false;
+                                errored_role_sub_ids = errored_role_sub_ids || subscription_id;
+                                raise warning 'WarnApplyingRlsToSubscription %: %', subscription_id, sqlerrm;
+                        end;
+
+                        -- Reset the role on every FOR..LOOP batch execution.
+                        -- The first batch of 10 rows is pre-fetched using the current connection role (PG internal behaviour)
+                        -- then we have to reset it again otherwise it would use the role defined in the `set_config` above
+                        -- to fetch the remaining rows when rows>10, which could be a user-defined role that lacks execution grants.
+                        -- The flow is:
+                        --   1. run batch with conn role
+                        --   2. set_config working_role
+                        --   3. execute walrus
+                        --   4. reset role (revert)
+                        --   5. repeat
+                        perform set_config('role', null, true);
+
+                        if subscription_has_access then
+                            visible_role_sub_ids = visible_role_sub_ids || subscription_id;
+                        end if;
+                    end if;
+                end loop;
+
+                perform set_config('role', null, true);
+
+                -- Inner loop: per distinct selected_columns for this role
+                for cols_record in
+                    select selected_columns
+                    from (select distinct selected_columns from unnest(subscriptions) s where s.claims_role = working_role) t
+                    order by coalesce(array_to_string(selected_columns, ','), '')
+                loop
+                    working_selected_columns := cols_record.selected_columns;
+
+                    output = jsonb_build_object(
+                        'schema', wal ->> 'schema',
+                        'table', wal ->> 'table',
+                        'type', action,
+                        'commit_timestamp', to_char(
+                            ((wal ->> 'timestamp')::timestamptz at time zone 'utc'),
+                            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+                        ),
+                        'columns', (
+                            select
+                                jsonb_agg(
+                                    jsonb_build_object(
+                                        'name', pa.attname,
+                                        'type', pt.typname
+                                    )
+                                    order by pa.attnum asc
+                                )
+                            from
+                                pg_attribute pa
+                                join pg_type pt
+                                    on pa.atttypid = pt.oid
+                                left join (
+                                    select unnest(conkey) as pkey_attnum
+                                    from pg_constraint
+                                    where conrelid = entity_ and contype = 'p'
+                                ) pk on pk.pkey_attnum = pa.attnum
+                            where
+                                attrelid = entity_
+                                and attnum > 0
+                                and pg_catalog.has_column_privilege(working_role, entity_, pa.attname, 'SELECT')
+                                and (working_selected_columns is null or pa.attname = any(working_selected_columns) or pk.pkey_attnum is not null)
+                        )
+                    )
+                    -- Add "record" key for insert and update
+                    || case
+                        when action in ('INSERT', 'UPDATE') then
+                            jsonb_build_object(
+                                'record',
+                                (
+                                    select
+                                        jsonb_object_agg(
+                                            -- if unchanged toast, get column name and value from old record
+                                            coalesce((c).name, (oc).name),
+                                            case
+                                                when (c).name is null then (oc).value
+                                                else (c).value
+                                            end
+                                        )
+                                    from
+                                        unnest(columns) c
+                                        full outer join unnest(old_columns) oc
+                                            on (c).name = (oc).name
+                                    where
+                                        coalesce((c).is_selectable, (oc).is_selectable)
+                                        and (working_selected_columns is null or coalesce((c).name, (oc).name) = any(working_selected_columns) or coalesce((c).is_pkey, (oc).is_pkey))
+                                        and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                                )
+                            )
+                        else '{}'::jsonb
+                    end
+                    -- Add "old_record" key for update and delete
+                    || case
+                        when action = 'UPDATE' then
+                            jsonb_build_object(
+                                    'old_record',
+                                    (
+                                        select jsonb_object_agg((c).name, (c).value)
+                                        from unnest(old_columns) c
+                                        where
+                                            (c).is_selectable
+                                            and (working_selected_columns is null or (c).name = any(working_selected_columns) or (c).is_pkey)
+                                            and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                                    )
+                                )
+                        when action = 'DELETE' then
+                            jsonb_build_object(
+                                'old_record',
+                                (
+                                    select jsonb_object_agg((c).name, (c).value)
+                                    from unnest(old_columns) c
+                                    where
+                                        (c).is_selectable
+                                        and (working_selected_columns is null or (c).name = any(working_selected_columns) or (c).is_pkey)
+                                        and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                                        and ( not is_rls_enabled or (c).is_pkey ) -- if RLS enabled, we can't secure deletes so filter to pkey
+                                )
+                            )
+                        else '{}'::jsonb
+                    end;
+
+                    -- Filter visible_role_sub_ids to those matching the current selected_columns group
+                    visible_to_subscription_ids = coalesce(
+                        (
+                            select array_agg(s.subscription_id)
+                            from unnest(subscriptions) s
+                            where s.claims_role = working_role
+                              and (s.selected_columns is not distinct from working_selected_columns)
+                              and s.subscription_id = any(visible_role_sub_ids)
+                        ),
+                        '{}'::uuid[]
+                    );
+
+                    return next (
+                        output,
+                        is_rls_enabled,
+                        visible_to_subscription_ids,
+                        case
+                            when error_record_exceeds_max_size then array['Error 413: Payload Too Large']
+                            else '{}'
+                        end
+                    )::realtime.wal_rls;
+                end loop;
+
+                -- Fan out 500 error per distinct selected_columns for the subscriptions whose
+                -- RLS evaluation raised. The record itself is withheld - only schema, table and
+                -- action are sent, same shape as the 400/401 rows above - so a policy that fails
+                -- to evaluate never discloses the row it was meant to gate.
+                if array_length(errored_role_sub_ids, 1) > 0 then
+                    for cols_record in
+                        select selected_columns
+                        from (
+                            select distinct selected_columns
+                            from unnest(subscriptions) s
+                            where s.claims_role = working_role and s.subscription_id = any(errored_role_sub_ids)
+                        ) t
+                        order by coalesce(array_to_string(selected_columns, ','), '')
+                    loop
+                        working_selected_columns := cols_record.selected_columns;
+                        return next (
+                            jsonb_build_object(
+                                'schema', wal ->> 'schema',
+                                'table', wal ->> 'table',
+                                'type', action
+                            ),
+                            is_rls_enabled,
+                            (
+                                select array_agg(s.subscription_id)
+                                from unnest(subscriptions) s
+                                where s.claims_role = working_role
+                                  and (s.selected_columns is not distinct from working_selected_columns)
+                                  and s.subscription_id = any(errored_role_sub_ids)
+                            ),
+                            array['Error 500: Internal Server Error, RLS policy evaluation failed']
+                        )::realtime.wal_rls;
+                    end loop;
+                end if;
+
+            end if;
+        end loop;
+
+        perform set_config('role', null, true);
+    end;
+    $$;
+    """)
+  end
+end

--- a/priv/repo/tenant_schema/realtime/functions/apply_rls.sql
+++ b/priv/repo/tenant_schema/realtime/functions/apply_rls.sql
@@ -57,6 +57,8 @@ declare
     cols_record record;
     -- Subscription ids visible at the role level (before fanning out by selected_columns)
     visible_role_sub_ids uuid[] = '{}';
+    -- Subscription ids whose RLS evaluation raised at the role level
+    errored_role_sub_ids uuid[] = '{}';
 
 begin
     perform set_config('role', null, true);
@@ -193,6 +195,7 @@ begin
 
             -- Collect all visible subscription IDs for this role (filter check + RLS check)
             visible_role_sub_ids = '{}';
+            errored_role_sub_ids = '{}';
 
             for subscription_id, claims in (
                     select
@@ -215,14 +218,29 @@ begin
                 if not is_rls_enabled or action = 'DELETE' then
                     visible_role_sub_ids = visible_role_sub_ids || subscription_id;
                 else
-                    -- Check if RLS allows the role to see the record
-                    perform
-                        -- Trim leading and trailing quotes from working_role because set_config
-                        -- doesn't recognize the role as valid if they are included
-                        set_config('role', trim(both '"' from working_role::text), true),
-                        set_config('request.jwt.claims', claims::text, true);
+                    -- Check if RLS allows the role to see the record.
+                    --
+                    -- A policy (or any function it calls) can raise on this subscription's
+                    -- stored claims - a cast of a malformed claim is enough. Contain that to
+                    -- the subscription it came from: uncaught, the exception propagates out
+                    -- of apply_rls and takes down the whole list_changes call, so every
+                    -- subscriber on the tenant loses the batch - and because the slot's
+                    -- confirmed_flush advances during decoding, those changes are gone
+                    -- rather than replayed on the next poll.
+                    begin
+                        perform
+                            -- Trim leading and trailing quotes from working_role because set_config
+                            -- doesn't recognize the role as valid if they are included
+                            set_config('role', trim(both '"' from working_role::text), true),
+                            set_config('request.jwt.claims', claims::text, true);
 
-                    execute 'execute walrus_rls_stmt' into subscription_has_access;
+                        execute 'execute walrus_rls_stmt' into subscription_has_access;
+                    exception
+                        when others then
+                            subscription_has_access = false;
+                            errored_role_sub_ids = errored_role_sub_ids || subscription_id;
+                            raise warning 'WarnApplyingRlsToSubscription %: %', subscription_id, sqlerrm;
+                    end;
 
                     -- Reset the role on every FOR..LOOP batch execution.
                     -- The first batch of 10 rows is pre-fetched using the current connection role (PG internal behaviour)
@@ -364,6 +382,40 @@ begin
                     end
                 )::realtime.wal_rls;
             end loop;
+
+            -- Fan out 500 error per distinct selected_columns for the subscriptions whose
+            -- RLS evaluation raised. The record itself is withheld - only schema, table and
+            -- action are sent, same shape as the 400/401 rows above - so a policy that fails
+            -- to evaluate never discloses the row it was meant to gate.
+            if array_length(errored_role_sub_ids, 1) > 0 then
+                for cols_record in
+                    select selected_columns
+                    from (
+                        select distinct selected_columns
+                        from unnest(subscriptions) s
+                        where s.claims_role = working_role and s.subscription_id = any(errored_role_sub_ids)
+                    ) t
+                    order by coalesce(array_to_string(selected_columns, ','), '')
+                loop
+                    working_selected_columns := cols_record.selected_columns;
+                    return next (
+                        jsonb_build_object(
+                            'schema', wal ->> 'schema',
+                            'table', wal ->> 'table',
+                            'type', action
+                        ),
+                        is_rls_enabled,
+                        (
+                            select array_agg(s.subscription_id)
+                            from unnest(subscriptions) s
+                            where s.claims_role = working_role
+                              and (s.selected_columns is not distinct from working_selected_columns)
+                              and s.subscription_id = any(errored_role_sub_ids)
+                        ),
+                        array['Error 500: Internal Server Error, RLS policy evaluation failed']
+                    )::realtime.wal_rls;
+                end loop;
+            end if;
 
         end if;
     end loop;

--- a/test/realtime/extensions/cdc_rls/subscriptions_test.exs
+++ b/test/realtime/extensions/cdc_rls/subscriptions_test.exs
@@ -1178,6 +1178,104 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
     end
   end
 
+  describe "rls policies that raise (apply_rls)" do
+    setup :setup_tenant
+
+    setup %{conn: conn} do
+      Postgrex.query!(conn, "alter table public.test enable row level security", [])
+
+      # Casting a claim is enough to make a policy raise: a claim carrying the
+      # string "null" instead of a JSON null fails `::uuid` with 22P02.
+      Postgrex.query!(
+        conn,
+        """
+        create policy test_app_id on public.test as permissive for select to anon
+        using (
+          coalesce(
+            ((current_setting('request.jwt.claims', true)::jsonb -> 'app_metadata' ->> 'app_id')::uuid)::text,
+            'no-app-id'
+          ) is not null
+        )
+        """,
+        []
+      )
+
+      :ok
+    end
+
+    test "one subscription raising does not stop delivery for the others", %{conn: conn} do
+      healthy_id = UUID.uuid1()
+      poisoned_id = UUID.uuid1()
+      slot_name = "test_apply_rls_policy_raise_#{:rand.uniform(999_999)}"
+
+      insert_subscription(conn, healthy_id, %{"role" => "anon"})
+      insert_subscription(conn, poisoned_id, %{"role" => "anon", "app_metadata" => %{"app_id" => "null"}})
+
+      Postgrex.query!(conn, "SELECT pg_create_logical_replication_slot($1, 'wal2json')", [slot_name])
+
+      try do
+        Postgrex.query!(conn, "insert into test (details) values ('hello')", [])
+
+        %{rows: rows} = list_changes(conn, slot_name)
+
+        healthy_bin = UUID.string_to_binary!(healthy_id)
+        poisoned_bin = UUID.string_to_binary!(poisoned_id)
+
+        delivered = Enum.find(rows, fn [_wal, sub_ids, _errors] -> healthy_bin in (sub_ids || []) end)
+        assert delivered != nil, "healthy subscription lost the record. rows=#{inspect(rows)}"
+        [healthy_wal, _, healthy_errors] = delivered
+        assert healthy_wal["record"]["details"] == "hello"
+        assert healthy_errors in [nil, []]
+
+        errored = Enum.find(rows, fn [_wal, sub_ids, _errors] -> poisoned_bin in (sub_ids || []) end)
+        assert errored != nil, "poisoned subscription got no error row. rows=#{inspect(rows)}"
+        [poisoned_wal, _, poisoned_errors] = errored
+        assert poisoned_errors == ["Error 500: Internal Server Error, RLS policy evaluation failed"]
+
+        # The policy could not be evaluated, so the row it was meant to gate is withheld
+        refute Map.has_key?(poisoned_wal, "record")
+
+        # The batch was consumed rather than left behind for the next poll to fail on again
+        assert %{rows: [[nil, nil, nil]]} = list_changes(conn, slot_name)
+      after
+        Postgrex.query(conn, "SELECT pg_drop_replication_slot($1)", [slot_name])
+      end
+    end
+
+    test "a role whose every subscription raises does not affect another role", %{conn: conn} do
+      Postgrex.query!(
+        conn,
+        "create policy test_authenticated on public.test as permissive for select to authenticated using (true)",
+        []
+      )
+
+      authenticated_id = UUID.uuid1()
+      poisoned_id = UUID.uuid1()
+      slot_name = "test_apply_rls_policy_raise_roles_#{:rand.uniform(999_999)}"
+
+      insert_subscription(conn, authenticated_id, %{"role" => "authenticated"})
+      insert_subscription(conn, poisoned_id, %{"role" => "anon", "app_metadata" => %{"app_id" => "null"}})
+
+      Postgrex.query!(conn, "SELECT pg_create_logical_replication_slot($1, 'wal2json')", [slot_name])
+
+      try do
+        Postgrex.query!(conn, "insert into test (details) values ('hello')", [])
+
+        %{rows: rows} = list_changes(conn, slot_name)
+
+        authenticated_bin = UUID.string_to_binary!(authenticated_id)
+        delivered = Enum.find(rows, fn [_wal, sub_ids, _errors] -> authenticated_bin in (sub_ids || []) end)
+
+        assert delivered != nil, "unrelated role lost the record. rows=#{inspect(rows)}"
+        [wal, _, errors] = delivered
+        assert wal["record"]["details"] == "hello"
+        assert errors in [nil, []]
+      after
+        Postgrex.query(conn, "SELECT pg_drop_replication_slot($1)", [slot_name])
+      end
+    end
+  end
+
   describe "subscribing with column selection (select param) - parse" do
     @describetag without_db: true
 
@@ -1410,6 +1508,22 @@ defmodule Realtime.Extensions.PostgresCdcRls.SubscriptionsTest do
 
       Postgrex.query(conn, "SELECT pg_drop_replication_slot($1)", [slot_name])
     end
+  end
+
+  defp insert_subscription(conn, subscription_id, claims) do
+    Postgrex.query!(
+      conn,
+      "insert into realtime.subscription (subscription_id, entity, claims) values ($1::text::uuid, 'public.test'::regclass, $2)",
+      [subscription_id, claims]
+    )
+  end
+
+  defp list_changes(conn, slot_name) do
+    Postgrex.query!(
+      conn,
+      "select wal, subscription_ids, errors from realtime.list_changes($1, $2, 100, 1048576)",
+      ["supabase_realtime_test", slot_name]
+    )
   end
 
   defp create_subscriptions(conn, num, opts \\ []) do


### PR DESCRIPTION
## Summary

Fixes #2093.

`realtime.apply_rls` evaluates each subscription against table RLS with a bare

```sql
execute 'execute walrus_rls_stmt' into subscription_has_access;
```

When a policy (or helper it calls) raises on one subscription's stored claims — e.g. casting the string `"null"` to `uuid` — that exception leaves `apply_rls` and aborts the whole `list_changes` call. **Every** subscriber on the tenant loses the batch, including healthy roles and unrelated tables. The slot's `confirmed_flush_lsn` still advances during decoding, so the batch is not replayed. That is what turned a single malformed claim into a silent, project-wide `postgres_changes` outage in #2093 (sockets up, subscriptions present, slot active, nothing delivered).

This wraps the per-subscription check in its own `begin … exception` block. A raising subscription is disqualified on its own, collected into `errored_role_sub_ids`, and gets a 500 error row (`Error 500: Internal Server Error, RLS policy evaluation failed`) with only `schema` / `table` / `type` — same shape as the existing 400/401 rows — so a policy that could not be evaluated never discloses the row it was meant to gate. Healthy subscriptions continue to receive the change.

Also updates the checked-in `priv/repo/tenant_schema/realtime/functions/apply_rls.sql` to match the migration (same function body as `20260709120000_fix_apply_rls_filter_role_leak`, plus this isolation).

## Credit / supersedes

This rebases and supersedes #2096 by @hamodywe, which has been `CONFLICTING`/`DIRTY` against `main` since 2026-08-17. Approach and regression tests are theirs; this PR re-applies them cleanly on current `main` (post–broadcast persistence and later releases) and keeps `apply_rls.sql` in sync.

## Test plan

- [x] Added regression tests in `test/realtime/extensions/cdc_rls/subscriptions_test.exs`:
  - poisoned + healthy subscription on the same role → healthy still gets the row; poisoned gets the 500 error row without `record`
  - poisoned on `anon` + healthy on `authenticated` → other role still delivered
- [ ] `mix test test/realtime/extensions/cdc_rls/subscriptions_test.exs` (Elixir/mix not available in the environment that opened this PR — please run in CI / locally)
- [ ] Confirm tenant migration `20260815120000` / `IsolateSubscriptionRlsErrors` is registered and runs on an existing tenant
- [ ] Manual: subscribe two clients, make one subscription's claims cause a policy raise, insert a row — only the poisoned channel should see the error; the healthy one should get the change