### PR TITLE
fix: replay messages sent in one transaction in send order

### DIFF
--- a/lib/realtime/tenants/migrations.ex
+++ b/lib/realtime/tenants/migrations.ex
@@ -100,7 +100,8 @@ defmodule Realtime.Tenants.Migrations do
     {20_260_707_120_000, Migrations.RestrictRealtimeSchema},
     {20_260_709_120_000, Migrations.FixApplyRlsFilterRoleLeak},
     {20_260_714_120_000, Migrations.AddBroadcastPersistence},
-    {20_260_827_120_000, Migrations.EmptySelectColumnsReturnPrimaryKeys}
+    {20_260_827_120_000, Migrations.EmptySelectColumnsReturnPrimaryKeys},
+    {20_260_910_120_000, Migrations.MessagesInsertedAtClockTimestamp}
   ]
 
   defstruct [:tenant_external_id, :settings, migrations_ran: 0]

--- a/lib/realtime/tenants/repo/migrations/20260910120000_messages_inserted_at_clock_timestamp.ex
+++ b/lib/realtime/tenants/repo/migrations/20260910120000_messages_inserted_at_clock_timestamp.ex
@@ -1,0 +1,17 @@
+defmodule Realtime.Tenants.Migrations.MessagesInsertedAtClockTimestamp do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  # realtime.send and realtime.send_binary leave inserted_at to the column default. now() is the
+  # transaction start time, so every message sent in one transaction got the same inserted_at and
+  # replay, which orders by inserted_at, could not tell them apart. clock_timestamp() is the time
+  # of each insert. Rows are inserted through the partitioned parent, whose default applies.
+  def up do
+    execute("ALTER TABLE realtime.messages ALTER COLUMN inserted_at SET DEFAULT clock_timestamp()")
+  end
+
+  def down do
+    execute("ALTER TABLE realtime.messages ALTER COLUMN inserted_at SET DEFAULT now()")
+  end
+end

--- a/priv/repo/tenant_db_dump_15.sql
+++ b/priv/repo/tenant_db_dump_15.sql
@@ -1080,7 +1080,7 @@ CREATE TABLE realtime.messages (
     event text,
     private boolean DEFAULT false,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
-    inserted_at timestamp without time zone DEFAULT now() NOT NULL,
+    inserted_at timestamp without time zone DEFAULT clock_timestamp() NOT NULL,
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     binary_payload bytea,
     skip_broadcast boolean DEFAULT false NOT NULL
@@ -1508,3 +1508,4 @@ INSERT INTO realtime."schema_migrations" (version) VALUES (20260707120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260709120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260714120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260827120000);
+INSERT INTO realtime."schema_migrations" (version) VALUES (20260910120000);

--- a/priv/repo/tenant_db_dump_17.sql
+++ b/priv/repo/tenant_db_dump_17.sql
@@ -1081,7 +1081,7 @@ CREATE TABLE realtime.messages (
     event text,
     private boolean DEFAULT false,
     updated_at timestamp without time zone DEFAULT now() NOT NULL,
-    inserted_at timestamp without time zone DEFAULT now() NOT NULL,
+    inserted_at timestamp without time zone DEFAULT clock_timestamp() NOT NULL,
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     binary_payload bytea,
     skip_broadcast boolean DEFAULT false NOT NULL
@@ -1509,3 +1509,4 @@ INSERT INTO realtime."schema_migrations" (version) VALUES (20260707120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260709120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260714120000);
 INSERT INTO realtime."schema_migrations" (version) VALUES (20260827120000);
+INSERT INTO realtime."schema_migrations" (version) VALUES (20260910120000);

--- a/priv/repo/tenant_schema/realtime/tables/messages.sql
+++ b/priv/repo/tenant_schema/realtime/tables/messages.sql
@@ -21,7 +21,7 @@ alter table "realtime"."messages"
   alter column "id" set default gen_random_uuid();
 
 alter table "realtime"."messages"
-  alter column "inserted_at" set default now();
+  alter column "inserted_at" set default clock_timestamp();
 
 alter table "realtime"."messages"
   alter column "private" set default false;

--- a/test/integration/rt_channel/broadcast_test.exs
+++ b/test/integration/rt_channel/broadcast_test.exs
@@ -484,6 +484,41 @@ defmodule Realtime.Integration.RtChannel.BroadcastTest do
   describe "broadcast replay" do
     setup [:rls_context]
 
+    @tag policies: [:authenticated_read_broadcast_and_presence]
+    test "replays messages sent in one transaction in the order they were sent", %{
+      tenant: tenant,
+      topic: topic,
+      db_conn: db_conn,
+      serializer: serializer
+    } do
+      # realtime.send leaves inserted_at to the column default, and replay orders by inserted_at, so
+      # the default has to tell apart messages that share a transaction.
+      {:ok, _} =
+        Postgrex.transaction(db_conn, fn conn ->
+          for value <- 1..5 do
+            Postgrex.query!(
+              conn,
+              "SELECT realtime.send(jsonb_build_object('value', $1::int), 'event', $2::text, TRUE::bool)",
+              [value, topic]
+            )
+          end
+        end)
+
+      {socket, _} = get_connection(tenant, serializer, role: "authenticated")
+      topic = "realtime:#{topic}"
+
+      WebsocketClient.join(socket, topic, %{config: %{private: true, broadcast: %{replay: %{limit: 10, since: 0}}}})
+      assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}, topic: ^topic}, 500
+
+      replayed =
+        for _ <- 1..5 do
+          assert_receive %Message{event: "broadcast", topic: ^topic, payload: %{"payload" => %{"value" => value}}}, 1000
+          value
+        end
+
+      assert replayed == [1, 2, 3, 4, 5]
+    end
+
     @tag policies: [:authenticated_read_broadcast_and_presence], serializer: RealtimeWeb.Socket.V2Serializer
     test "replays binary messages as binary frames", %{
       tenant: tenant,


### PR DESCRIPTION
Fixes #2201

## What

`realtime.send` / `realtime.send_binary` insert into `realtime.messages` without an `inserted_at`, so it takes the column default, `now()` — the **transaction start time**. Every message sent in one transaction gets the identical `inserted_at`. `Realtime.Messages.replay/5` orders by `inserted_at DESC`, applies the limit, and reverses to oldest-first; Postgres returns the tied rows in insertion order, so the reverse flips them. Messages sent `1..5` in one transaction replay as `5, 4, 3, 2, 1`.

`id` is a random `gen_random_uuid()`, so no stored column records the order of same-transaction rows — it can't be fixed in the replay query.

## Fix

A tenant migration switching the default to `clock_timestamp()`, the time of each insert:

```sql
ALTER TABLE realtime.messages ALTER COLUMN inserted_at SET DEFAULT clock_timestamp()
```

- Rows are inserted through the partitioned parent, whose default is the one applied.
- Only inserts that omit `inserted_at` are affected (`realtime.send`, `realtime.send_binary`, direct inserts). `Messages.persist/5` sets `inserted_at` from Elixir and is unchanged.
- Checked against 200 `realtime.send` calls in one transaction: 200 distinct timestamps, `ORDER BY inserted_at` matching send order exactly, and replay returning the last 25 in order.
- `down` restores `now()`.

### Regenerated artifacts

The snapshot workflow only commits for same-repo PRs, and a fresh tenant loads the bundled dump and is then marked fully migrated — so a stale dump would silently skip this migration for new tenants. I regenerated them following `update-tenant-db-snapshots.yml` (`mix ecto.setup` → `mix realtime.export_tenant_schema` → `mix realtime.export_tenant_db_dump --pg-major N`) against `supabase/postgres:15.14.1.167` and `17.6.1.166`, with `@supabase/pg-delta@1.0.0-alpha.48` from `mise.toml`:

- `tenant_db_dump_{15,17}.sql`: the `inserted_at` default and the new `schema_migrations` row. Nothing else changed.
- `tenant_schema/realtime/tables/messages.sql`: the default. The export was identical across both majors (the check the workflow runs).

I used the images' own `pg_dump`, which only changed the `-- Dumped by pg_dump version` banner comment; I restored those two comment lines so the committed provenance stays the workflow's. If the workflow regenerates on a maintainer branch it should produce the same content.

## Test

`test/integration/rt_channel/broadcast_test.exs` — "replays messages sent in one transaction in the order they were sent": five `realtime.send` calls in one transaction, join with replay, assert the order.

Red on `main` @ `ee315cae`, on both serializers:

```
code:  assert replayed == [1, 2, 3, 4, 5]
left:  [5, 4, 3, 2, 1]
right: [1, 2, 3, 4, 5]
```

Green with the migration. The existing "replays binary and json messages in insertion order" test doesn't catch this because `message_fixture` inserts each row in its own transaction with an explicit timestamp.

## Validation

Local, Elixir 1.20.4 / OTP 29 (repo pins 1.19.5 / OTP 28.5.0.4), `supabase/postgres:15.14.1.167`:

- `mix test test/integration/rt_channel test/realtime/tenants test/realtime/messages_test.exs test/realtime_web/channels test/realtime_web/dashboard` — 985 passed. This includes the dump-load path ("loads the bundled dump for a brand-new tenant") and the pg-delta drift check "reports no drift for a freshly migrated tenant", which compares a migrated tenant against the regenerated schema artifact. (The dashboard/schema pg-delta tests need `pgdelta` on `PATH`; without it they fail with `pgdelta not found on PATH` on `main` too.)
- `mix compile --force --warnings-as-errors` — no warnings from the changed files (a few pre-existing warnings appear under 1.20 but not the pinned 1.19)
- `mix format --check-formatted`, `mix credo` (no issues), `mix deps.unlock --check-unused`, `mix sobelow`, `mix dialyzer` (passed), `git diff --check` — clean

Not run locally: the full 4-partition × 5-postgres matrix, including PG 14 and OrioleDB — left to CI.
