### PR TITLE
feat(telemetry): log request path in HTTP response logs

### DIFF
--- a/lib/realtime/telemetry/logger.ex
+++ b/lib/realtime/telemetry/logger.ex
@@ -105,20 +105,25 @@ defmodule Realtime.Telemetry.Logger do
     end
   end
 
-  def handle_event([:phoenix, :endpoint, :stop], measurements, %{conn: conn}, _config) do
-    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
-    message = "#{conn.method} #{conn.request_path} - Sent #{conn.status} in #{duration_ms}ms"
+  def handle_event([:phoenix, :endpoint, :stop], measurements, %{conn: conn} = metadata, _config) do
+    case resolve_log_level(metadata[:options][:log], conn) do
+      false ->
+        :ok
 
-    cond do
-      conn.status >= 500 -> log_error("HttpServerError", message)
-      conn.status >= 400 -> log_warning("HttpClientError", message)
-      true -> Logger.info(message)
+      level ->
+        duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+        message = "#{conn.method} #{conn.request_path} - Sent #{conn.status} in #{duration_ms}ms"
+        Logger.log(level, message)
     end
   end
 
   def handle_event(_event, _measurements, _metadata, _config) do
     :ok
   end
+
+  defp resolve_log_level(nil, _conn), do: :info
+  defp resolve_log_level(level, _conn) when is_atom(level), do: level
+  defp resolve_log_level({mod, fun, args}, conn), do: apply(mod, fun, [conn | args])
 
   defp format_reason(_kind, reason) when is_exception(reason),
     do: "#{inspect(reason.__struct__)} - #{Exception.message(reason)}"

--- a/lib/realtime/telemetry/logger.ex
+++ b/lib/realtime/telemetry/logger.ex
@@ -18,7 +18,8 @@ defmodule Realtime.Telemetry.Logger do
     [:realtime, :tenants, :migrations, :exception],
     [:realtime, :tenants, :migrations, :reconcile, :stop],
     [:realtime, :tenants, :migrations, :reconcile, :exception],
-    [:phoenix, :error_rendered]
+    [:phoenix, :error_rendered],
+    [:phoenix, :endpoint, :stop]
   ]
 
   def start_link(args) do
@@ -26,6 +27,7 @@ defmodule Realtime.Telemetry.Logger do
   end
 
   def init(handler_id: handler_id) do
+    :telemetry.detach({Phoenix.Logger, [:phoenix, :endpoint, :stop]})
     :telemetry.attach_many(handler_id, @events, &__MODULE__.handle_event/4, [])
 
     {:ok, []}
@@ -100,6 +102,17 @@ defmodule Realtime.Telemetry.Logger do
       log_error("HttpServerError", message)
     else
       log_warning("HttpClientError", message)
+    end
+  end
+
+  def handle_event([:phoenix, :endpoint, :stop], measurements, %{conn: conn}, _config) do
+    duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
+    message = "#{conn.method} #{conn.request_path} - Sent #{conn.status} in #{duration_ms}ms"
+
+    cond do
+      conn.status >= 500 -> log_error("HttpServerError", message)
+      conn.status >= 400 -> log_warning("HttpClientError", message)
+      true -> Logger.info(message)
     end
   end
 

--- a/lib/realtime/telemetry/logger.ex
+++ b/lib/realtime/telemetry/logger.ex
@@ -121,9 +121,10 @@ defmodule Realtime.Telemetry.Logger do
     :ok
   end
 
+  # in practice we always have MFA set --> matching on it first for a micto bit of perf 😇
+  defp resolve_log_level({mod, fun, args}, conn), do: apply(mod, fun, [conn | args])
   defp resolve_log_level(nil, _conn), do: :info
   defp resolve_log_level(level, _conn) when is_atom(level), do: level
-  defp resolve_log_level({mod, fun, args}, conn), do: apply(mod, fun, [conn | args])
 
   defp format_reason(_kind, reason) when is_exception(reason),
     do: "#{inspect(reason.__struct__)} - #{Exception.message(reason)}"

--- a/test/realtime/telemetry/logger_test.exs
+++ b/test/realtime/telemetry/logger_test.exs
@@ -86,4 +86,21 @@ defmodule Realtime.Telemetry.LoggerTest do
       assert {:noreply, []} = TelemetryLogger.handle_info(:unexpected, [])
     end
   end
+
+  describe "phoenix endpoint stop events" do
+    test "logs the request method and path alongside the response" do
+      start_link_supervised!({TelemetryLogger, handler_id: "telemetry-logger-test"})
+
+      conn = %Plug.Conn{method: "GET", request_path: "/api/tenants/abc/health", status: 401, state: :sent}
+
+      log =
+        capture_log(fn ->
+          :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 1_000_000}, %{conn: conn, options: []})
+        end)
+
+      assert log =~ "GET /api/tenants/abc/health"
+      assert log =~ "401"
+      refute log =~ ~r/^Sent /
+    end
+  end
 end

--- a/test/realtime/telemetry/logger_test.exs
+++ b/test/realtime/telemetry/logger_test.exs
@@ -95,12 +95,24 @@ defmodule Realtime.Telemetry.LoggerTest do
 
       log =
         capture_log(fn ->
-          :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 1_000_000}, %{conn: conn, options: []})
+          :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 1}, %{conn: conn, options: []})
         end)
 
-      assert log =~ "GET /api/tenants/abc/health"
-      assert log =~ "401"
+      assert log =~ "GET /api/tenants/abc/health - Sent 401 in "
       refute log =~ ~r/^Sent /
+    end
+
+    test "does not log when the endpoint's configured log level is false" do
+      start_link_supervised!({TelemetryLogger, handler_id: "telemetry-logger-test"})
+
+      conn = %Plug.Conn{method: "GET", request_path: "/healthcheck", status: 200, state: :sent}
+
+      log =
+        capture_log(fn ->
+          :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: 1}, %{conn: conn, options: [log: false]})
+        end)
+
+      assert log == ""
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature: 
- HTTP response logs showed only status and duration, not which request they were for
- Added the method and path to the log line
- Removed Phoenix's default line for the same event, so each response logs once

Testing:
- Added a test checking the new line has the path and status
- Added a test checking Phoenix's old line is gone
- Checked live against a local server: works for normal responses (401 on `/api/ping`).

Resolves REAL-793

Please review thoroughly. Hoping things are correct and actually tackled what we wanted.
