### PR TITLE
chore: fix flaky user counter tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -102,6 +102,10 @@ config :realtime,
 # stops flooding almost immediately instead of after the 30s default.
 config :realtime, muster_singleton_promotion_timeout_ms: 100
 
+config :realtime,
+  users_scope_broadcast_interval_in_ms: 100,
+  users_scope_discover_interval_in_ms: 100
+
 config :realtime, RealtimeWeb.Endpoint,
   http: [port: port],
   server: true

--- a/lib/realtime/application.ex
+++ b/lib/realtime/application.ex
@@ -86,6 +86,8 @@ defmodule Realtime.Application do
     master_region = Application.get_env(:realtime, :master_region) || region
     user_scope_shards = Application.fetch_env!(:realtime, :users_scope_shards)
     user_scope_broadast_interval_in_ms = Application.get_env(:realtime, :users_scope_broadcast_interval_in_ms, 10_000)
+    user_scope_discover_interval_in_ms = Application.get_env(:realtime, :users_scope_discover_interval_in_ms, 60_000)
+
     muster_scope_shards = Application.fetch_env!(:realtime, :muster_scope_shards)
 
     # Only set in :test, where the single-node scope must reach :ready quickly
@@ -127,6 +129,7 @@ defmodule Realtime.Application do
            [
              partitions: user_scope_shards,
              broadcast_interval_in_ms: user_scope_broadast_interval_in_ms,
+             discover_interval_in_ms: user_scope_discover_interval_in_ms,
              message_module: Realtime.ForumPubSubAdapter
            ]
          ]},

--- a/test/realtime/users_counter_test.exs
+++ b/test/realtime/users_counter_test.exs
@@ -56,7 +56,8 @@ defmodule Realtime.UsersCounterTest do
   describe "tenant_counts/0" do
     test "map of tenant and number of users", %{tenant_id: tenant_id, count: expected} do
       assert UsersCounter.add(self(), tenant_id) == :ok
-      Process.sleep(1000)
+      await_tenant_users!(tenant_id, expected + 1)
+
       counts = UsersCounter.tenant_counts()
 
       assert counts[tenant_id] == expected + 1
@@ -86,9 +87,15 @@ defmodule Realtime.UsersCounterTest do
 
   describe "tenant_users/1" do
     test "returns count of connected clients for tenant on cluster node", %{tenant_id: tenant_id, count: expected} do
-      Process.sleep(1000)
-      assert UsersCounter.tenant_users(tenant_id) == expected
+      await_tenant_users!(tenant_id, expected)
     end
+  end
+
+  defp await_tenant_users!(tenant_id, expected) do
+    eventually(fn -> UsersCounter.tenant_users(tenant_id) == expected end)
+
+    # eventually/2 only answers true/false, so re-assert to get the counts on failure.
+    assert UsersCounter.tenant_users(tenant_id) == expected
   end
 
   defp generate_load(tenant_id) do
@@ -107,38 +114,46 @@ defmodule Realtime.UsersCounterTest do
     on_exit(fn -> Application.put_env(:gen_rpc, :client_config_per_node, {:internal, %{}}) end)
     Application.put_env(:gen_rpc, :client_config_per_node, {:internal, nodes})
 
-    Enum.each(peers, fn {peer, region} ->
-      extra_config = [
-        {:gen_rpc, :tcp_server_port, TestEnv.peer_gen_rpc_port(peer)},
-        {:gen_rpc, :client_config_per_node, {:internal, nodes}},
-        {:realtime, :users_scope_broadcast_interval_in_ms, 100},
-        {:realtime, :region, region}
-      ]
+    joins =
+      Enum.flat_map(peers, fn {peer, region} ->
+        extra_config = [
+          {:gen_rpc, :tcp_server_port, TestEnv.peer_gen_rpc_port(peer)},
+          {:gen_rpc, :client_config_per_node, {:internal, nodes}},
+          {:realtime, :region, region}
+        ]
 
-      {:ok, node} =
-        Clustered.start(@aux_mod,
-          name: peer,
-          extra_config: extra_config,
-          phoenix_port: TestEnv.peer_http_port(peer)
-        )
+        {:ok, node} =
+          Clustered.start(@aux_mod,
+            name: peer,
+            extra_config: extra_config,
+            phoenix_port: TestEnv.peer_http_port(peer)
+          )
 
-      for _ <- 1..processes do
-        pid = Rpc.call(node, Aux, :ping, [])
+        peer_joins =
+          for _ <- 1..processes do
+            pid = Rpc.call(node, Aux, :ping, [])
 
-        for _ <- 1..10 do
-          # replicate same pid added multiple times concurrently
-          Task.start(fn ->
-            Rpc.call(node, Aux, :join, [pid, tenant_id])
-          end)
+            # :rpc.call/5 answers {:badrpc, reason} rather than raising, so without this a
+            # transport failure would surface much later as an unexplained count.
+            assert is_pid(pid)
 
-          # noisy neighbors to test handling of bigger loads on concurrent calls
-          Task.start(fn ->
-            Rpc.call(node, Aux, :join, [pid, random_string()])
-          end)
-        end
-      end
-    end)
+            for _ <- 1..10 do
+              [
+                # replicate same pid added multiple times concurrently
+                Task.async(fn -> Rpc.call(node, Aux, :join, [pid, tenant_id]) end),
+                # noisy neighbors to test handling of bigger loads on concurrent calls
+                Task.async(fn -> Rpc.call(node, Aux, :join, [pid, random_string()]) end)
+              ]
+            end
+          end
 
-    3 * processes
+        List.flatten(peer_joins)
+      end)
+
+    # Awaited rather than fire-and-forget, so the count we return is the number of joins
+    # that actually landed instead of a guess the assertions then have to match.
+    assert Enum.all?(Task.await_many(joins, 15_000), &(&1 == :ok))
+
+    length(peers) * processes
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?



```
1) test tenant_counts/0 map of tenant and number of users (Realtime.UsersCounterTest)
     test/realtime/users_counter_test.exs:57
     Assertion with == failed
     code:  assert counts[tenant_id] == expected + 1
     left:  5
     right: 7
     stacktrace:
       test/realtime/users_counter_test.exs:62: (test)

.

  2) test tenant_users/1 returns count of connected clients for tenant on cluster node (Realtime.UsersCounterTest)
     test/realtime/users_counter_test.exs:88
     Assertion with == failed
     code:  assert UsersCounter.tenant_users(tenant_id) == expected
     left:  4
     right: 6
     stacktrace:
       test/realtime/users_counter_test.exs:90: (test)

```

https://github.com/supabase/realtime/actions/runs/34296756211/job/102294955407?pr=2179