### PR TITLE
fix: track a join rejected for an empty topic name

### DIFF
--- a/lib/realtime_web/channels/realtime_channel.ex
+++ b/lib/realtime_web/channels/realtime_channel.ex
@@ -45,6 +45,11 @@ defmodule RealtimeWeb.RealtimeChannel do
 
   @impl true
   def join("realtime:", _params, socket) do
+    # `terminate/2` untracks every channel process, including one whose join was rejected, so
+    # this clause has to track too. Otherwise the socket's other channels are untracked in its
+    # place and the Tracker reaps a transport that still has channels open.
+    Tracker.track(socket.transport_pid)
+
     socket
     |> log_error("TopicNameRequired", "You must provide a topic name")
     |> join_error()

--- a/test/integration/tracker_test.exs
+++ b/test/integration/tracker_test.exs
@@ -93,4 +93,31 @@ defmodule Integration.TrackerTest do
     assert [{_pid, count}] = Tracker.list_pids()
     assert count == 2
   end
+
+  test "a join rejected before tracking does not untrack the socket's live channels", %{tenant: tenant} do
+    assert [] = Tracker.list_pids()
+
+    {socket, _} = get_connection(tenant)
+    config = %{broadcast: %{self: true}, private: false, presence: %{enabled: false}}
+
+    topic = "realtime:#{random_string()}"
+    :ok = WebsocketClient.join(socket, topic, %{config: config})
+    assert_receive %Message{topic: ^topic, event: "phx_reply", payload: %{"status" => "ok"}}, 500
+    assert [{_pid, 1}] = Tracker.list_pids()
+
+    # `realtime:` is rejected by the first join/3 clause, before the channel is tracked
+    for _ <- 1..5 do
+      :ok = WebsocketClient.join(socket, "realtime:", %{config: config})
+
+      assert_receive %Message{topic: "realtime:", event: "phx_reply", payload: %{"status" => "error"}}, 1000
+    end
+
+    assert [{_pid, count}] = Tracker.list_pids()
+    assert count == 1
+
+    # the socket still has a channel open, so the Tracker must not reap it
+    start_supervised!({Tracker, check_interval_in_ms: 100})
+    Process.sleep(300)
+    assert Process.alive?(socket)
+  end
 end


### PR DESCRIPTION
Fixes #2190

## What

`RealtimeChannel.join/3`'s first clause — the one that rejects the empty topic name `realtime:` — returns before `Tracker.track(socket.transport_pid)`, but `terminate/2` still calls `Tracker.untrack(transport_pid)` for that channel process. `Phoenix.Channel.Server.channel_join/4` turns an `{:error, reply}` join into `{:stop, :shutdown, socket}`, so `terminate/2` runs even though the join was rejected.

Every empty-topic join therefore decrements the transport pid's counter with no matching increment. Since `Tracker` reaps any pid whose counter is `=< 0`, a socket that still has channels open gets `Process.exit(pid, :kill)`ed on the next sweep — the client loses the websocket and all its other subscriptions, with no close frame.

Every other rejection path in `join/3` returns from after the `track/1` call, so this clause is the only unbalanced one.

## Fix

Track in that clause too, so every channel process that reaches `terminate/2` has a matching `track/1`. `Tracker`'s `=< 0` match is deliberate (it is what reaps counters that drifted), so this is fixed on the tracking side rather than by changing the sweep.

## Test

`test/integration/tracker_test.exs` — "a join rejected before tracking does not untrack the socket's live channels": joins a real topic, then five `realtime:` joins, and asserts the counter stays at `1` and the transport survives a `Tracker` sweep.

It sits next to the two existing tests that already pin this invariant for the other rejection paths ("failed connections are present in tracker with counter lower than 0..." and "failed connections but one succeeds properly tracks").

Red on `main` @ `99b3d633`:

```
1) test a join rejected before tracking does not untrack the socket's live channels
   Assertion with == failed
   code:  assert count == 1
   left:  -4
   right: 1
```

Green with the fix.

## Validation

Run locally on Elixir 1.20.4 / OTP 29 against `supabase/postgres:15.14.1.167` (the repo pins 1.19.5 / OTP 28.5.0.4 — CI will confirm on the pinned toolchain and the full postgres matrix):

- `mix test test/integration/tracker_test.exs` — 4 passed; repeated 3x, stable
- `mix test test/integration/tracker_test.exs test/realtime_web/channels/realtime_channel/tracker_test.exs test/realtime_web/channels/realtime_channel_test.exs test/integration/rt_channel/authorization_test.exs test/realtime_web/channels/user_socket_test.exs` — 130 passed
- `mix compile --force --warnings-as-errors` — no warnings from the changed files (the checkout emits a few pre-existing warnings under 1.20 that do not appear on the pinned 1.19)
- `mix format --check-formatted`, `mix credo` (no issues), `mix deps.unlock --check-unused`, `mix sobelow`, `mix dialyzer` (passed successfully), `git diff --check` — all clean

Not run locally: the full 4-partition × 5-postgres test matrix — left to CI.
