### PR TITLE
chore(tests): Attempt to fix flaky Node regions test

### DIFF
--- a/test/realtime/nodes_test.exs
+++ b/test/realtime/nodes_test.exs
@@ -34,7 +34,9 @@ defmodule Realtime.NodesTest do
     end
 
     test "with no other nodes, returns my region only" do
-      assert Nodes.all_node_regions() == ["us-east-1"]
+      # Flaky under CPU-contention in CI runners; not sure why.
+      # This is an _attempt_ at fixing it.
+      assert eventually(fn -> Nodes.all_node_regions() == ["us-east-1"] end)
     end
   end
 


### PR DESCRIPTION
https://github.com/supabase/realtime/actions/runs/34439478592/job/102751321026

```
  5) test all_node_regions/0 with no other nodes, returns my region only (Realtime.NodesTest)
     test/realtime/nodes_test.exs:36
     Assertion with == failed
     code:  assert Nodes.all_node_regions() == ["us-east-1"]
     left:  []
     right: ["us-east-1"]
     stacktrace:
       test/realtime/nodes_test.exs:37: (test)
```

I'm honestly unsure about the mechanism at play here, but deemed an `eventually` a worthy try and if not, we at least learn that under some circumstances it may be "more" broken and have that aid our investigation.
