### PR TITLE
chore: use docker for schema & dump generation

### DIFF
--- a/.github/workflows/update-tenant-db-snapshots.yml
+++ b/.github/workflows/update-tenant-db-snapshots.yml
@@ -24,24 +24,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  export-snapshots:
-    name: Export schema & dump (pg${{ matrix.pg_major }})
+  update-snapshots:
+    name: Export and commit schema & dumps
     runs-on: blacksmith-2vcpu-ubuntu-2404
     # Do not run for dependabot (as usually dependabot upgrades shouldn't touch schema and we don't want to duplicate secrets)
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - pg_major: 15
-            postgres_image: supabase/postgres:15.14.1.167
-          - pg_major: 17
-            postgres_image: supabase/postgres:17.6.1.166
-    env:
-      POSTGRES_IMAGE: ${{ matrix.postgres_image }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.GH_APP_MANAGER_ID }}
+          private-key: ${{ secrets.GH_APP_MANAGER_PRIVATE_KEY }}
+
+      # The PR branch itself, not the merge commit: whatever comes out is committed back onto it.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -59,24 +61,17 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
 
-      - name: Install PostgreSQL client
-        run: |
-          sudo install -d /usr/share/postgresql-common/pgdg
-          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail \
-            https://www.postgresql.org/media/keys/ACCC4CF8.asc
-          . /etc/os-release
-          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list
-          sudo apt-get update -y
-          sudo apt-get install -y "postgresql-client-${{ matrix.pg_major }}"
-          echo "/usr/lib/postgresql/${{ matrix.pg_major }}/bin" >> "$GITHUB_PATH"
+      # `mise run tenant-dumps` starts a database per major and dumps it from inside its own
+      # container, so these are every image the job needs.
+      - name: Resolve Postgres images
+        run: echo "PG_IMAGES=$(mise run tenant-dump-images | tr '\n' ' ')" >> "$GITHUB_ENV"
 
       - name: Cache Docker images
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: docker-cache
         with:
           path: /tmp/docker-images
-          key: docker-images-zstd-${{ matrix.postgres_image }}
+          key: docker-images-zstd-${{ hashFiles('mise.toml') }}
 
       - name: Load Docker images from cache
         if: steps.docker-cache.outputs.cache-hit == 'true'
@@ -85,80 +80,19 @@ jobs:
       - name: Pull and save Docker images
         if: steps.docker-cache.outputs.cache-hit != 'true'
         run: |
-          docker pull ${{ matrix.postgres_image }}
+          for image in $PG_IMAGES; do docker pull "$image"; done
           mkdir -p /tmp/docker-images
-          docker image save ${{ matrix.postgres_image }} | zstd -T0 -o /tmp/docker-images/postgres.tar.zst
+          # PG_IMAGES is a space-separated list; word splitting is intentional here.
+          # shellcheck disable=SC2086
+          docker image save $PG_IMAGES | zstd -T0 -o /tmp/docker-images/postgres.tar.zst
 
-      - name: Start Postgres
-        run: docker compose -f compose.dbs.yml up -d --wait
-
-      # Force re-generating a fresh dump
-      - name: Remove committed db dump
-        run: rm -f priv/repo/tenant_db_dump_${{ matrix.pg_major }}.sql
-
-      - name: Set up realtime DB and migrate tenant DB
-        run: mix ecto.setup
-
-      - name: Export Tenant DB schema
-        run: mix realtime.export_tenant_schema
-
-      - name: Export Tenant DB dump
-        run: mix realtime.export_tenant_db_dump --pg-major ${{ matrix.pg_major }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: tenant-dump-${{ matrix.pg_major }}
-          path: |
-            priv/repo/tenant_db_dump_${{ matrix.pg_major }}.sql
-            priv/repo/tenant_schema/
-          # pg-delta .pgdelta-export.json
-          include-hidden-files: true
-          if-no-files-found: ignore
-
-  commit-changes:
-    name: Commit schema and dump snapshots
-    needs: export-snapshots
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    # Do not run for dependabot (as usually dependabot upgrades shouldn't touch schema and we don't want to duplicate secrets)
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
-
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.GH_APP_MANAGER_ID }}
-          private-key: ${{ secrets.GH_APP_MANAGER_PRIVATE_KEY }}
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          pattern: tenant-dump-*
-          path: artifacts
-
-      # The schema artifact must be identical on every major; a divergence means it
-      # can no longer be a single directory and needs splitting per major again.
-      - name: Verify the schema artifact matches across majors
-        run: diff -r artifacts/tenant-dump-15/tenant_schema artifacts/tenant-dump-17/tenant_schema
-
-      - name: Move artifacts into place
-        run: |
-          rm -rf priv/repo/tenant_schema
-          cp -R artifacts/tenant-dump-17/. priv/repo/
-          cp artifacts/tenant-dump-15/tenant_db_dump_15.sql priv/repo/
+      - name: Export tenant schema and dumps
+        run: mise run tenant-dumps
 
       - name: Check if schema or dumps changed
         id: check-changes
         run: |
-          git add -A priv/repo/tenant_schema \
-            priv/repo/tenant_db_dump_15.sql priv/repo/tenant_db_dump_17.sql
+          git add -A priv/repo/tenant_schema priv/repo/tenant_db_dump_*.sql
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -8,6 +8,7 @@
   - [Architecture](#architecture)
   - [Server setup](#server-setup)
   - [Tenants](#tenants)
+  - [Tenant migrations and snapshots](#tenant-migrations-and-snapshots)
   - [Devcontainer](#devcontainer)
   - [WebSocket](#websocket)
     - [WebSocket URL](#websocket-url)
@@ -130,6 +131,27 @@ You can start playing around with Broadcast, Presence, and Postgres Changes feat
 The WebSocket URL must contain the subdomain, `external_id` of the tenant on the `tenants` table, and the token must be signed with the `jwt_secret` that was inserted along with the tenant.
 
 If you're using the default tenant, the URL is `ws://realtime-dev.localhost:4000/socket` (make sure the port is correct for your development environment), and you can use `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MDMwMjgwODcsInJvbGUiOiJwb3N0Z3JlcyJ9.tz_XJ89gd6bN8MBpCl7afvPrZiBH6RB65iA1FadPT3Y` for the token. The token must have `exp` and `role` (database role) keys.
+
+### Tenant migrations and snapshots
+
+Adding a migration under `lib/realtime/tenants/repo/migrations/` also changes two committed snapshots of
+where those migrations land:
+
+- `priv/repo/tenant_db_dump_<major>.sql` — one dump per supported Postgres major, loaded into a brand new
+  tenant database in place of replaying every migration.
+- `priv/repo/tenant_schema/` — the declarative schema the dashboard compares a tenant's live state against.
+  It is one directory for all majors, so the task fails if the majors disagree.
+
+Regenerate both:
+
+```bash
+mise run tenant-dumps      # every major
+mise run tenant-dumps 17   # only pg17, while iterating
+```
+
+Each major gets its own throwaway realtime and tenant database, on ports docker picks, so your dev stack keeps running. `pg_dump` runs inside the tenant database's own container, so nothing needs installing. `TENANT_DUMP_IMAGES` in `mise.toml` is the list of majors and the image each dump is generated from.
+
+[update-tenant-db-snapshots.yml](.github/workflows/update-tenant-db-snapshots.yml) also runs the same task on every PR that touches the migrations and commits the result back to the branch if there are changes.
 
 ### Devcontainer
 

--- a/lib/mix/tasks/realtime.export_tenant_db_dump.ex
+++ b/lib/mix/tasks/realtime.export_tenant_db_dump.ex
@@ -5,47 +5,65 @@ defmodule Mix.Tasks.Realtime.ExportTenantDbDump do
   Dumps the tenant database's `realtime` schema to `priv/repo/tenant_db_dump_<pg_major>.sql`,
   the `supabase_realtime_admin` role definition, and the `realtime.schema_migrations` rows.
 
-  Usage:
+  `mise run tenant-dumps` provisions the databases and calls this task for every major we ship a
+  dump for, so prefer it over calling this task by hand:
 
-      mix realtime.export_tenant_db_dump --pg-major 17
+      mise run tenant-dumps        # every major
+      mise run tenant-dumps 17     # just pg17
 
-  The target tenant DB is expected to already have all tenant migrations applied,
+  Called directly, the target tenant DB is expected to already have all tenant migrations applied,
   so make sure it is in a good state before generating it:
 
-      mise task run db-rm
-      mise task run db-start
-      mix setup
+      mise run db-rm
+      mise run db-start
+      mix realtime.export_tenant_db_dump --container tenant-realtime-dev-tenant_db-1
 
   The target DB is read from `DB_HOST` / `DB_PORT` / `DB_NAME` / `DB_USER` / `DB_PASSWORD` env vars.
+  Its major version names the file that comes out, so there is no way to write a dump under a major
+  it was not taken from.
 
-  Requires `pg_dump` and `pg_dumpall` matching the target's major version on `$PATH`.
+  `pg_dump` and `pg_dumpall` run with `docker exec` inside `--container`, the target's own database
+  container, so they always match the target's major version and the host needs no Postgres client
+  installed. Only `docker` and a container we can reach the database through.
   """
   use Mix.Task
 
   @realtime_admin_role "supabase_realtime_admin"
 
+  # What the database listens on inside its own container.
+  @container_port 5432
+
   @impl Mix.Task
   def run(args) do
     {:ok, _} = Application.ensure_all_started(:postgrex)
 
-    {opts, _, _} = OptionParser.parse(args, strict: [pg_major: :integer])
-    pg_major = opts[:pg_major] || Mix.raise("--pg-major is required, e.g. --pg-major 17")
+    {opts, _, _} = OptionParser.parse(args, strict: [container: :string])
 
-    host = System.get_env("DB_HOST", "127.0.0.1")
-    port = Realtime.Env.get_integer("DB_PORT", 5433)
-    database = System.get_env("DB_NAME", "postgres")
-    user = System.get_env("DB_USER", "supabase_admin")
-    password = System.get_env("DB_PASSWORD", "postgres")
+    target = %{
+      host: System.get_env("DB_HOST", "127.0.0.1"),
+      port: Realtime.Env.get_integer("DB_PORT", 5433),
+      database: System.get_env("DB_NAME", "postgres"),
+      user: System.get_env("DB_USER", "supabase_admin"),
+      password: System.get_env("DB_PASSWORD", "postgres"),
+      container: container!(opts)
+    }
+
+    conn = connect!(target)
+    pg_major = pg_major!(conn)
     path = dump_path(pg_major)
 
-    Mix.shell().info("[export_tenant_db_dump] target: #{host}:#{port}/#{database} (pg#{pg_major})")
+    Mix.shell().info("[export_tenant_db_dump] target: #{target.host}:#{target.port}/#{target.database} (pg#{pg_major})")
+
+    Mix.shell().info("[export_tenant_db_dump] container: #{target.container}")
 
     lines = [
       banner(pg_major),
-      realtime_admin_role_sql!(host, port, database, user, password),
-      pg_dump!(host, port, database, user, password) |> postprocess(),
-      schema_migrations_sql!(host, port, database, user, password)
+      realtime_admin_role_sql!(target),
+      target |> pg_dump!() |> postprocess(),
+      schema_migrations_sql!(conn)
     ]
+
+    GenServer.stop(conn)
 
     File.write!(path, lines)
 
@@ -53,6 +71,14 @@ defmodule Mix.Tasks.Realtime.ExportTenantDbDump do
   end
 
   defp dump_path(pg_major), do: Application.app_dir(:realtime, "priv/repo/tenant_db_dump_#{pg_major}.sql")
+
+  defp container!(opts) do
+    opts[:container] ||
+      Mix.raise("""
+      --container is required: pg_dump runs inside the target database's own container, e.g.
+      --container tenant-realtime-dev-tenant_db-1. `mise run tenant-dumps` passes it for you.
+      """)
+  end
 
   @doc false
   def banner(pg_major) do
@@ -72,52 +98,14 @@ defmodule Mix.Tasks.Realtime.ExportTenantDbDump do
     """
   end
 
-  defp pg_dump!(host, port, database, user, password) do
-    pg_dump = System.find_executable("pg_dump") || Mix.raise("pg_dump not found on $PATH")
-
-    args = [
-      "--host",
-      host,
-      "--port",
-      to_string(port),
-      "--username",
-      user,
-      "--dbname",
-      database,
-      "--schema-only",
-      "--schema",
-      "realtime"
-    ]
-
-    case System.cmd(pg_dump, args, env: [{"PGPASSWORD", password}]) do
-      {output, 0} -> output
-      {_output, code} -> Mix.raise("pg_dump exited #{code} - see output above")
-    end
+  defp pg_dump!(target) do
+    docker_exec!(target, "pg_dump", ["--dbname", target.database, "--schema-only", "--schema", "realtime"])
   end
 
-  defp realtime_admin_role_sql!(host, port, database, user, password) do
-    pg_dumpall = System.find_executable("pg_dumpall") || Mix.raise("pg_dumpall not found on $PATH")
-
-    args = [
-      "--host",
-      host,
-      "--port",
-      to_string(port),
-      "--username",
-      user,
-      "--database",
-      database,
-      "--roles-only"
-    ]
-
-    output =
-      case System.cmd(pg_dumpall, args, env: [{"PGPASSWORD", password}], stderr_to_stdout: true) do
-        {output, 0} -> output
-        {output, code} -> Mix.raise("pg_dumpall exited #{code}:\n#{output}")
-      end
-
+  defp realtime_admin_role_sql!(target) do
     lines =
-      output
+      target
+      |> docker_exec!("pg_dumpall", ["--database", target.database, "--roles-only"])
       |> String.split("\n")
       |> Enum.filter(&realtime_admin_role_line?/1)
       |> Enum.uniq()
@@ -146,14 +134,55 @@ defmodule Mix.Tasks.Realtime.ExportTenantDbDump do
       Regex.match?(~r/^GRANT .*TO #{@realtime_admin_role}/, line)
   end
 
-  defp schema_migrations_sql!(host, port, database, user, password) do
-    {:ok, conn} =
-      Postgrex.start_link(hostname: host, port: port, database: database, username: user, password: password)
+  # Runs one of the container's own dump binaries against the database next to it, capturing the
+  # SQL from stdout while diagnostics go straight to our own stderr. The connection is the
+  # container's loopback, not ours. PGPASSWORD is handed over by name so it stays off the command
+  # line.
+  defp docker_exec!(target, binary, args) do
+    docker = System.find_executable("docker") || Mix.raise("docker not found on $PATH")
 
+    argv =
+      [
+        "exec",
+        "--env",
+        "PGPASSWORD",
+        target.container,
+        binary,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        to_string(@container_port),
+        "--username",
+        target.user
+      ] ++ args
+
+    case System.cmd(docker, argv, env: [{"PGPASSWORD", target.password}]) do
+      {output, 0} -> output
+      {_output, code} -> Mix.raise("#{binary} in #{target.container} exited #{code} - see output above")
+    end
+  end
+
+  defp connect!(target) do
+    {:ok, conn} =
+      Postgrex.start_link(
+        hostname: target.host,
+        port: target.port,
+        database: target.database,
+        username: target.user,
+        password: target.password
+      )
+
+    conn
+  end
+
+  defp pg_major!(conn) do
+    {:ok, %{rows: [[version_num]]}} = Postgrex.query(conn, "SELECT current_setting('server_version_num')", [])
+    version_num |> String.to_integer() |> div(10_000)
+  end
+
+  defp schema_migrations_sql!(conn) do
     {:ok, %{rows: rows}} =
       Postgrex.query(conn, ~s(SELECT version FROM realtime."schema_migrations" ORDER BY version), [])
-
-    GenServer.stop(conn)
 
     inserts =
       Enum.map_join(rows, fn [version] ->

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,10 @@ supabase = "latest"
 # default. Setting TENANT yourself wins. A dot becomes a dash: a tenant is a compose project name
 # and a subdomain, and neither takes dots.
 TENANT = "{% if env.TENANT %}{{ env.TENANT }}{% else %}{% set dir = config_root | split(pat='/') | last | replace(from='.', to='-') %}{% if dir == 'realtime' %}realtime-dev{% else %}{{ dir }}{% endif %}{% endif %}"
+# The Postgres majors that get a committed tenant dump (priv/repo/tenant_db_dump_<major>.sql), and
+# the image each one is generated from — both `tenant-dumps` and the workflow that runs it read
+# this list. Keep the images in step with the ones the test workflows run against.
+TENANT_DUMP_IMAGES = "15=supabase/postgres:15.14.1.167 17=supabase/postgres:17.6.1.166"
 REGION = "us-east-1"
 API_JWT_SECRET = "dev"
 DB_ENC_KEY = "1234567890123456"
@@ -77,6 +81,102 @@ run = """
 set -eu
 COMPOSE_PROJECT_NAME="tenant-${TENANT:-realtime-dev}" docker compose -f compose.tenant-db.yml rm -sf
 """
+
+# Regenerates the committed tenant snapshots: priv/repo/tenant_schema, the declarative schema the
+# dashboard compares a tenant against, and priv/repo/tenant_db_dump_<major>.sql, what a brand new
+# tenant database is loaded with instead of replaying every migration. Both come out of a database
+# this task creates and throws away, so it leaves the dev stack alone. Also runs in CI, on every PR
+# that touches the tenant migrations - see .github/workflows/update-tenant-db-snapshots.yml.
+[tasks.tenant-dumps]
+description = "Regenerate priv/repo/tenant_schema and the tenant db dump of every supported Postgres major"
+usage = '''
+arg "[majors]..." help="Only regenerate these majors, such as 17. Defaults to every major in TENANT_DUMP_IMAGES."
+'''
+run = '''
+set -eu
+
+compose="docker compose -f compose.dbs.yml"
+
+db_down() { # <major> <image>
+  COMPOSE_PROJECT_NAME="tenant-dumps-pg$1" POSTGRES_IMAGE="$2" $compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+}
+
+for major in ${usage_majors:-}; do
+  case " $TENANT_DUMP_IMAGES " in
+    *" $major="*) ;;
+    *) echo "pg$major has no tenant dump; TENANT_DUMP_IMAGES is: $TENANT_DUMP_IMAGES" >&2; exit 1 ;;
+  esac
+done
+
+schemas=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$schemas"
+  for pair in $TENANT_DUMP_IMAGES; do
+    db_down "${pair%%=*}" "${pair#*=}"
+    dump="priv/repo/tenant_db_dump_${pair%%=*}.sql"
+    [ -e "$dump" ] || git checkout -- "$dump" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+reference=""
+for pair in $TENANT_DUMP_IMAGES; do
+  major=${pair%%=*}
+  image=${pair#*=}
+
+  case " ${usage_majors:-} " in
+    "  ") ;;              # nothing asked for, so every major
+    *" $major "*) ;;      # this one was asked for
+    *) continue ;;
+  esac
+
+  echo "==> pg$major ($image)"
+  project="tenant-dumps-pg$major"
+  dump="priv/repo/tenant_db_dump_${major}.sql"
+
+  db_down "$major" "$image"
+  COMPOSE_PROJECT_NAME="$project" POSTGRES_IMAGE="$image" DB_PORT=0 TENANT_DB_PORT=0 $compose up -d --wait
+
+  published=$(COMPOSE_PROJECT_NAME="$project" POSTGRES_IMAGE="$image" $compose port realtime_db 5432)
+  realtime_port=${published##*:}
+  published=$(COMPOSE_PROJECT_NAME="$project" POSTGRES_IMAGE="$image" $compose port tenant_db 5432)
+  tenant_port=${published##*:}
+  tenant_container=$(COMPOSE_PROJECT_NAME="$project" POSTGRES_IMAGE="$image" $compose ps -q tenant_db)
+
+  # The committed dump goes too: with one in place `mix seed` loads it into the fresh tenant
+  # database instead of running the migrations we are here to capture.
+  rm -f "$dump"
+
+  # DB_PORT is the realtime database to the server and the tenant database to the export tasks, so
+  # each command gets the one it means.
+  DB_PORT="$realtime_port" TENANT_DB_PORT="$tenant_port" mix ecto.setup
+  DB_PORT="$tenant_port" mix realtime.export_tenant_schema
+  DB_PORT="$tenant_port" mix realtime.export_tenant_db_dump --container "$tenant_container"
+
+  # The dump names itself after the major it came out of, so the one we removed coming back is what
+  # says this image really is pg$major.
+  if [ ! -e "$dump" ]; then
+    echo "pg$major: $image wrote no $dump, so it is not pg$major. Fix TENANT_DUMP_IMAGES." >&2
+    exit 1
+  fi
+
+  # One schema artifact serves every major. A divergence means it can no longer be a single
+  # directory and needs splitting per major again.
+  cp -R priv/repo/tenant_schema "$schemas/$major"
+  if [ -n "$reference" ]; then
+    diff -r "$schemas/$reference" "$schemas/$major"
+  else
+    reference=$major
+  fi
+
+  db_down "$major" "$image"
+done
+'''
+
+[tasks.tenant-dump-images]
+description = "Print the Postgres image every committed tenant dump is generated from, one per line"
+run = 'for pair in $TENANT_DUMP_IMAGES; do echo "${pair#*=}"; done'
 
 [tasks.realtime-start]
 description = "Start Realtime and its databases in containers"

--- a/priv/repo/tenant_db_dump_15.sql
+++ b/priv/repo/tenant_db_dump_15.sql
@@ -29,7 +29,7 @@ END $$;
 
 
 -- Dumped from database version 15.14
--- Dumped by pg_dump version 15.19 (Ubuntu 15.19-1.pgdg24.04+2)
+-- Dumped by pg_dump version 15.14
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/priv/repo/tenant_db_dump_17.sql
+++ b/priv/repo/tenant_db_dump_17.sql
@@ -29,7 +29,7 @@ END $$;
 
 
 -- Dumped from database version 17.6
--- Dumped by pg_dump version 17.11 (Ubuntu 17.11-1.pgdg24.04+2)
+-- Dumped by pg_dump version 17.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This way we don't need to have pg-dump for a specific major version etc. We just use the tools from the image that we are extracting the dump from.

It's also easier to run it locally. We won't __need__ to push to GitHub to get the new dumps. It's now optional.
