### PR TITLE
chore(tests): Liveliness probe & diagnostics in tenant DB checkout

### DIFF
--- a/lib/realtime/database.ex
+++ b/lib/realtime/database.ex
@@ -51,25 +51,30 @@ defmodule Realtime.Database do
     |> then(&from_settings(&1, application_name, backoff))
   end
 
+  @encrypted_keys ~w(db_host db_port db_name db_user db_password)
+
   @doc """
-  Creates a database connection struct from the given settings.
+  Creates a database connection struct from a tenant's stored settings.
   """
   @spec from_settings(map(), binary(), :stop | :exp | :rand | :rand_exp) :: {:ok, t()} | {:error, :nxdomain}
   def from_settings(settings, application_name, backoff \\ :rand_exp) do
-    pool = pool_size_by_application_name(application_name, settings)
-
-    settings =
+    decrypted_settings =
       settings
-      |> Map.take([
-        "db_host",
-        "db_port",
-        "db_name",
-        "db_user",
-        "db_password"
-      ])
-      |> Enum.map(fn {k, v} -> {k, Crypto.decrypt!(v)} end)
-      |> Map.new()
-      |> then(&Map.merge(settings, &1))
+      |> Map.take(@encrypted_keys)
+      |> Map.new(fn {k, v} -> {k, Crypto.decrypt!(v)} end)
+
+    settings
+    |> Map.merge(decrypted_settings)
+    |> from_plaintext_settings(application_name, backoff)
+  end
+
+  @doc """
+  Same as `from_settings/3`, for settings whose credentials are already plaintext.
+  """
+  @spec from_plaintext_settings(map(), binary(), :stop | :exp | :rand | :rand_exp) ::
+          {:ok, t()} | {:error, :nxdomain}
+  def from_plaintext_settings(settings, application_name, backoff \\ :rand_exp) do
+    pool = pool_size_by_application_name(application_name, settings)
 
     with {:ok, addrtype} <- detect_ip_version(settings["db_host"]) do
       ssl = if default_ssl_param(settings), do: [verify: :verify_none], else: false

--- a/test/support/test_tenant_db.ex
+++ b/test/support/test_tenant_db.ex
@@ -1,3 +1,11 @@
+defmodule TestTenantDb.UnhealthyDatabaseError do
+  @moduledoc false
+  # Raised when a checkout could not be served by any pool worker because their
+  # databases stopped answering. Named (rather than a bare `:error`) so the flaky
+  # digest can group it and so the failure carries its own root cause.
+  defexception [:message]
+end
+
 defmodule TestTenantDb do
   @moduledoc false
   # Backend-neutral pool of ready-to-use tenant databases for the test suite.
@@ -5,9 +13,47 @@ defmodule TestTenantDb do
   alias Extensions.PostgresCdcRls
   alias Realtime.Tenants.Connect
   alias TestTenantDb.Backend
+  alias TestTenantDb.Probe
+  alias TestTenantDb.UnhealthyDatabaseError
   alias Realtime.Database
 
   use GenServer
+
+  # Every checkout probes its database before handing it to the test.
+  # We do this, to make sure the database is healthy and ready.
+  # If a database stops working, it poisons the entire run (observed in many
+  # failures in the flaky test report).
+  # We also use this to print diagnostics to hopefully get to the bottom of
+  # this.
+  #
+  # "Stops answering" deliberately covers three different states, because we do
+  # not know which one CI hits:
+  #
+  #   1. the container is gone (crash, OOM kill) — connect is refused at once
+  #   2. it is up but not accepting connections — connect hangs
+  #   3. it is accepting, but queries block on a stuck backend — the query hangs
+  #
+  # Our check for 3. only says "this database accept queries" - locks or others may still hold it up
+  #
+  # The check itself lives in `TestTenantDb.Probe`, shared with the backend's readiness
+  # gate so the two cannot disagree about what "usable" means.
+
+  # A probe is only allowed to condemn a database after failing twice.
+  @probe_attempts 2
+
+  # Attempts across *different* workers.
+  @checkout_attempts 3
+
+  # How long to wait for a _free worker_
+  # The timeouts above ask "is this database healthy"; this one asks "is a peer test done
+  # with theirs yet" - poolboy only.
+  #
+  # We have more workers in the pool than parallel cases - should be instant unless
+  # something is too slow.
+  @worker_checkout_timeout_ms 5_000
+
+  @unhealthy_table __MODULE__.Unhealthy
+  @probe_retry_table __MODULE__.ProbeRetries
 
   def start_link(max_cases), do: GenServer.start_link(__MODULE__, max_cases, name: __MODULE__)
 
@@ -16,6 +62,11 @@ defmodule TestTenantDb do
   end
 
   def handle_continue({:pool, max_cases}, state) do
+    # Owned by this long-lived process so the tallies survive every test process.
+    for table <- [@unhealthy_table, @probe_retry_table] do
+      :ets.new(table, [:named_table, :public, :set, write_concurrency: true])
+    end
+
     {worker_module, size} = Backend.current().pool_spec(max_cases)
 
     {:ok, _pid} =
@@ -49,17 +100,168 @@ defmodule TestTenantDb do
   def checkout_tenant(opts \\ []), do: do_checkout_tenant(opts, :sandbox)
   def checkout_tenant_unboxed(opts \\ []), do: do_checkout_tenant(opts, :unboxed)
 
+  @doc """
+  Tears the pool down and hands the backend its resources back.
+
+  Done after tests finish to not leave resources hanging.
+
+  The pool has to go first, as workers claim their resource lazily.
+  A short run might finish while resources are still being acquired and then left hanging around.
+  """
+  def shutdown(_results \\ %{}) do
+    if pid = Process.whereis(__MODULE__), do: GenServer.stop(pid)
+    Backend.current().cleanup!()
+  catch
+    # after_suite runs after the results are decided but before they are reported, so
+    # anything raised here replaces the suite's verdict with a teardown error. A docker
+    # hiccup must not turn a green run red — say what leaked and let the run stand.
+    kind, reason ->
+      IO.puts(:stderr, "[TestTenantDb] teardown failed (#{kind}: #{inspect(reason)}); resources may have leaked")
+  end
+
+  @doc """
+  Prints the run's unhealthy-checkout and retried-probe tallies.
+
+  Deliberately loud so we can figure out what's going on/breaking.
+  """
+  def report_unhealthy_checkouts(_results \\ %{}) do
+    report_offenders(:ets.tab2list(@unhealthy_table))
+    report_retries(:ets.tab2list(@probe_retry_table))
+  end
+
+  defp report_offenders([]), do: :ok
+
+  defp report_offenders(offenders) do
+    IO.puts(:stderr, """
+
+    [TestTenantDb] #{total(offenders)} unhealthy tenant-database checkout(s) across #{length(offenders)} resource(s):
+    #{tally_lines(offenders)}
+    The resources were replaced mid-run, so tests that drew them were retried rather than
+    killed.
+    """)
+  end
+
+  defp report_retries([]), do: :ok
+
+  defp report_retries(retries) do
+    IO.puts(:stderr, """
+
+    [TestTenantDb] #{total(retries)} probe(s) failed once and succeeded on retry:
+    #{tally_lines(retries)}
+    These cost checkout time without failing anything. A non-trivial count means the probe
+    is too strict for the load, not that the databases are broken.
+    """)
+  end
+
+  defp total(tally), do: tally |> Enum.map(&elem(&1, 1)) |> Enum.sum()
+
+  defp tally_lines(tally) do
+    tally
+    |> Enum.sort_by(&elem(&1, 1), :desc)
+    |> Enum.map_join("\n", fn {label, count} -> "  #{count}x  #{label}" end)
+  end
+
   # Acquire a tenant database for one test — a pooled supabase/postgres
   # container, or (in external mode) one of the pre-configured external DBs.
   # Either way it's a real pool checkout, released via the returned checkin
   # function once the caller is done.
-  defp acquire_tenant_db do
-    case :poolboy.checkout(TestTenantDb.Pool, true, 5_000) do
-      worker when is_pid(worker) ->
-        {:ok, Backend.current().worker_port(worker), fn -> :poolboy.checkin(TestTenantDb.Pool, worker) end}
+  #
+  # A worker whose database fails the probe is discarded rather than handed on:
+  # its resource is destroyed and the worker killed, which makes poolboy start a
+  # replacement that claims a fresh one.
+  defp acquire_tenant_db(attempts \\ @checkout_attempts, failures \\ [])
 
-      _ ->
-        :error
+  defp acquire_tenant_db(0, failures) do
+    raise UnhealthyDatabaseError,
+      message:
+        "no healthy tenant database after #{@checkout_attempts} checkout attempts.\n\n" <>
+          Enum.join(Enum.reverse(failures), "\n\n")
+  end
+
+  defp acquire_tenant_db(attempts, failures) do
+    case checkout_worker() do
+      {:ok, worker} ->
+        port = Backend.current().worker_port(worker)
+
+        case probe(port) do
+          :ok ->
+            {:ok, port, fn -> :poolboy.checkin(TestTenantDb.Pool, worker) end}
+
+          {:error, reason} ->
+            acquire_tenant_db(attempts - 1, [discard_worker(worker, port, reason) | failures])
+        end
+
+      :full ->
+        no_free_worker(failures)
+    end
+  end
+
+  # A blocking `:poolboy.checkout/3` never returns `:full` — it lets its own
+  # `GenServer.call` time out and re-raises, which reaches the test as a bare
+  # `** (EXIT) time out` naming nothing. Translated here so pool exhaustion raises
+  # like every other failure in this module.
+  defp checkout_worker do
+    {:ok, :poolboy.checkout(TestTenantDb.Pool, true, @worker_checkout_timeout_ms)}
+  catch
+    :exit, {:timeout, _} -> :full
+  end
+
+  # Poolboy gave up waiting for a free worker. If this checkout already condemned
+  # databases on the way here, that is the likeliest reason the pool is short — so
+  # say so and keep the forensics.
+  defp no_free_worker(failures) do
+    raise UnhealthyDatabaseError,
+      message: "no free tenant database within #{@worker_checkout_timeout_ms}ms" <> after_discarding(failures)
+  end
+
+  defp after_discarding([]), do: "."
+
+  defp after_discarding(failures) do
+    ", after discarding #{length(failures)} unhealthy one(s) during this checkout.\n\n" <>
+      Enum.join(Enum.reverse(failures), "\n\n")
+  end
+
+  # Capture the forensics *before* destroying anything: `docker inspect` and
+  # `docker logs` on the dead container are the only place an OOM kill or a
+  # Postgres PANIC shows up, and they vanish with the container.
+  defp discard_worker(worker, port, reason) do
+    {label, details} = Backend.current().diagnose(worker)
+    _count = :ets.update_counter(@unhealthy_table, label, 1, {label, 0})
+
+    report =
+      "[TestTenantDb] tenant database #{label} (port #{port}) failed its checkout probe: " <>
+        "#{reason}\n#{details}"
+
+    # Straight to stderr, in the test environment we might not get log lines (capturing etc).
+    IO.puts(:stderr, report <> "\n")
+
+    # Same error message is also included here to ideally be attached to the failing test
+    Backend.current().discard(worker)
+    # We diagnosed it as unhealthy/unresponsive, kill it so poolboy can start a new one.
+    Process.exit(worker, :kill)
+
+    report
+  end
+
+  defp probe(port, attempts \\ @probe_attempts) do
+    case Probe.check_port(port) do
+      :ok ->
+        :ok
+
+      # we already ran another probe --> attempts already exhausted
+      {:error, reason} when attempts <= 1 ->
+        {:error, reason}
+
+      {:error, reason} ->
+        # Only counted when we retry, as the other proves show up in different unhealthy reports
+        case probe(port, attempts - 1) do
+          :ok ->
+            :ets.update_counter(@probe_retry_table, reason, 1, {reason, 0})
+            :ok
+
+          error ->
+            error
+        end
     end
   end
 

--- a/test/support/test_tenant_db.ex
+++ b/test/support/test_tenant_db.ex
@@ -228,8 +228,11 @@ defmodule TestTenantDb do
     {label, details} = Backend.current().diagnose(worker)
     _count = :ets.update_counter(@unhealthy_table, label, 1, {label, 0})
 
+    # UTC so it lines up with the container's own log timestamps below.
+    at = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
     report =
-      "[TestTenantDb] tenant database #{label} (port #{port}) failed its checkout probe: " <>
+      "[TestTenantDb] tenant database #{label} (port #{port}) failed its checkout probe at #{at}: " <>
         "#{reason}\n#{details}"
 
     # Straight to stderr, in the test environment we might not get log lines (capturing etc).

--- a/test/support/test_tenant_db/backend.ex
+++ b/test/support/test_tenant_db/backend.ex
@@ -25,6 +25,9 @@ defmodule TestTenantDb.Backend do
   # One-off setup before the pool starts. Runs before TestTenantDb.start_link/1.
   @callback prepare!() :: :ok
 
+  # Undo prepare!/0, called from TestTenantDb.shutdown/1 at the end of the run.
+  @callback cleanup!() :: :ok
+
   # Poolboy worker module and pool size.
   @callback pool_spec(max_cases :: pos_integer()) :: {module(), pos_integer()}
 
@@ -33,6 +36,17 @@ defmodule TestTenantDb.Backend do
 
   # Ensure the tenant's database exists
   @callback storage_up!(tenant :: struct()) :: :ok
+
+  # Forensics for a worker whose database stopped answering: a short label
+  # identifying the backing resource (so repeat offenders can be grouped) and a
+  # best-effort human-readable dump. Only ever called on the unhealthy path, so
+  # it is allowed to be slow.
+  @callback diagnose(pid()) :: {label :: String.t(), details :: String.t()}
+
+  # Destroy a worker's backing resource. The worker is being thrown away, and a
+  # container we have given up on keeps competing for the runner's CPU and memory
+  # for the rest of the suite if it is still running.
+  @callback discard(pid()) :: :ok
 
   def resolve! do
     backend = choose()

--- a/test/support/test_tenant_db/backend/docker.ex
+++ b/test/support/test_tenant_db/backend/docker.ex
@@ -14,9 +14,33 @@ defmodule TestTenantDb.Backend.Docker do
 
   alias Realtime.Database
   alias Realtime.Env
+  alias TestTenantDb.Probe
 
   @container_prefix "realtime-test"
   @container_suffix_length 12
+
+  # Docker states a pool container never comes back from. "created" belongs here
+  # only because we look at it while the pool is stopped — see prune_dead_containers/0.
+  @dead_statuses ["created", "exited", "dead"]
+
+  # -- Timeouts for bringing a worker's container up.
+  #
+  # A worker becoming usable is two phases, and a caller blocked in
+  # `Worker.port/1` is waiting for both:
+  #
+  #   claim      — queue behind other workers, then `docker run -d` + read the port.
+  #                Serialised through this module's GenServer, but it does not wait
+  #                for Postgres, so it is short per worker.
+  #   wait_ready — poll until a real connection from the host succeeds. Runs in the
+  #                worker itself, so all workers do this in parallel.
+  #
+  # `Worker.port/1` must allow more than claim + wait_ready combined.
+  @claim_timeout_ms 30_000
+  @container_ready_timeout_ms 25_000
+  @ready_poll_interval_ms 250
+
+  # Careful that this doesn't go over ~60s / exunits default timeout
+  def worker_ready_timeout_ms, do: @claim_timeout_ms + @container_ready_timeout_ms
 
   # -- TestTenantDb.Backend implementation
 
@@ -31,6 +55,7 @@ defmodule TestTenantDb.Backend.Docker do
 
     existing =
       if Env.get_boolean("REUSE_CONTAINERS", false) do
+        prune_dead_containers()
         existing_containers()
       else
         stop_containers()
@@ -38,6 +63,17 @@ defmodule TestTenantDb.Backend.Docker do
       end
 
     {:ok, _pid} = GenServer.start_link(__MODULE__, existing, name: __MODULE__)
+    :ok
+  end
+
+  # We keep containers around for diagnostics/no `--rm`, hence we need to clean up
+  # after ourselves.
+  #
+  # The registry is stopped before we list, to prevent it from launching more containers.
+  @impl TestTenantDb.Backend
+  def cleanup! do
+    if pid = Process.whereis(__MODULE__), do: GenServer.stop(pid)
+    unless Env.get_boolean("REUSE_CONTAINERS", false), do: stop_containers()
     :ok
   end
 
@@ -65,11 +101,111 @@ defmodule TestTenantDb.Backend.Docker do
     end
   end
 
+  @inspect_format "status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} " <>
+                    "error={{.State.Error}} started={{.State.StartedAt}} finished={{.State.FinishedAt}}"
+
+  @stats_format "mem={{.MemUsage}} mem%={{.MemPerc}} cpu={{.CPUPerc}} pids={{.PIDs}}"
+
+  @activity_query "SELECT pid, state, wait_event_type, wait_event, application_name, " <>
+                    "now() - query_start AS running, left(query, 120) FROM pg_stat_activity ORDER BY query_start"
+
+  @slots_query "SELECT slot_name, active, active_pid, wal_status, safe_wal_size FROM pg_replication_slots"
+
+  @impl TestTenantDb.Backend
+  def diagnose(pid) do
+    case __MODULE__.Worker.container(pid) do
+      nil ->
+        {"unknown container", "worker #{inspect(pid)} did not report a container name"}
+
+      name ->
+        {name, Enum.join(state_of(name) ++ inside(name) ++ logs_of(name), "\n")}
+    end
+  end
+
+  defp state_of(name) do
+    [
+      "verdict: " <> verdict(name),
+      "container: " <> docker(["inspect", "--format", @inspect_format, name]),
+      "resources: " <> docker(["stats", "--no-stream", "--format", @stats_format, name])
+    ]
+  end
+
+  # Say what the state means, so the first line of the dump already narrows it down.
+  defp verdict(name) do
+    # Several `docker inspect` calls vs. one for simplicity: This is for a failure cause only, we can afford the extra time.
+    running = docker(["inspect", "--format", "{{.State.Running}}", name])
+    oom = docker(["inspect", "--format", "{{.State.OOMKilled}}", name])
+    code = docker(["inspect", "--format", "{{.State.ExitCode}}", name])
+
+    case {running, oom, code} do
+      {"true", _, _} ->
+        "container is UP but Postgres did not answer from the host — see the process list and logs below"
+
+      {_, "true", _} ->
+        "OOM-KILLED"
+
+      {_, _, "137"} ->
+        "SIGKILLed from OUTSIDE the container. Postgres did not crash on its own"
+
+      {_, _, "0"} ->
+        "exited cleanly (code 0) — something stopped it on purpose"
+
+      {_, _, other} ->
+        "Postgres exited on its own with code #{other} — the log lines below should say why"
+    end
+  end
+
+  defp inside(name) do
+    if running?(name) do
+      [
+        "backends:\n" <> docker(["exec", name, "ps", "-eo", "pid,stat,etime,args"]),
+        "pg_stat_activity:\n" <> psql(name, @activity_query),
+        "pg_replication_slots:\n" <> psql(name, @slots_query)
+      ]
+    else
+      ["(container is not running, so no in-container state to collect)"]
+    end
+  end
+
+  defp logs_of(name), do: ["last 40 log lines:\n" <> docker(["logs", "--tail", "40", name])]
+
+  defp running?(name) do
+    docker(["inspect", "--format", "{{.State.Running}}", name]) == "true"
+  end
+
+  @impl TestTenantDb.Backend
+  def discard(pid) do
+    case __MODULE__.Worker.container(pid) do
+      nil -> :ok
+      name -> docker(["rm", "-f", name])
+    end
+
+    :ok
+  end
+
+  # Every call here runs against a container that has already stopped answering, so
+  # each one is wrapped in `timeout`. If the container is up but its Postgres is
+  # blocked, `docker exec` inherits that block and never returns — hanging the
+  # test process these diagnostics exist to explain.
+  defp docker(args, seconds \\ 5) do
+    case System.cmd("timeout", [to_string(seconds), "docker" | args], stderr_to_stdout: true) do
+      {output, 0} -> String.trim(output)
+      {_output, 124} -> "(timed out after #{seconds}s: docker #{Enum.join(args, " ")})"
+      {output, code} -> "(docker #{Enum.join(args, " ")} exited #{code}: #{String.trim(output)})"
+    end
+  end
+
+  # Over the unix socket rather than TCP: the probe already established that the
+  # port is not answering, and the postmaster sometimes still serves locally.
+  defp psql(name, query) do
+    docker(["exec", name, "psql", "-U", "postgres", "-h", "/var/run/postgresql", "-tAc", query])
+  end
+
   # -- Container registry (claimed by TestTenantDb.Backend.Docker.Worker)
 
   # Hand a worker a container: reuse a pre-existing one if any remain,
   # otherwise start a fresh one on a free port. Returns {:ok, name, port}.
-  def claim, do: GenServer.call(__MODULE__, :claim, 30_000)
+  def claim, do: GenServer.call(__MODULE__, :claim, @claim_timeout_ms)
 
   @impl GenServer
   def init(existing), do: {:ok, %{existing: existing}}
@@ -139,8 +275,8 @@ defmodule TestTenantDb.Backend.Docker do
   # The docker name filter is a substring match: a run listing "realtime-test" also gets another
   # run's "realtime-test_port4003-...". A container is this run's only if its name is exactly
   # this run's prefix followed by a random suffix.
-  def own_container?(name) do
-    prefix = container_prefix() <> "-"
+  def own_container?(name, prefix \\ container_prefix()) do
+    prefix = prefix <> "-"
 
     String.starts_with?(name, prefix) and byte_size(name) == byte_size(prefix) + @container_suffix_length
   end
@@ -163,18 +299,41 @@ defmodule TestTenantDb.Backend.Docker do
   def reap_abandoned_containers do
     {list, 0} = System.cmd("docker", ["ps", "-a", "--format", "{{.Names}}", "--filter", "name=#{@container_prefix}"])
 
-    for name <- String.split(list, "\n", trim: true), abandoned_container?(name) do
-      System.cmd("docker", ["rm", "-f", name])
-    end
+    list
+    |> String.split("\n", trim: true)
+    |> Enum.filter(&abandoned_container?/1)
+    |> remove!()
   end
 
   def stop_containers() do
     {list, 0} =
       System.cmd("docker", ["ps", "-a", "--format", "{{.Names}}", "--filter", "name=#{container_prefix()}"])
 
-    for name <- String.split(list, "\n", trim: true), own_container?(name) do
-      System.cmd("docker", ["rm", "-f", name])
-    end
+    list
+    |> String.split("\n", trim: true)
+    |> Enum.filter(&own_container?/1)
+    |> remove!()
+  end
+
+  # As we keep dead containers around for diagnostics we also need to clean them up.
+  def prune_dead_containers, do: remove!(dead_containers())
+
+  defp remove!([]), do: :ok
+
+  defp remove!(names) do
+    System.cmd("docker", ["rm", "-f" | names], stderr_to_stdout: true)
+    :ok
+  end
+
+  def dead_containers(prefix \\ container_prefix()) do
+    filters = Enum.flat_map(@dead_statuses, &["--filter", "status=#{&1}"])
+
+    {list, 0} =
+      System.cmd("docker", ["ps", "-a", "--format", "{{.Names}}", "--filter", "name=#{prefix}"] ++ filters)
+
+    list
+    |> String.split("\n", trim: true)
+    |> Enum.filter(&own_container?(&1, prefix))
   end
 
   def existing_containers do
@@ -198,17 +357,25 @@ defmodule TestTenantDb.Backend.Docker do
     end)
   end
 
-  def wait_ready!(name, attempts \\ 100)
-  def wait_ready!(name, 0), do: raise("Container #{name} is not ready")
+  # Gate on exactly what consumers use: a real connection from the host to the published port.
+  def wait_ready!(name, port) do
+    settings = Probe.settings!(port)
+    wait_ready!(name, settings, System.monotonic_time(:millisecond) + @container_ready_timeout_ms)
+  end
 
-  def wait_ready!(name, attempts) do
-    case System.cmd("docker", ["exec", name, "pg_isready", "-p", "5432", "-h", "localhost"]) do
-      {_, 0} ->
+  defp wait_ready!(name, settings, deadline) do
+    case Probe.check(settings) do
+      :ok ->
         :ok
 
-      {_, _} ->
-        Process.sleep(250)
-        wait_ready!(name, attempts - 1)
+      {:error, reason} ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          raise "Container #{name} did not accept connections within " <>
+                  "#{@container_ready_timeout_ms}ms. Last error: #{reason}"
+        else
+          Process.sleep(@ready_poll_interval_ms)
+          wait_ready!(name, settings, deadline)
+        end
     end
   end
 
@@ -216,12 +383,12 @@ defmodule TestTenantDb.Backend.Docker do
     initdb_sh = Path.expand("../../../../dev/postgres/za-permit-supabase-admin.sh", __DIR__)
     initdb_sql = Path.expand("../../../../dev/postgres/zb-supabase-schema.sql", __DIR__)
 
+    # Deliberately no `--rm`, we keep containers around for diagnostics of why they died
     System.cmd(
       "docker",
       [
         "run",
         "-d",
-        "--rm",
         "--name",
         name,
         "-e",

--- a/test/support/test_tenant_db/backend/docker.ex
+++ b/test/support/test_tenant_db/backend/docker.ex
@@ -73,7 +73,7 @@ defmodule TestTenantDb.Backend.Docker do
   @impl TestTenantDb.Backend
   def cleanup! do
     if pid = Process.whereis(__MODULE__), do: GenServer.stop(pid)
-    unless Env.get_boolean("REUSE_CONTAINERS", false), do: stop_containers()
+    if !Env.get_boolean("REUSE_CONTAINERS", false), do: stop_containers()
     :ok
   end
 

--- a/test/support/test_tenant_db/backend/docker.ex
+++ b/test/support/test_tenant_db/backend/docker.ex
@@ -106,6 +106,8 @@ defmodule TestTenantDb.Backend.Docker do
 
   @stats_format "mem={{.MemUsage}} mem%={{.MemPerc}} cpu={{.CPUPerc}} pids={{.PIDs}}"
 
+  @all_stats_format "{{.Name}} mem={{.MemUsage}} cpu={{.CPUPerc}} pids={{.PIDs}}"
+
   @activity_query "SELECT pid, state, wait_event_type, wait_event, application_name, " <>
                     "now() - query_start AS running, left(query, 120) FROM pg_stat_activity ORDER BY query_start"
 
@@ -118,7 +120,7 @@ defmodule TestTenantDb.Backend.Docker do
         {"unknown container", "worker #{inspect(pid)} did not report a container name"}
 
       name ->
-        {name, Enum.join(state_of(name) ++ inside(name) ++ logs_of(name), "\n")}
+        {name, Enum.join(state_of(name) ++ host_load() ++ inside(name) ++ logs_of(name), "\n")}
     end
   end
 
@@ -127,6 +129,21 @@ defmodule TestTenantDb.Backend.Docker do
       "verdict: " <> verdict(name),
       "container: " <> docker(["inspect", "--format", @inspect_format, name]),
       "resources: " <> docker(["stats", "--no-stream", "--format", @stats_format, name])
+    ]
+  end
+
+  # One container's CPU number cannot tell it's just this container vs. it's the host
+  # so add host load to distinguish
+  defp host_load do
+    load =
+      case File.read("/proc/loadavg") do
+        {:ok, contents} -> contents |> String.split() |> Enum.take(3) |> Enum.join(" ")
+        _ -> "unknown"
+      end
+
+    [
+      "runner: #{:erlang.system_info(:logical_processors_available)} cores, loadavg #{load}",
+      "all containers:\n" <> docker(["stats", "--no-stream", "--format", @all_stats_format])
     ]
   end
 
@@ -158,7 +175,7 @@ defmodule TestTenantDb.Backend.Docker do
   defp inside(name) do
     if running?(name) do
       [
-        "backends:\n" <> docker(["exec", name, "ps", "-eo", "pid,stat,etime,args"]),
+        "backends:\n" <> docker(["exec", name, "ps", "-eo", "pid,stat,time,etime,rss,args"]),
         "pg_stat_activity:\n" <> psql(name, @activity_query),
         "pg_replication_slots:\n" <> psql(name, @slots_query)
       ]
@@ -167,7 +184,10 @@ defmodule TestTenantDb.Backend.Docker do
     end
   end
 
-  defp logs_of(name), do: ["last 40 log lines:\n" <> docker(["logs", "--tail", "40", name])]
+  # we've seen some tight loops and didn't see where they started,
+  # ---> more log lines to see where it may have started
+  # It's only printed in a failure case so that's ok.
+  defp logs_of(name), do: ["last 200 log lines:\n" <> docker(["logs", "--tail", "200", name])]
 
   defp running?(name) do
     docker(["inspect", "--format", "{{.State.Running}}", name]) == "true"

--- a/test/support/test_tenant_db/backend/docker/worker.ex
+++ b/test/support/test_tenant_db/backend/docker/worker.ex
@@ -11,7 +11,20 @@ defmodule TestTenantDb.Backend.Docker.Worker do
     GenServer.start_link(__MODULE__, args, opts)
   end
 
-  def port(pid), do: GenServer.call(pid, :port, 15_000)
+  # The worker does not answer calls until it has claimed a container and waited
+  # for Postgres, so this call is really "wait for the container to come up".
+  def port(pid), do: GenServer.call(pid, :port, Docker.worker_ready_timeout_ms())
+
+  # Deliberately shorter: this is only called on the failure path, to name
+  # the container - don't want to wait too long on a failure.
+  @container_call_timeout_ms 5_000
+
+  # Name of the docker container backing this worker, for diagnostics and teardown.
+  def container(pid) do
+    GenServer.call(pid, :container, @container_call_timeout_ms)
+  catch
+    _, _ -> nil
+  end
 
   @impl true
   def init(_args), do: {:ok, %{}, {:continue, :claim}}
@@ -24,10 +37,13 @@ defmodule TestTenantDb.Backend.Docker.Worker do
 
   @impl true
   def handle_continue(:wait_ready, state) do
-    Docker.wait_ready!(state.name)
+    Docker.wait_ready!(state.name, state.port)
     {:noreply, state}
   end
 
   @impl true
   def handle_call(:port, _from, state), do: {:reply, state[:port], state}
+
+  @impl true
+  def handle_call(:container, _from, state), do: {:reply, state[:name], state}
 end

--- a/test/support/test_tenant_db/backend/docker_test.exs
+++ b/test/support/test_tenant_db/backend/docker_test.exs
@@ -14,6 +14,31 @@ defmodule TestTenantDb.Backend.DockerTest do
     on_exit(fn -> Application.put_env(:realtime, :test_run_tag, original) end)
   end
 
+  # A prefix of its own, so the filters here cannot match the real pool's
+  # containers, whose prefix is a different string entirely.
+  @prune_prefix "realtime-test_prunetest"
+
+  # we don't call `prune_dead_containers/0` here as that'd effect the tests suite's own pool
+  # we need this to be isolated from our actual usage.
+  describe "dead_containers/1" do
+    @tag :requires_docker_backend
+    test "selects finished containers under the given prefix and not the running ones" do
+      dead = "#{@prune_prefix}-#{String.duplicate("a", 12)}"
+      alive = "#{@prune_prefix}-#{String.duplicate("b", 12)}"
+      on_exit(fn -> System.cmd("docker", ["rm", "-f", dead, alive], stderr_to_stdout: true) end)
+
+      # `create` never starts the container, so it sits in "created" — one of the
+      # states we treat as finished. `sleep` rather than postgres keeps the running
+      # one cheap; only its name and state matter here.
+      assert {_, 0} = System.cmd("docker", ["create", "--name", dead, image(), "true"])
+      assert {_, 0} = System.cmd("docker", ["run", "-d", "--name", alive, image(), "sleep", "300"])
+
+      assert Docker.dead_containers(@prune_prefix) == [dead]
+    end
+  end
+
+  defp image, do: Env.get_binary("POSTGRES_IMAGE", "supabase/postgres:17.6.1.166")
+
   describe "container_prefix/0 and container_name/0" do
     test "the first run on a machine names containers as it always did" do
       put_run_tag("")

--- a/test/support/test_tenant_db/backend/external.ex
+++ b/test/support/test_tenant_db/backend/external.ex
@@ -44,6 +44,10 @@ defmodule TestTenantDb.Backend.External do
     :ok
   end
 
+  # The external servers outlive the run; there is nothing of ours to tear down.
+  @impl TestTenantDb.Backend
+  def cleanup!, do: :ok
+
   @impl TestTenantDb.Backend
   def pool_spec(_max_cases), do: {__MODULE__.Worker, length(ports!())}
 
@@ -56,6 +60,26 @@ defmodule TestTenantDb.Backend.External do
   # existence probe).
   @impl TestTenantDb.Backend
   def storage_up!(_tenant), do: :ok
+
+  @impl TestTenantDb.Backend
+  def diagnose(pid) do
+    # Tolerant of a worker that is dead or not answering: this runs on the failure
+    # path, where raising would bury the failure it is meant to explain.
+    port =
+      try do
+        __MODULE__.Worker.port(pid)
+      catch
+        _, _ -> "unknown"
+      end
+
+    {"127.0.0.1:#{port}", "external tenant DB on 127.0.0.1:#{port} stopped answering."}
+  end
+
+  # The external servers are supplied to us; throwing the worker away cannot
+  # recreate one, and a replacement worker reclaims the very same port. Retrying
+  # the checkout is therefore futile here, and TestTenantDb raises instead.
+  @impl TestTenantDb.Backend
+  def discard(_pid), do: :ok
 
   # -- Port configuration
 

--- a/test/support/test_tenant_db/probe.ex
+++ b/test/support/test_tenant_db/probe.ex
@@ -1,0 +1,89 @@
+defmodule TestTenantDb.Probe do
+  @moduledoc false
+  # One definition of "this tenant database is usable": a real connection from the
+  # host to the published port, plus a query.
+  #
+  # Both callers go through here on purpose:
+  #
+  #   * `TestTenantDb`, per checkout, to decide whether to hand the database to a test
+  #   * `TestTenantDb.Backend.Docker.wait_ready!/2`, to decide when a freshly started
+  #     container may join the pool
+
+  alias Realtime.Database
+
+  @connect_timeout_ms 2_000
+  @deadline_ms 5_000
+
+  @spec settings!(pos_integer()) :: Database.t()
+  def settings!(port) do
+    {:ok, settings} =
+      Database.from_plaintext_settings(
+        %{
+          "db_host" => "127.0.0.1",
+          "db_port" => to_string(port),
+          "db_name" => "postgres",
+          "db_user" => System.get_env("DB_USER", "supabase_admin"),
+          "db_password" => "postgres",
+          "ssl_enforced" => false
+        },
+        "test_tenant_db_probe",
+        # Fail fast rather than retry in the background: a probe that keeps
+        # reconnecting cannot answer "is this database usable right now".
+        :stop
+      )
+
+    settings
+  end
+
+  @doc "Convenience for callers that check a port once."
+  @spec check_port(pos_integer()) :: :ok | {:error, String.t()}
+  def check_port(port), do: check(settings!(port))
+
+  @doc """
+  One attempt, bounded by @deadline_ms.
+
+  Runs in a `spawn_monitor`'d process, never a linked one. The pool uses
+  `backoff_type: :stop`, so a refused connection kills it, and `DBConnection.Watcher`
+  answers that by killing whoever started it.
+  We want to catch and debug exactly that behavior, so we need to "live".
+  """
+  @spec check(Database.t()) :: :ok | {:error, String.t()}
+  def check(%Database{} = settings) do
+    {pid, ref} = spawn_monitor(fn -> exit({:probe_result, connect_and_query(settings)}) end)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, {:probe_result, result}} ->
+        result
+
+      {:DOWN, ^ref, :process, ^pid, :killed} ->
+        {:error, "could not connect (probe pool died on its first connection attempt)"}
+
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        {:error, "probe process exited: #{inspect(reason)}"}
+    after
+      @deadline_ms ->
+        Process.exit(pid, :kill)
+        receive do: ({:DOWN, ^ref, :process, ^pid, _reason} -> :ok)
+        {:error, "did not answer probe within #{@deadline_ms}ms"}
+    end
+  end
+
+  defp connect_and_query(settings) do
+    extra_opts = [connect_timeout: @connect_timeout_ms, queue_interval: @deadline_ms]
+
+    case Database.connect_db(settings, extra_opts) do
+      {:ok, conn} ->
+        try do
+          case Postgrex.query(conn, "SELECT 1", [], timeout: @deadline_ms) do
+            {:ok, _result} -> :ok
+            {:error, error} -> {:error, Exception.message(error)}
+          end
+        after
+          if Process.alive?(conn), do: GenServer.stop(conn)
+        end
+
+      {:error, error} ->
+        {:error, "could not connect: #{inspect(error)}"}
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -42,6 +42,10 @@ requires_no_supautils_policy_grants = if has_supautils_realtime_grants, do: :req
 
 skip_orioledb = if orioledb?, do: :skip_orioledb
 
+# Tests that kill and recreate a pooled tenant database; only the docker backend
+# owns its databases, external servers are supplied to us.
+requires_docker_backend = if backend != TestTenantDb.Backend.Docker, do: :requires_docker_backend
+
 exclude =
   Enum.reject(
     [
@@ -50,7 +54,8 @@ exclude =
       requires_pg_150000,
       requires_supautils_policy_grants,
       requires_no_supautils_policy_grants,
-      skip_orioledb
+      skip_orioledb,
+      requires_docker_backend
     ],
     &is_nil/1
   )
@@ -66,6 +71,15 @@ max_cases = ExUnit.configuration()[:max_cases]
 backend.prepare!()
 
 {:ok, _pid} = TestTenantDb.start_link(max_cases)
+
+# after_suite callbacks run in reverse registration order, so teardown is registered
+# first to make it run last — `report_unhealthy_checkouts/1` must be run when the pool
+# still exists.
+ExUnit.after_suite(&TestTenantDb.shutdown/1)
+
+# A wedged tenant database is recovered from silently (the worker is replaced), so
+# the rate has to be reported explicitly or it disappears from CI entirely.
+ExUnit.after_suite(&TestTenantDb.report_unhealthy_checkouts/1)
 
 for tenant <- Api.list_tenants(), do: Api.delete_tenant_by_external_id(tenant.external_id)
 


### PR DESCRIPTION
## Main Goal
Addressing our most common/annoying flakies:
the one where the tests are just killed, best to our knowledge because we failed to acquire a tenant DB.

Now, before handing out a database we run a small probe that the DB is healthy.

The same probe is also now run to declare the container ready for the pool.

If it is unhealthy, we discard it so a new one can be started, so in theory this should self-heal and help eliminate errors.

## Diagnostics
Also we now keep the docker containers around instead of deleting them (`--rm`), so we can diagnose what killed them.

Hope to be able to use these diagnostics/logs from the container, to track down the actual source of the issues and fix that as well.

Sadly, this means we also need to manually clean them up in the end.

Managed to produce one faulty checkout and that seems to have recovered mid run as intended 💃 

<details>
  <summary>Example log from the one test I managed to fail</summary>

Log visible in: https://github.com/supabase/realtime/actions/runs/34363039950/job/102509397975?pr=2185

Seems to have been retried and worked 💃 

```
[TestTenantDb] tenant database realtime-test-7BWNZClHnHxO (port 32769) failed its checkout probe: did not answer probe within 5000ms
verdict: container is UP but Postgres did not answer from the host — see the process list and logs below
container: status=running exit=0 oom=false error= started=2026-09-09T14:34:54.439369845Z finished=0001-01-01T00:00:00Z
resources: mem=204.8MiB / 30.95GiB mem%=0.65% cpu=247.19% pids=26
backends:
PID   STAT ELAPSED COMMAND
    1 S     1:27   {.postgres-wrapp} /nix/var/nix/profiles/default/bin/postgres -c config_file=/etc/postgresql/postgresql.conf -c wal_keep_size=32MB -c max_wal_size=1GB -c max_slot_wal_keep_size=32MB
  204 S     1:25   {.postgres-wrapp} postgres: main: checkpointer 
  205 S     1:25   {.postgres-wrapp} postgres: main: background writer 
  207 R     1:25   {.postgres-wrapp} postgres: main: orioledb background writer 0 
  208 S     1:25   {.postgres-wrapp} postgres: main: walwriter 
  209 S     1:25   {.postgres-wrapp} postgres: main: autovacuum launcher 
  210 S     1:25   {.postgres-wrapp} postgres: main: pg_net 0.20.4 worker 
  211 R     1:25   {.postgres-wrapp} postgres: main: pg_cron launcher 
  212 S     1:25   {.postgres-wrapp} postgres: main: logical replication launcher 
 1328 S     0:22   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(42098) idle
 1329 R     0:22   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(42102) BIND
 1330 S     0:22   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(42114) idle
 1331 S     0:22   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(42124) idle
 1332 S     0:22   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(42132) idle
 1333 S     0:22   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(42140) idle
 1334 R     0:22   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(42156) PARSE
 1335 S     0:22   {.postgres-wrapp} postgres: main: walsender supabase_admin postgres 172.17.0.1(42168) START_REPLICATION
 1342 S     0:21   {.postgres-wrapp} postgres: main: postgres postgres 127.0.0.1(51600) initializing
 1347 S     0:17   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(49536) initializing
 1348 S     0:17   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(49538) initializing
 1354 S     0:17   {.postgres-wrapp} postgres: main: postgres postgres 127.0.0.1(42170) initializing
 1361 S     0:13   {.postgres-wrapp} postgres: main: postgres postgres 127.0.0.1(42270) initializing
 1362 S     0:13   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(49554) initializing
 1372 S     0:09   {.postgres-wrapp} postgres: main: postgres postgres 127.0.0.1(59776) initializing
 1373 S     0:08   {.postgres-wrapp} postgres: main: supabase_admin postgres 172.17.0.1(52950) initializing
 1379 S     0:05   {.postgres-wrapp} postgres: main: postgres postgres 127.0.0.1(59882) initializing
 1380 R     0:01   ps -eo pid,stat,etime,args
pg_stat_activity:
(timed out after 5s: docker exec realtime-test-7BWNZClHnHxO psql -U postgres -h /var/run/postgresql -tAc SELECT pid, state, wait_event_type, wait_event, application_name, now() - query_start AS running, left(query, 120) FROM pg_stat_activity ORDER BY query_start)
pg_replication_slots:
(timed out after 5s: docker exec realtime-test-7BWNZClHnHxO psql -U postgres -h /var/run/postgresql -tAc SELECT slot_name, active, active_pid, wal_status, safe_wal_size FROM pg_replication_slots)
last 40 log lines:
172.17.0.1 2026-09-09 14:35:25.928 UTC [868] supabase_admin@postgres LOG:  unexpected EOF on standby connection
172.17.0.1 2026-09-09 14:35:25.928 UTC [868] supabase_admin@postgres STATEMENT:  START_REPLICATION SLOT supabase_realtime_messages_replication_slot_ LOGICAL 0/0 (proto_version '2', publication_names 'supabase_realtime_messages_publication', binary 'true')
172.17.0.1 2026-09-09 14:35:26.841 UTC [886] supabase_admin@postgres LOG:  logical decoding found consistent point at 0/4E2F2E0
172.17.0.1 2026-09-09 14:35:26.841 UTC [886] supabase_admin@postgres DETAIL:  There are no running transactions.
172.17.0.1 2026-09-09 14:35:26.841 UTC [886] supabase_admin@postgres STATEMENT:  SELECT pg_create_logical_replication_slot($1, 'wal2json')
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres LOG:  logical decoding found consistent point at 0/6AE13F8
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres DETAIL:  There are no running transactions.
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres STATEMENT:  CREATE_REPLICATION_SLOT supabase_realtime_messages_replication_slot_ TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres LOG:  starting logical decoding for slot "supabase_realtime_messages_replication_slot_"
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres DETAIL:  Streaming transactions committing after 0/6AE1448, reading WAL from 0/6AE13F8.
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres STATEMENT:  START_REPLICATION SLOT supabase_realtime_messages_replication_slot_ LOGICAL 0/0 (proto_version '2', publication_names 'supabase_realtime_messages_publication', binary 'true')
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres LOG:  logical decoding found consistent point at 0/6AE13F8
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres DETAIL:  There are no running transactions.
172.17.0.1 2026-09-09 14:35:53.493 UTC [1284] supabase_admin@postgres STATEMENT:  START_REPLICATION SLOT supabase_realtime_messages_replication_slot_ LOGICAL 0/0 (proto_version '2', publication_names 'supabase_realtime_messages_publication', binary 'true')
172.17.0.1 2026-09-09 14:35:53.586 UTC [1284] supabase_admin@postgres LOG:  unexpected EOF on standby connection
172.17.0.1 2026-09-09 14:35:53.586 UTC [1284] supabase_admin@postgres STATEMENT:  START_REPLICATION SLOT supabase_realtime_messages_replication_slot_ LOGICAL 0/0 (proto_version '2', publication_names 'supabase_realtime_messages_publication', binary 'true')
172.17.0.1 2026-09-09 14:35:59.103 UTC [1329] supabase_admin@postgres LOG:  logical decoding found consistent point at 0/6E6A6B8
172.17.0.1 2026-09-09 14:35:59.103 UTC [1329] supabase_admin@postgres DETAIL:  There are no running transactions.
172.17.0.1 2026-09-09 14:35:59.103 UTC [1329] supabase_admin@postgres STATEMENT:  select
	        case when not exists (
	          select 1
	          from pg_replication_slots
	          where slot_name = $1
	        )
	        then (
	          select 1 from pg_create_logical_replication_slot($1, 'wal2json', 'true')
	        )
	        else 1
	        end;
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres LOG:  logical decoding found consistent point at 0/6E6ADE0
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres DETAIL:  There are no running transactions.
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres STATEMENT:  CREATE_REPLICATION_SLOT supabase_realtime_messages_replication_slot_ TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres LOG:  starting logical decoding for slot "supabase_realtime_messages_replication_slot_"
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres DETAIL:  Streaming transactions committing after 0/6E6AE30, reading WAL from 0/6E6ADE0.
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres STATEMENT:  START_REPLICATION SLOT supabase_realtime_messages_replication_slot_ LOGICAL 0/0 (proto_version '2', publication_names 'supabase_realtime_messages_publication', binary 'true')
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres LOG:  logical decoding found consistent point at 0/6E6ADE0
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres DETAIL:  There are no running transactions.
172.17.0.1 2026-09-09 14:35:59.108 UTC [1335] supabase_admin@postgres STATEMENT:  START_REPLICATION SLOT supabase_realtime_messages_replication_slot_ LOGICAL 0/0 (proto_version '2', publication_names 'supabase_realtime_messages_publication', binary 'true')
172.17.0.1 2026-09-09 14:36:04.093 UTC [1335] supabase_admin@postgres LOG:  unexpected EOF on standby connection
172.17.0.1 2026-09-09 14:36:04.093 UTC [1335] supabase_admin@postgres STATEMENT:  START_REPLICATION SLOT supabase_realtime_messages_replication_slot_ LOGICAL 0/0 (proto_version '2', publication_names 'supabase_realtime_messages_publication', binary 'true')
```

</details>