### PR TITLE
chore(tests): Wait for muster to be ready + increase timeout

### DIFF
--- a/test/integration/distributed_realtime_channel_test.exs
+++ b/test/integration/distributed_realtime_channel_test.exs
@@ -4,6 +4,7 @@ defmodule Realtime.Integration.DistributedRealtimeChannelTest do
     async: false,
     parameterize: [%{serializer: Phoenix.Socket.V1.JSONSerializer}, %{serializer: RealtimeWeb.Socket.V2Serializer}]
 
+  alias Forum.Muster
   alias Phoenix.Socket.Message
 
   alias Realtime.Tenants.Connect
@@ -18,6 +19,9 @@ defmodule Realtime.Integration.DistributedRealtimeChannelTest do
     assert Connect.ready?(tenant.external_id)
 
     assert node(db_conn) == node
+
+    wait_for_muster_ready(node, region)
+
     %{tenant: tenant, topic: random_string()}
   end
 
@@ -44,7 +48,24 @@ defmodule Realtime.Integration.DistributedRealtimeChannelTest do
       payload = %{"event" => "TEST", "payload" => %{"msg" => 1}, "type" => "broadcast"}
       :ok = WebsocketClient.send_event(remote_socket, topic, "broadcast", payload)
 
-      assert_receive %Message{event: "broadcast", payload: ^payload, topic: ^topic}, 2000
+      assert_receive %Message{event: "broadcast", payload: ^payload, topic: ^topic}, 5000
     end
+  end
+
+  # Broadcasts route through Muster's region ring, so wait for the local and
+  # peer node to both consider it :ready and agree on the same ring view before
+  # sending anything cross-node.
+  defp wait_for_muster_ready(node, region) do
+    scope = :"realtime_channels_#{region}"
+
+    assert TestHelpers.eventually(
+             fn ->
+               Muster.status(scope) == :ready and
+                 :erpc.call(node, Muster, :status, [scope]) == :ready and
+                 Muster.view_hash(scope) == :erpc.call(node, Muster, :view_hash, [scope])
+             end,
+             retries: 150,
+             sleep: 100
+           )
   end
 end


### PR DESCRIPTION
After test processes killed, distributed_realtime_channel_test.exs was the most prominent failure both yesterday and today https://supabase.slack.com/archives/C070A8D2DKP/p1789027852388999

This should help by first waiting that Muster is ready even if the environment is busy and then to also wait for the message a little longer - which only has a negative effect in the negative case so should be an ok tradeoff.

If this is deemed good, might make the `wait_for_muster` into a more general helper that we might apply elsewhere as well.